### PR TITLE
refactor: update core tests to use invoke() instead of execute()

### DIFF
--- a/packages/core/src/langchain/converter.ts
+++ b/packages/core/src/langchain/converter.ts
@@ -55,7 +55,7 @@ export function toLangChainTool(
     description: tool.metadata.description,
     schema: tool.schema as any,
     func: async (input: any) => {
-      const result = await tool.execute(input);
+      const result = await tool.invoke(input);
 
       // LangChain tools must return strings
       // Convert result to string if it's not already

--- a/packages/core/src/tools/executor.ts
+++ b/packages/core/src/tools/executor.ts
@@ -110,7 +110,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
     input: any,
     policy?: RetryPolicy
   ): Promise<any> {
-    // Use invoke if available (LangChain compatibility), otherwise use execute (required)
+    // Use invoke (primary method), fallback to execute (deprecated alias) for backward compatibility
     const executeFn = tool.invoke || tool.execute;
 
     if (!executeFn) {

--- a/packages/core/src/tools/helpers.ts
+++ b/packages/core/src/tools/helpers.ts
@@ -11,22 +11,22 @@ import { validateSchemaDescriptions } from './validation.js';
 
 /**
  * Create a tool with automatic validation
- * 
+ *
  * This function validates:
  * 1. Metadata is valid (name, description, category, etc.)
  * 2. Schema has descriptions on ALL fields (enforced!)
- * 
+ *
  * Why enforce descriptions?
  * - LLMs need context to understand parameters
  * - Better descriptions = Better tool usage
  * - Prevents common mistakes
- * 
+ *
  * @param metadata - Tool metadata
  * @param schema - Zod schema for input validation (must have descriptions!)
- * @param execute - Tool implementation
+ * @param invoke - Tool implementation (primary method, industry standard)
  * @returns Validated tool
  * @throws {Error} If metadata is invalid or schema is missing descriptions
- * 
+ *
  * @example
  * ```ts
  * // ✅ This works - all fields have descriptions
@@ -43,7 +43,7 @@ import { validateSchemaDescriptions } from './validation.js';
  *     // Implementation
  *   }
  * );
- * 
+ *
  * // ❌ This throws - missing description on 'path'
  * const badTool = createTool(
  *   { name: 'bad', description: 'Bad tool', category: ToolCategory.UTILITY },
@@ -57,7 +57,7 @@ import { validateSchemaDescriptions } from './validation.js';
 export function createTool<TInput = unknown, TOutput = unknown>(
   metadata: ToolMetadata,
   schema: z.ZodSchema<TInput>,
-  execute: (input: TInput) => Promise<TOutput>
+  invoke: (input: TInput) => Promise<TOutput>
 ): Tool<TInput, TOutput> {
   // Validate metadata
   const metadataResult = validateToolMetadata(metadata);
@@ -71,40 +71,40 @@ export function createTool<TInput = unknown, TOutput = unknown>(
   // Validate schema has descriptions on all fields
   validateSchemaDescriptions(schema);
 
-  // Create the tool with both execute and invoke (LangChain compatibility)
+  // Create the tool with invoke as primary method (industry standard)
   const tool: Tool<TInput, TOutput> = {
     metadata: metadataResult.data,
     schema,
-    execute,
+    invoke,
   };
 
-  // Add invoke as an alias for execute (LangChain compatibility)
-  // This allows developers familiar with LangChain to use .invoke() instead of .execute()
-  (tool as any).invoke = execute;
+  // Add execute as a deprecated alias for invoke (backward compatibility)
+  // This maintains compatibility with existing code while encouraging use of invoke()
+  (tool as any).execute = invoke;
 
   return tool;
 }
 
 /**
  * Create a tool without enforcing schema descriptions
- * 
+ *
  * ⚠️ WARNING: Only use this if you have a good reason to skip description validation.
  * In most cases, you should use `createTool()` instead.
- * 
+ *
  * This is useful for:
  * - Migration from existing code
  * - Tools with dynamic schemas
  * - Testing
- * 
+ *
  * @param metadata - Tool metadata
  * @param schema - Zod schema for input validation
- * @param execute - Tool implementation
+ * @param invoke - Tool implementation (primary method, industry standard)
  * @returns Tool (without schema validation)
  */
 export function createToolUnsafe<TInput = unknown, TOutput = unknown>(
   metadata: ToolMetadata,
   schema: z.ZodSchema<TInput>,
-  execute: (input: TInput) => Promise<TOutput>
+  invoke: (input: TInput) => Promise<TOutput>
 ): Tool<TInput, TOutput> {
   // Only validate metadata, skip schema description validation
   const metadataResult = validateToolMetadata(metadata);
@@ -115,15 +115,15 @@ export function createToolUnsafe<TInput = unknown, TOutput = unknown>(
     throw new Error(`Invalid tool metadata:\n${errors}`);
   }
 
-  // Create the tool with both execute and invoke (LangChain compatibility)
+  // Create the tool with invoke as primary method (industry standard)
   const tool: Tool<TInput, TOutput> = {
     metadata: metadataResult.data,
     schema,
-    execute,
+    invoke,
   };
 
-  // Add invoke as an alias for execute (LangChain compatibility)
-  (tool as any).invoke = execute;
+  // Add execute as a deprecated alias for invoke (backward compatibility)
+  (tool as any).execute = invoke;
 
   return tool;
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -341,7 +341,7 @@ export interface Tool<TInput = unknown, TOutput = unknown> {
   schema: z.ZodSchema<TInput>;
 
   /**
-   * Tool implementation
+   * Tool implementation (primary method)
    *
    * Why async?
    * - Most tools do I/O (files, network, database)
@@ -349,22 +349,33 @@ export interface Tool<TInput = unknown, TOutput = unknown> {
    *
    * The input is automatically validated against the schema
    * before this function is called.
-   */
-  execute: (input: TInput) => Promise<TOutput>;
-
-  /**
-   * LangChain-compatible alias for execute
    *
-   * This allows developers familiar with LangChain to use .invoke()
-   * instead of .execute(). Both methods do exactly the same thing.
+   * This is the industry standard method name used by LangChain.
    *
    * @example
    * ```ts
-   * // Both of these work:
+   * const result = await tool.invoke({ input: 'hello' });
+   * ```
+   */
+  invoke: (input: TInput) => Promise<TOutput>;
+
+  /**
+   * Deprecated alias for invoke()
+   *
+   * @deprecated Use invoke() instead. This method will be removed in v1.0.0.
+   *
+   * Both methods do exactly the same thing, but invoke() is the industry
+   * standard used by LangChain and should be preferred.
+   *
+   * @example
+   * ```ts
+   * // ❌ Deprecated (still works, but will be removed in v1.0.0):
    * const result1 = await tool.execute({ input: 'hello' });
+   *
+   * // ✅ Preferred (industry standard):
    * const result2 = await tool.invoke({ input: 'hello' });
    * ```
    */
-  invoke?: (input: TInput) => Promise<TOutput>;
+  execute?: (input: TInput) => Promise<TOutput>;
 }
 

--- a/packages/core/tests/tools/builder.test.ts
+++ b/packages/core/tests/tools/builder.test.ts
@@ -28,7 +28,7 @@ describe('ToolBuilder', () => {
       expect(tool.metadata.description).toBe('A test tool for testing');
       expect(tool.metadata.category).toBe(ToolCategory.UTILITY);
 
-      const result = await tool.execute({ input: 'hello' });
+      const result = await tool.invoke({ input: 'hello' });
       expect(result).toBe('Result: hello');
     });
 
@@ -232,7 +232,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ name: 'test', age: 25 });
+      const result = await tool.invoke({ name: 'test', age: 25 });
       expect(result.nameUpper).toBe('TEST');
       expect(result.ageDouble).toBe(50);
     });
