### PR TITLE
docs: add Slack tools documentation and changelog entry

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -1,6 +1,6 @@
 # @agentforge/tools
 
-Standard tools library with 70 production-ready tools.
+Standard tools library with 74 production-ready tools.
 
 ## Installation
 
@@ -8,7 +8,7 @@ Standard tools library with 70 production-ready tools.
 pnpm add @agentforge/tools
 ```
 
-## Web Tools (11)
+## Web Tools (15)
 
 ### Web Search
 
@@ -122,6 +122,102 @@ const url = await urlBuilder.invoke({
 const params = await urlQueryParser.invoke({
   url: 'https://example.com?foo=bar&baz=qux'
 });
+```
+
+### Slack Integration
+
+```typescript
+import {
+  sendSlackMessage,
+  notifySlack,
+  getSlackChannels,
+  getSlackMessages,
+  createSlackTools
+} from '@agentforge/tools';
+
+// Send a message to a Slack channel
+const result = await sendSlackMessage.invoke({
+  channel: '#general',
+  text: 'Hello from AgentForge! 👋'
+});
+
+// Send a notification with @mentions
+const notification = await notifySlack.invoke({
+  channel: '#alerts',
+  text: 'Deployment completed successfully!',
+  mentions: ['@john', '@jane']
+});
+
+// List available channels
+const channels = await getSlackChannels.invoke({
+  includePrivate: true
+});
+
+console.log(`Found ${channels.channels.length} channels`);
+channels.channels.forEach(ch => {
+  console.log(`${ch.name} (${ch.memberCount} members)`);
+});
+
+// Read message history
+const messages = await getSlackMessages.invoke({
+  channel: '#general',
+  limit: 10
+});
+
+console.log(`Retrieved ${messages.messages.length} messages`);
+messages.messages.forEach(msg => {
+  console.log(`[${msg.timestamp}] ${msg.user}: ${msg.text}`);
+});
+
+// Custom configuration with factory function
+const customSlackTools = createSlackTools({
+  token: 'xoxb-your-custom-token'
+});
+
+// Use custom tools
+const customResult = await customSlackTools[0].invoke({
+  channel: '#custom',
+  text: 'Using custom token configuration'
+});
+```
+
+**Features:**
+- Send messages to any Slack channel
+- Notify team members with @mentions
+- List public and private channels
+- Read message history with pagination
+- Configurable via environment variables or programmatic configuration
+- Full TypeScript support with Zod validation
+- Structured logging for debugging
+
+**Environment Setup:**
+```bash
+# Add to your .env file
+# Use either a User Token or Bot Token
+SLACK_USER_TOKEN=xoxp-your-user-token-here
+# OR
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+```
+
+**Getting a Slack Token:**
+1. Go to [Slack API Apps](https://api.slack.com/apps)
+2. Create a new app or select an existing one
+3. Navigate to "OAuth & Permissions"
+4. Add required scopes:
+   - **User Token Scopes**: `channels:read`, `channels:history`, `chat:write`, `groups:read`, `groups:history`
+   - **Bot Token Scopes**: `channels:read`, `channels:history`, `chat:write`, `groups:read`, `groups:history`
+5. Install the app to your workspace
+6. Copy the token (starts with `xoxp-` for user tokens or `xoxb-` for bot tokens)
+
+**Programmatic Configuration:**
+```typescript
+// Override environment variables with custom configuration
+const slackTools = createSlackTools({
+  token: 'xoxb-your-custom-token'
+});
+
+// Use the custom tools
+const [sendMessage, notify, getChannels, getMessages] = slackTools;
 ```
 
 ## Data Tools (18)

--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### @agentforge/tools
+- **feat: add Slack integration tools** - Four new tools for Slack workspace integration
+  - `sendSlackMessage` - Send messages to Slack channels
+  - `notifySlack` - Send notifications with @mentions to alert team members
+  - `getSlackChannels` - List available Slack channels (public and private)
+  - `getSlackMessages` - Read message history from channels
+  - Configurable via environment variables (`SLACK_USER_TOKEN` or `SLACK_BOT_TOKEN`) or programmatic configuration
+  - Factory function `createSlackTools(config)` for custom token configuration
+  - Comprehensive test coverage (23 tests)
+  - Full TypeScript support with Zod schema validation
+  - Structured logging for debugging and monitoring
+  - Tool count increased from 70 to 74 tools
+  - Web Tools category increased from 11 to 15 tools
+
 ## [0.8.2] - 2026-01-28
 
 ### Changed


### PR DESCRIPTION
Add comprehensive documentation for new Slack integration tools.

## Changes

### Changelog (docs-site/changelog.md)
- Added Slack tools entry to [Unreleased] section
- Documented all 4 tools: sendSlackMessage, notifySlack, getSlackChannels, getSlackMessages
- Included configuration options, test coverage, and tool count updates
- Tool count: 70 → 74 tools
- Web Tools category: 11 → 15 tools

### API Documentation (docs-site/api/tools.md)
- Updated tool count from 70 to 74 tools
- Updated Web Tools category from 11 to 15 tools
- Added comprehensive Slack Integration section (103 lines)
- Included code examples for all 4 tools
- Documented environment setup (SLACK_USER_TOKEN or SLACK_BOT_TOKEN)
- Added token acquisition guide with step-by-step instructions
- Showed programmatic configuration with createSlackTools()
- Documented features and capabilities

## Slack Tools Documented
- **sendSlackMessage** - Send messages to Slack channels- **sendSlackMessage** - Send messages to Slack channels- **sendSlackann- **sendSlackMessage** - Send messages to Slack channels- **senckM- **sendS - - **sendSlackMessage** - Send message# - **sendSlackMessage** - Send messages to Slack  D- **sendSlackMessage** - Send messages to Slack channels- **sendSlackMessage** - Send messs - **sendSlackMessage** - Send messages to Slack channels- **sendSlackMe - **sendSlackMessage** - Sense- **sendSlackMessage** - Send messtests- **sendSlackMessage** - Send messages to Slan ✅
- Phase 6: Updated playground to use - Phase 6: Updated playground to use - Phase 6: verification ✅