### PR TITLE
refactor: update examples to use invoke() instead of execute()

### DIFF
--- a/packages/core/examples/basic-tool.ts
+++ b/packages/core/examples/basic-tool.ts
@@ -147,7 +147,7 @@ async function main() {
   const calcValidation = calculatorTool.schema.safeParse(calcInput);
   
   if (calcValidation.success) {
-    const result = await calculatorTool.execute(calcValidation.data);
+    const result = await calculatorTool.invoke(calcValidation.data);
     console.log(`   Result: ${calcInput.a} + ${calcInput.b} = ${result}\n`);
   }
 
@@ -163,7 +163,7 @@ async function main() {
   const fileValidation = readFileTool.schema.safeParse(fileInput);
   
   if (fileValidation.success) {
-    const result = await readFileTool.execute(fileValidation.data);
+    const result = await readFileTool.invoke(fileValidation.data);
     console.log(`   Result: ${result}\n`);
   }
 

--- a/packages/core/examples/builder-vs-manual.ts
+++ b/packages/core/examples/builder-vs-manual.ts
@@ -199,8 +199,8 @@ async function testTools() {
 
   const input = { text: 'hello world', format: 'titlecase' as const };
 
-  const manualResult = await manualTool.execute(input);
-  const builderResult = await builderTool.execute(input);
+  const manualResult = await manualTool.invoke(input);
+  const builderResult = await builderTool.invoke(input);
 
   console.log('Input:', input);
   console.log('Manual Tool Result:', manualResult);

--- a/packages/core/examples/resources/circuit-breaker.ts
+++ b/packages/core/examples/resources/circuit-breaker.ts
@@ -52,7 +52,7 @@ async function main() {
 
   for (let i = 0; i < 8; i++) {
     try {
-      const result = await breaker.execute(() => unstableAPI.call(`request-${i + 1}`));
+      const result = await breaker.invoke(() => unstableAPI.call(`request-${i + 1}`));
       console.log(`  Result ${i + 1}: ${result}`);
     } catch (error) {
       console.log(`  Request ${i + 1} failed: ${(error as Error).message}`);
@@ -86,7 +86,7 @@ async function main() {
   console.log('  Triggering failures...');
   for (let i = 0; i < 4; i++) {
     try {
-      await recoveryBreaker.execute(() => unstableAPI.call(`request-${i + 1}`));
+      await recoveryBreaker.invoke(() => unstableAPI.call(`request-${i + 1}`));
     } catch (error) {
       // Ignore failures
     }
@@ -100,7 +100,7 @@ async function main() {
   failureCount = 10; // Make next calls succeed
 
   try {
-    const result = await recoveryBreaker.execute(() => unstableAPI.call('recovery-test'));
+    const result = await recoveryBreaker.invoke(() => unstableAPI.call('recovery-test'));
     console.log(`  Recovery successful: ${result}`);
   } catch (error) {
     console.log(`  Recovery failed: ${(error as Error).message}`);
@@ -121,7 +121,7 @@ async function main() {
 
   const callWithFallback = async (input: string): Promise<string> => {
     try {
-      return await fallbackBreaker.execute(() => unstableAPI.call(input));
+      return await fallbackBreaker.invoke(() => unstableAPI.call(input));
     } catch (error) {
       if ((error as Error).message === 'Circuit breaker is open') {
         console.log('  Using fallback response');
@@ -169,7 +169,7 @@ async function main() {
 
   for (const code of testCodes) {
     try {
-      const result = await selectiveBreaker.execute(() => apiWithErrors.call(code));
+      const result = await selectiveBreaker.invoke(() => apiWithErrors.call(code));
       console.log(`  ${code}: ${result}`);
     } catch (error) {
       console.log(`  ${code}: ${(error as Error).message}`);

--- a/packages/core/examples/schema-descriptions.ts
+++ b/packages/core/examples/schema-descriptions.ts
@@ -242,7 +242,7 @@ async function main() {
 
   if (validResult.success) {
     console.log('\n✅ Valid input:', validInput);
-    const output = await readFileTool.execute(validResult.data);
+    const output = await readFileTool.invoke(validResult.data);
     console.log('   Output:', output);
   }
 

--- a/packages/core/examples/tool-builder.ts
+++ b/packages/core/examples/tool-builder.ts
@@ -163,7 +163,7 @@ async function main() {
   console.log('   Name:', calculatorTool.metadata.name);
   console.log('   Description:', calculatorTool.metadata.description);
   
-  const calcResult = await calculatorTool.execute({ a: 6, b: 7 });
+  const calcResult = await calculatorTool.invoke({ a: 6, b: 7 });
   console.log(`   Result: 6 × 7 = ${calcResult}\n`);
 
   // Example 2: File Search
@@ -174,7 +174,7 @@ async function main() {
   console.log('   Examples:', searchFilesTool.metadata.examples?.length);
   console.log('   Limitations:', searchFilesTool.metadata.limitations?.length);
   
-  const searchResult = await searchFilesTool.execute({
+  const searchResult = await searchFilesTool.invoke({
     directory: './src',
     pattern: '*.ts',
     recursive: true,
@@ -187,7 +187,7 @@ async function main() {
   console.log('   HTTP GET:', httpGetTool.metadata.name);
   console.log('   HTTP POST:', httpPostTool.metadata.name);
   
-  const getResult = await httpGetTool.execute({
+  const getResult = await httpGetTool.invoke({
     url: 'https://api.example.com/data',
     headers: { 'Authorization': 'Bearer token' },
   });

--- a/packages/core/examples/tools/async-execution.ts
+++ b/packages/core/examples/tools/async-execution.ts
@@ -77,7 +77,7 @@ async function main() {
 
   // Example 1: Execute single tool
   console.log('1. Single tool execution:');
-  const result1 = await executor.execute(searchTool, 'TypeScript');
+  const result1 = await executor.invoke(searchTool, 'TypeScript');
   console.log('Result:', result1);
   console.log();
 
@@ -94,10 +94,10 @@ async function main() {
   // Example 3: Priority-based execution
   console.log('3. Priority-based execution:');
   const promises = [
-    executor.execute(processTool, { data: 'low priority' }, { priority: 'low' }),
-    executor.execute(searchTool, 'high priority', { priority: 'high' }),
-    executor.execute(fetchTool, 'normal priority', { priority: 'normal' }),
-    executor.execute(searchTool, 'critical', { priority: 'critical' }),
+    executor.invoke(processTool, { data: 'low priority' }, { priority: 'low' }),
+    executor.invoke(searchTool, 'high priority', { priority: 'high' }),
+    executor.invoke(fetchTool, 'normal priority', { priority: 'normal' }),
+    executor.invoke(searchTool, 'critical', { priority: 'critical' }),
   ];
   await Promise.all(promises);
   console.log();
@@ -105,7 +105,7 @@ async function main() {
   // Example 4: Retry on failure
   console.log('4. Retry on failure:');
   try {
-    const result = await executor.execute(unstableTool, { test: 'data' });
+    const result = await executor.invoke(unstableTool, { test: 'data' });
     console.log('Unstable tool succeeded:', result);
   } catch (error) {
     console.log('Unstable tool failed after retries');

--- a/packages/core/examples/tools/lifecycle-management.ts
+++ b/packages/core/examples/tools/lifecycle-management.ts
@@ -105,11 +105,11 @@ async function main() {
 
   // Execute queries
   console.log('Executing queries:');
-  const result1 = await dbTool.execute({ query: 'SELECT * FROM users' });
+  const result1 = await dbTool.invoke({ query: 'SELECT * FROM users' });
   console.log('Result 1:', result1);
   console.log();
 
-  const result2 = await dbTool.execute({ query: 'SELECT * FROM posts' });
+  const result2 = await dbTool.invoke({ query: 'SELECT * FROM posts' });
   console.log('Result 2:', result2);
   console.log();
 
@@ -159,7 +159,7 @@ async function main() {
   });
 
   await apiTool.initialize();
-  const apiResult = await apiTool.execute({ endpoint: '/users/123' });
+  const apiResult = await apiTool.invoke({ endpoint: '/users/123' });
   console.log('API result:', apiResult);
   console.log();
 

--- a/packages/core/examples/tools/testing.ts
+++ b/packages/core/examples/tools/testing.ts
@@ -129,10 +129,10 @@ async function main() {
   // Execute tools through simulator
   console.log('  Executing tools...');
   try {
-    await simulator.execute('search', 'TypeScript');
-    await simulator.execute('fetch', 'https://example.com');
-    await simulator.execute('process', { data: 'test' });
-    await simulator.execute('search', 'LangGraph');
+    await simulator.invoke('search', 'TypeScript');
+    await simulator.invoke('fetch', 'https://example.com');
+    await simulator.invoke('process', { data: 'test' });
+    await simulator.invoke('search', 'LangGraph');
   } catch (error) {
     console.log('  Some executions failed (expected with 10% error rate)');
   }

--- a/packages/tools/examples/web-search-example.ts
+++ b/packages/tools/examples/web-search-example.ts
@@ -21,7 +21,7 @@ async function main() {
   // Example 1: Basic search (uses DuckDuckGo by default)
   console.log('1. Basic search with DuckDuckGo:');
   try {
-    const result1 = await webSearch.execute({
+    const result1 = await webSearch.invoke({
       query: 'TypeScript programming language',
       maxResults: 5,
     });
@@ -46,7 +46,7 @@ async function main() {
   if (process.env.SERPER_API_KEY) {
     console.log('2. Search with Serper API:');
     try {
-      const result2 = await webSearch.execute({
+      const result2 = await webSearch.invoke({
         query: 'Latest AI developments 2026',
         maxResults: 5,
         preferSerper: true,
@@ -74,7 +74,7 @@ async function main() {
   // Example 3: Demonstrate fallback behavior
   console.log('3. Fallback behavior (DuckDuckGo → Serper):');
   try {
-    const result3 = await webSearch.execute({
+    const result3 = await webSearch.invoke({
       query: 'obscure technical query that might return no results',
       maxResults: 10,
       preferSerper: false, // Prefer DuckDuckGo, but will fallback to Serper if empty


### PR DESCRIPTION
Updates all example files to use invoke() as the primary method instead of execute().

## Changes
- Updated packages/core/examples/tools/testing.ts: 4 occurrences
- Updated packages/core/examples/tools/lifecycle-management.ts: 2 occurrences
- Updated packages/core/examples/tools/async-execution.ts: 6 occurrences
- Updated packages/core/examples/resources/circuit-breaker.ts: 5 occurrences
- Updated packages/core/examples/schema-descriptions.ts: 1 occurrence
- Updated packages/core/examples/tool-builder.ts: 3 occurrences
- Updated packages/core/examples/basic-tool.ts: 2 occurrences
- Updated packages/core/examples/builder-vs-manual.ts: 2 occurrences
- Updated packages/tools/examples/web-search-example.ts: 3 occurrences
- Total: 29 occurrences updated across 9 files

## Part of Migration Plan
Part of **Phase 5** of the invoke migration plan (dev-docs/INVOKE_MIGRATION_PLAN.md).

## Testing
- ✅ All 997 tests passing
- ✅ No breaking changes
- ✅ Backward compatibility maintained

## Dependencies
Depends on PR #17, PR #18, and PR #19 - all merged