@@ -257,7 +257,7 @@ describe('ToolBuilder', () => {
         }))
         .build();
 
-      const result = await tool.execute({
+      const result = await tool.invoke({
         user: { name: 'John', email: 'john@example.com' },
         tags: ['tag1', 'tag2'],
       });
@@ -282,7 +282,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ value: 'test' });
+      const result = await tool.invoke({ value: 'test' });
 
       expect(result.success).toBe(true);
       expect(result.data).toBe('Processed: test');
@@ -305,7 +305,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ shouldFail: true });
+      const result = await tool.invoke({ shouldFail: true });
 
       expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
@@ -325,7 +325,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ input: 'test' });
+      const result = await tool.invoke({ input: 'test' });
 
       expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
@@ -350,7 +350,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ name: 'test', count: 5 });
+      const result = await tool.invoke({ name: 'test', count: 5 });
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual({
@@ -374,7 +374,7 @@ describe('ToolBuilder', () => {
         })
         .build();
 
-      const result = await tool.execute({ value: 10 });
+      const result = await tool.invoke({ value: 10 });
 
       // TypeScript should know result has { success, data?, error? }
       if (result.success) {

--- a/packages/core/tests/tools/executor.test.ts
+++ b/packages/core/tests/tools/executor.test.ts
@@ -23,7 +23,7 @@ describe('Tool Executor', () => {
 
       const executor = createToolExecutor();
       const result = await executor.execute(tool, { input: 'hello' });
-      
+
       expect(result).toBe('Result: hello');
     });
 
@@ -36,7 +36,7 @@ describe('Tool Executor', () => {
 
       const executor = createToolExecutor();
       const result = await executor.execute(tool, 'test');
-      
+
       expect(result).toBe('LangChain result: test');
     });
 
@@ -50,7 +50,7 @@ describe('Tool Executor', () => {
 
       const executor = createToolExecutor();
       const result = await executor.execute(tool, 'test');
-      
+
       // Should prefer invoke (LangChain compatibility)
       expect(result).toBe('Invoke: test');
     });
@@ -63,7 +63,7 @@ describe('Tool Executor', () => {
       };
 
       const executor = createToolExecutor();
-      
+
       await expect(executor.execute(tool, 'test')).rejects.toThrow(
         'Tool must implement either invoke() or execute() method'
       );
@@ -81,7 +81,7 @@ describe('Tool Executor', () => {
 
       const executor = createToolExecutor();
       const result = await executor.execute(tool, 'hello');
-      
+
       expect(result).toBe('test-value: hello');
     });
 
@@ -97,7 +97,7 @@ describe('Tool Executor', () => {
 
       const executor = createToolExecutor();
       const result = await executor.execute(tool, 'hello');
-      
+
       expect(result).toBe('test-value: hello');
     });
   });
@@ -125,7 +125,7 @@ describe('Tool Executor', () => {
       });
 
       const result = await executor.execute(tool, 'test');
-      
+
       expect(result).toBe('Success after 3 attempts');
       expect(attempts).toBe(3);
     });
@@ -152,7 +152,7 @@ describe('Tool Executor', () => {
       });
 
       const result = await executor.execute(tool, 'test');
-      
+
       expect(result).toBe('Success after 2 attempts');
       expect(attempts).toBe(2);
     });

--- a/packages/core/tests/tools/helpers.test.ts
+++ b/packages/core/tests/tools/helpers.test.ts
@@ -30,7 +30,7 @@ describe('createTool', () => {
     expect(tool.metadata.description).toBe('A test tool');
     expect(tool.metadata.category).toBe(ToolCategory.UTILITY);
 
-    const result = await tool.execute({ input: 'hello' });
+    const result = await tool.invoke({ input: 'hello' });
     expect(result).toBe('Result: hello');
   });
 
@@ -101,7 +101,7 @@ describe('createTool', () => {
       async ({ required, optional }) => ({ required, optional })
     );
 
-    const result = await tool.execute({ required: 'test' });
+    const result = await tool.invoke({ required: 'test' });
     expect(result.required).toBe('test');
     expect(result.optional).toBeUndefined();
   });
@@ -121,7 +121,7 @@ describe('createTool', () => {
       async ({ items }) => items
     );
 
-    const result = await tool.execute({ items: ['a', 'b', 'c'] });
+    const result = await tool.invoke({ items: ['a', 'b', 'c'] });
     expect(result).toEqual(['a', 'b', 'c']);
   });
 });
@@ -141,7 +141,7 @@ describe('createToolUnsafe', () => {
     );
 
     expect(tool.metadata.name).toBe('unsafe-tool');
-    const result = await tool.execute({ input: 'test' });
+    const result = await tool.invoke({ input: 'test' });
     expect(result).toBe('test');
   });
 

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -226,7 +226,7 @@ export function createExecutorNode(config: ExecutorConfig) {
             );
 
             result = await Promise.race([
-              tool.execute(currentStep.args || {}),
+              tool.invoke(currentStep.args || {}),
               timeoutPromise,
             ]);
 

--- a/packages/patterns/src/react/nodes.ts
+++ b/packages/patterns/src/react/nodes.ts
@@ -237,7 +237,7 @@ export function createActionNode(
       try {
         // Execute the tool
         const startTime = Date.now();
-        const result = await tool.execute(action.arguments);
+        const result = await tool.invoke(action.arguments);
         const executionTime = Date.now() - startTime;
 
         toolsExecuted++;


### PR DESCRIPTION
Updates core test files to use invoke() as the primary method instead of execute().

## Changes
- Updated packages/core/tests/tools/helpers.test.ts: 4 occurrences
- Updated packages/core/tests/tools/builder.test.ts: 8 occurrences
- Fixed packages/core/tests/tools/executor.test.ts: kept executor.execute() (executor doesn't have invoke method)
- Fixed packages/core/tests/tools/types.test.ts: kept raw tool object using execute()
- All 498 core tests passing

## Part of Migration Plan
Part of **Phase 3** of the invoke migration plan (dev-docs/INVOKE_MIGRATION_PLAN.md).

## Testing
- ✅ All 498 core tests passing
- ✅ No breaking changes
- ✅ Backward compatibility maintained

## Dependencies
Depends on PR #17 (Phase 2: Core Implementation)