### PR TITLE
docs: update documentation to use invoke() instead of execute()

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -16,7 +16,7 @@ pnpm add @agentforge/tools
 import { webSearch } from '@agentforge/tools';
 
 // Basic search (no API key needed - uses DuckDuckGo)
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'TypeScript programming language',
   maxResults: 10
 });
@@ -29,7 +29,7 @@ result.results.forEach(r => {
 
 // Premium search with Serper API (requires SERPER_API_KEY env var)
 // Get your API key at: https://serper.dev
-const premiumResult = await webSearch.execute({
+const premiumResult = await webSearch.invoke({
   query: 'Latest AI developments 2026',
   maxResults: 5,
   preferSerper: true  // Use Serper for Google search results

--- a/docs-site/examples/custom-tools.md
+++ b/docs-site/examples/custom-tools.md
@@ -48,7 +48,7 @@ const calculatorTool = toolBuilder()
   .build();
 
 // Use the tool
-const result = await calculatorTool.execute({
+const result = await calculatorTool.invoke({
   operation: 'multiply',
   a: 6,
   b: 7

--- a/docs-site/guide/advanced/human-in-the-loop.md
+++ b/docs-site/guide/advanced/human-in-the-loop.md
@@ -31,7 +31,7 @@ const agent = createReActAgent({
 The `askHuman` tool accepts several parameters:
 
 ```typescript
-const response = await askHuman.execute({
+const response = await askHuman.invoke({
   question: 'Do you approve this refund of $500?',
   priority: 'high',
   timeout: 60000, // 1 minute
@@ -84,14 +84,14 @@ Use priority levels to help humans triage requests:
 
 ```typescript
 // Critical approval
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Delete all customer data? This cannot be undone!',
   priority: 'critical',
   suggestions: ['Cancel', 'Confirm deletion']
 });
 
 // Low priority feedback
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Which color scheme do you prefer?',
   priority: 'low',
   timeout: 30000,
@@ -104,7 +104,7 @@ await askHuman.execute({
 Set timeouts to prevent agents from waiting indefinitely:
 
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Approve deployment to production?',
   timeout: 120000, // 2 minutes
   defaultResponse: 'no', // Safe default
@@ -122,7 +122,7 @@ await askHuman.execute({
 Pass context to help humans make informed decisions:
 
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Approve this refund?',
   context: {
     customerId: 'CUST-12345',
@@ -141,7 +141,7 @@ The `askHuman` tool uses LangGraph's `interrupt()` function to pause execution a
 
 ### How It Works
 
-1. Agent calls `askHuman.execute()`
+1. Agent calls `askHuman.invoke()`
 2. Tool calls `interrupt()` with the request
 3. LangGraph pauses execution and saves state
 4. Human receives request via SSE stream
@@ -247,7 +247,7 @@ const agent = createPlanExecuteAgent({
 **Planning Phase Example:**
 ```typescript
 // Agent asks for clarification before creating plan
-await askHuman.execute({
+await askHuman.invoke({
   question: 'What is the target completion date?',
   context: { phase: 'planning' },
   suggestions: ['Today', 'This week', 'This month']
@@ -257,7 +257,7 @@ await askHuman.execute({
 **Execution Phase Example:**
 ```typescript
 // Agent asks for approval during execution
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Step 3 requires admin approval. Proceed?',
   context: { phase: 'execution', step: 3 },
   priority: 'high',
@@ -272,12 +272,12 @@ await askHuman.execute({
 
 ❌ **Bad:**
 ```typescript
-await askHuman.execute({ question: 'OK?' });
+await askHuman.invoke({ question: 'OK?' });
 ```
 
 ✅ **Good:**
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Approve refund of $500 to customer John Doe for order #12345?',
   context: { orderId: '12345', amount: 500, customer: 'John Doe' }
 });
@@ -305,14 +305,14 @@ Always use safe defaults for timeouts:
 
 ```typescript
 // ✅ Safe: Defaults to 'no' for approvals
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Delete user account?',
   timeout: 60000,
   defaultResponse: 'no'
 });
 
 // ❌ Unsafe: Defaults to 'yes' for destructive action
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Delete user account?',
   timeout: 60000,
   defaultResponse: 'yes' // DANGEROUS!
@@ -324,7 +324,7 @@ await askHuman.execute({
 Include relevant information to help humans decide:
 
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Approve this expense?',
   context: {
     amount: 5000,
@@ -341,7 +341,7 @@ await askHuman.execute({
 Help humans respond quickly with suggestions:
 
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'How should we handle this error?',
   suggestions: [
     'Retry automatically',
@@ -358,7 +358,7 @@ Handle errors gracefully:
 
 ```typescript
 try {
-  const result = await askHuman.execute({
+  const result = await askHuman.invoke({
     question: 'Approve this action?',
     timeout: 30000,
     defaultResponse: 'no'

--- a/docs-site/guide/advanced/streaming.md
+++ b/docs-site/guide/advanced/streaming.md
@@ -196,7 +196,7 @@ streamingAgent.on('chunk', (chunk) => {
   console.log('Client 2 received:', chunk);
 });
 
-await streamingAgent.execute('Research task');
+await streamingAgent.invoke('Research task');
 ```
 
 ## Server-Sent Events (SSE)

--- a/docs-site/guide/concepts/tools.md
+++ b/docs-site/guide/concepts/tools.md
@@ -367,7 +367,7 @@ const readJsonTool = toolBuilder()
   }))
   .implement(async ({ path }) => {
     // Use the read-file tool
-    const content = await readFileTool.execute({ path, encoding: 'utf-8' });
+    const content = await readFileTool.invoke({ path, encoding: 'utf-8' });
     return JSON.parse(content);
   })
   .build();

--- a/docs-site/guide/migration.md
+++ b/docs-site/guide/migration.md
@@ -538,7 +538,7 @@ Use this checklist when migrating each tool:
 - [ ] Add at least one `.example()` showing typical usage
 - [ ] Add `.usageNotes()` if there are important usage details
 - [ ] Add `.limitation()` for any known limitations
-- [ ] Test the tool with `.execute()`
+- [ ] Test the tool with `.invoke()`
 - [ ] Verify LangChain conversion with `.toLangChainTool()`
 - [ ] Add to registry if using centralized tool management
 

--- a/docs-site/tutorials/custom-tools.md
+++ b/docs-site/tutorials/custom-tools.md
@@ -350,7 +350,7 @@ import { calculator } from './calculator.js';
 
 describe('Calculator Tool', () => {
   it('should perform addition', async () => {
-    const result = await calculator.execute({
+    const result = await calculator.invoke({
       expression: '2 + 2'
     });
 
@@ -359,7 +359,7 @@ describe('Calculator Tool', () => {
   });
 
   it('should handle errors', async () => {
-    const result = await calculator.execute({
+    const result = await calculator.invoke({
       expression: 'invalid'
     });
 

--- a/docs-site/tutorials/testing.md
+++ b/docs-site/tutorials/testing.md
@@ -77,7 +77,7 @@ import { searchTool } from '../../../src/tools/search';
 
 describe('Search Tool', () => {
   it('should search and return results', async () => {
-    const result = await searchTool.execute({
+    const result = await searchTool.invoke({
       query: 'AgentForge',
       limit: 5
     });
@@ -88,12 +88,12 @@ describe('Search Tool', () => {
   
   it('should handle empty queries', async () => {
     await expect(
-      searchTool.execute({ query: '', limit: 5 })
+      searchTool.invoke({ query: '', limit: 5 })
     ).rejects.toThrow('Query cannot be empty');
   });
   
   it('should respect limit parameter', async () => {
-    const result = await searchTool.execute({
+    const result = await searchTool.invoke({
       query: 'test',
       limit: 3
     });
@@ -540,7 +540,7 @@ describe('Plan-Execute Agent', () => {
 // ✅ Good - isolated test
 it('should add numbers', async () => {
   const tool = createCalculatorTool();
-  const result = await tool.execute({ operation: 'add', a: 2, b: 2 });
+  const result = await tool.invoke({ operation: 'add', a: 2, b: 2 });
   expect(result).toBe('4');
 });
 
@@ -550,7 +550,7 @@ it('should create tool', () => {
   sharedTool = createCalculatorTool();
 });
 it('should use tool', async () => {
-  const result = await sharedTool.execute({ operation: 'add', a: 2, b: 2 });
+  const result = await sharedTool.invoke({ operation: 'add', a: 2, b: 2 });
   expect(result).toBe('4');
 });
 ```

--- a/examples/applications/customer-support/APPROVAL_WORKFLOW.md
+++ b/examples/applications/customer-support/APPROVAL_WORKFLOW.md
@@ -37,7 +37,7 @@ if (refundAmount <= 100) {
   processRefund({ approved: true });
 } else {
   // Request human approval for large refunds
-  const approval = await askHuman.execute({
+  const approval = await askHuman.invoke({
     question: `Approve refund of $${amount}?`,
     context: {
       customer: customerInfo,
@@ -152,7 +152,7 @@ Use appropriate priority for different scenarios:
 Always set timeouts with safe defaults:
 
 ```typescript
-await askHuman.execute({
+await askHuman.invoke({
   question: 'Approve this refund?',
   timeout: 120000, // 2 minutes
   defaultResponse: 'no' // Safe: deny if no response

--- a/packages/core/docs/LANGCHAIN_COMPATIBILITY.md
+++ b/packages/core/docs/LANGCHAIN_COMPATIBILITY.md
@@ -6,16 +6,16 @@ AgentForge tools are designed to be compatible with LangChain patterns to make m
 
 ## The `invoke` Alias
 
-All AgentForge tools support both `.execute()` and `.invoke()` methods:
+All AgentForge tools support both `.invoke()` and `.invoke()` methods:
 
-- **`.execute()`** - The native AgentForge method
-- **`.invoke()`** - An alias for `.execute()` for LangChain compatibility
+- **`.invoke()`** - The native AgentForge method
+- **`.invoke()`** - An alias for `.invoke()` for LangChain compatibility
 
 Both methods do exactly the same thing and can be used interchangeably.
 
 ## Usage Examples
 
-### Using `.execute()` (AgentForge style)
+### Using `.invoke()` (AgentForge style)
 
 ```typescript
 import { toolBuilder, ToolCategory } from '@agentforge/core';
@@ -34,7 +34,7 @@ const greetTool = toolBuilder()
   .build();
 
 // AgentForge style
-const result = await greetTool.execute({ name: 'Alice' });
+const result = await greetTool.invoke({ name: 'Alice' });
 console.log(result); // "Hello, Alice!"
 ```
 
@@ -50,7 +50,7 @@ console.log(result); // "Hello, Bob!"
 
 ```typescript
 // These produce identical results
-const result1 = await greetTool.execute({ name: 'Charlie' });
+const result1 = await greetTool.invoke({ name: 'Charlie' });
 const result2 = await greetTool.invoke({ name: 'Charlie' });
 
 console.log(result1 === result2); // true
@@ -74,7 +74,7 @@ const result = await myAgentForgeTool.invoke({ input: 'data' });
 
 You can use whichever method feels more natural to you:
 
-- **`.execute()`** - More explicit about what's happening
+- **`.invoke()`** - More explicit about what's happening
 - **`.invoke()`** - Shorter and familiar to LangChain users
 
 ## Implementation Details
@@ -103,17 +103,17 @@ const tool = toolBuilder()
   .build();
 
 // TypeScript knows the input type for both methods
-const result1 = await tool.execute({ a: 1, b: 2 }); // ✅ Type-safe
+const result1 = await tool.invoke({ a: 1, b: 2 }); // ✅ Type-safe
 const result2 = await tool.invoke({ a: 1, b: 2 });  // ✅ Type-safe
 
 // TypeScript catches errors for both methods
-await tool.execute({ a: 'wrong' }); // ❌ Type error
+await tool.invoke({ a: 'wrong' }); // ❌ Type error
 await tool.invoke({ a: 'wrong' });  // ❌ Type error
 ```
 
 ## Best Practices
 
-1. **Choose one style and stick with it** - For consistency, pick either `.execute()` or `.invoke()` and use it throughout your codebase
+1. **Choose one style and stick with it** - For consistency, pick either `.invoke()` or `.invoke()` and use it throughout your codebase
 
 2. **Document your choice** - If you're building a library or framework, document which method you use in your examples
 

--- a/packages/core/examples/tools/README.md
+++ b/packages/core/examples/tools/README.md
@@ -108,7 +108,7 @@ const executor = createToolExecutor({
 });
 
 // Execute with automatic retry and timeout
-const result = await executor.execute(myTool, input);
+const result = await executor.invoke(myTool, input);
 ```
 
 ### Pattern 2: Resource Management
@@ -135,7 +135,7 @@ const dbTool = createManagedTool({
 });
 
 await dbTool.initialize();
-const result = await dbTool.execute({ query: 'SELECT * FROM users' });
+const result = await dbTool.invoke({ query: 'SELECT * FROM users' });
 await dbTool.cleanup();
 ```
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -44,23 +44,23 @@ All tools feature:
 import { httpGet, jsonParser, fileReader, calculator } from '@agentforge/tools';
 
 // Make an HTTP GET request
-const response = await httpGet.execute({
+const response = await httpGet.invoke({
   url: 'https://api.example.com/data'
 });
 
 // Parse JSON
-const parsed = await jsonParser.execute({
+const parsed = await jsonParser.invoke({
   json: '{"name": "John", "age": 30}'
 });
 
 // Read a file
-const file = await fileReader.execute({
+const file = await fileReader.invoke({
   path: './data.txt',
   encoding: 'utf8'
 });
 
 // Perform calculations
-const result = await calculator.execute({
+const result = await calculator.invoke({
   operation: 'add',
   a: 10,
   b: 20
@@ -213,7 +213,7 @@ General utility tools for common operations.
 import { webSearch } from '@agentforge/tools';
 
 // Basic search (no API key needed - uses DuckDuckGo)
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'TypeScript programming language',
   maxResults: 10
 });
@@ -226,7 +226,7 @@ result.results.forEach(r => {
 
 // Premium search with Serper API (requires SERPER_API_KEY env var)
 // Get your API key at: https://serper.dev
-const premiumResult = await webSearch.execute({
+const premiumResult = await webSearch.invoke({
   query: 'Latest AI developments 2026',
   maxResults: 5,
   preferSerper: true  // Use Serper for Google search results
@@ -291,7 +291,7 @@ SERPER_API_KEY=your-serper-api-key-here
 ```typescript
 import { webScraper } from '@agentforge/tools';
 
-const result = await webScraper.execute({
+const result = await webScraper.invoke({
   url: 'https://example.com',
   selector: 'article h1',
   extractText: true,
@@ -316,26 +316,26 @@ import {
 } from '@agentforge/tools';
 
 // Send a simple message
-const message = await sendSlackMessage.execute({
+const message = await sendSlackMessage.invoke({
   channel: 'general',
   message: 'Hello from AgentForge!'
 });
 
 // Send a notification with mentions
-const notification = await notifySlack.execute({
+const notification = await notifySlack.invoke({
   channel: 'alerts',
   message: 'System alert: High CPU usage detected',
   mentions: ['john', 'jane']  // Will send as: @john @jane System alert...
 });
 
 // List available channels
-const channels = await getSlackChannels.execute({
+const channels = await getSlackChannels.invoke({
   include_private: false  // Only public channels
 });
 console.log(channels.data?.channels);
 
 // Read message history
-const history = await getSlackMessages.execute({
+const history = await getSlackMessages.invoke({
   channel: 'general',
   limit: 50
 });
@@ -348,7 +348,7 @@ const customTools = createSlackTools({
   botIcon: ':rocket:'
 });
 
-await customTools.sendMessage.execute({
+await customTools.sendMessage.invoke({
   channel: 'general',
   message: 'Message from custom bot!'
 });
@@ -384,34 +384,34 @@ import {
 } from '@agentforge/tools';
 
 // Search for pages
-const searchResults = await searchConfluence.execute({
+const searchResults = await searchConfluence.invoke({
   cql: 'type=page AND space=DOCS',
   limit: 10
 });
 console.log(`Found ${searchResults.results.length} pages`);
 
 // Get a specific page
-const page = await getConfluencePage.execute({
+const page = await getConfluencePage.invoke({
   page_id: '123456'
 });
 console.log(`Page title: ${page.page.title}`);
 console.log(`Content: ${page.page.content}`);
 
 // List all spaces
-const spaces = await listConfluenceSpaces.execute({
+const spaces = await listConfluenceSpaces.invoke({
   limit: 50
 });
 console.log(`Found ${spaces.spaces.length} spaces`);
 
 // Get pages from a space
-const spacePages = await getSpacePages.execute({
+const spacePages = await getSpacePages.invoke({
   space_key: 'DOCS',
   limit: 25
 });
 console.log(`Found ${spacePages.pages.length} pages in DOCS space`);
 
 // Create a new page
-const newPage = await createConfluencePage.execute({
+const newPage = await createConfluencePage.invoke({
   space_key: 'DOCS',
   title: 'My New Page',
   content: '<p>This is the page content in HTML format</p>',
@@ -420,7 +420,7 @@ const newPage = await createConfluencePage.execute({
 console.log(`Created page with ID: ${newPage.page.id}`);
 
 // Update an existing page
-const updated = await updateConfluencePage.execute({
+const updated = await updateConfluencePage.invoke({
   page_id: newPage.page.id,
   title: 'Updated Page Title',
   content: '<p>Updated content</p>'
@@ -428,7 +428,7 @@ const updated = await updateConfluencePage.execute({
 console.log(`Updated to version ${updated.page.version}`);
 
 // Archive a page
-const archived = await archiveConfluencePage.execute({
+const archived = await archiveConfluencePage.invoke({
   page_id: newPage.page.id,
   reason: 'No longer needed'
 });
@@ -441,7 +441,7 @@ const customTools = createConfluenceTools({
   siteUrl: 'https://your-domain.atlassian.net'
 });
 
-await customTools.searchConfluence.execute({
+await customTools.searchConfluence.invoke({
   cql: 'type=page',
   limit: 5
 });
@@ -468,13 +468,13 @@ ATLASSIAN_SITE_URL=https://your-domain.atlassian.net
 import { csvParser, arrayFilter, arraySort } from '@agentforge/tools';
 
 // Parse CSV data
-const parsed = await csvParser.execute({
+const parsed = await csvParser.invoke({
   csv: 'name,age,city\nJohn,30,NYC\nJane,25,LA',
   hasHeaders: true
 });
 
 // Filter the data
-const filtered = await arrayFilter.execute({
+const filtered = await arrayFilter.invoke({
   array: parsed.data,
   property: 'age',
   operator: 'greater-than',
@@ -482,7 +482,7 @@ const filtered = await arrayFilter.execute({
 });
 
 // Sort the results
-const sorted = await arraySort.execute({
+const sorted = await arraySort.invoke({
   array: filtered.filtered,
   property: 'age',
   order: 'desc'
@@ -497,7 +497,7 @@ console.log(sorted.sorted);
 import { fileReader, fileWriter, directoryList } from '@agentforge/tools';
 
 // Read a file
-const content = await fileReader.execute({
+const content = await fileReader.invoke({
   path: './data.json',
   encoding: 'utf8'
 });
@@ -506,14 +506,14 @@ const content = await fileReader.execute({
 const processed = JSON.parse(content.content);
 processed.updated = new Date().toISOString();
 
-await fileWriter.execute({
+await fileWriter.invoke({
   path: './data-updated.json',
   content: JSON.stringify(processed, null, 2),
   createDirs: true
 });
 
 // List directory
-const files = await directoryList.execute({
+const files = await directoryList.invoke({
   path: './',
   recursive: false,
   includeDetails: true
@@ -528,13 +528,13 @@ console.log(files.files);
 import { currentDateTime, dateArithmetic, dateDifference } from '@agentforge/tools';
 
 // Get current date
-const now = await currentDateTime.execute({
+const now = await currentDateTime.invoke({
   format: 'custom',
   customFormat: 'yyyy-MM-dd HH:mm:ss'
 });
 
 // Add 7 days
-const future = await dateArithmetic.execute({
+const future = await dateArithmetic.invoke({
   date: now.iso,
   operation: 'add',
   amount: 7,
@@ -542,7 +542,7 @@ const future = await dateArithmetic.execute({
 });
 
 // Calculate difference
-const diff = await dateDifference.execute({
+const diff = await dateDifference.invoke({
   startDate: now.iso,
   endDate: future.result,
   unit: 'hours'
@@ -557,20 +557,20 @@ console.log(`${diff.difference} hours until ${future.result}`);
 import { stringCaseConverter, stringReplace, stringSplit } from '@agentforge/tools';
 
 // Convert to different cases
-const camel = await stringCaseConverter.execute({
+const camel = await stringCaseConverter.invoke({
   text: 'hello world example',
   targetCase: 'camel'
 });
 // Result: "helloWorldExample"
 
-const kebab = await stringCaseConverter.execute({
+const kebab = await stringCaseConverter.invoke({
   text: 'HelloWorldExample',
   targetCase: 'kebab'
 });
 // Result: "hello-world-example"
 
 // Replace text
-const replaced = await stringReplace.execute({
+const replaced = await stringReplace.invoke({
   text: 'Hello World, Hello Universe',
   search: 'Hello',
   replace: 'Hi',
@@ -579,7 +579,7 @@ const replaced = await stringReplace.execute({
 // Result: "Hi World, Hi Universe"
 
 // Split string
-const parts = await stringSplit.execute({
+const parts = await stringSplit.invoke({
   text: 'apple,banana,orange',
   delimiter: ','
 });
@@ -592,19 +592,19 @@ const parts = await stringSplit.execute({
 import { emailValidator, urlValidatorSimple, creditCardValidator } from '@agentforge/tools';
 
 // Validate email
-const email = await emailValidator.execute({
+const email = await emailValidator.invoke({
   email: 'user@example.com'
 });
 console.log(email.valid); // true
 
 // Validate URL
-const url = await urlValidatorSimple.execute({
+const url = await urlValidatorSimple.invoke({
   url: 'https://example.com/path'
 });
 console.log(url.valid); // true
 
 // Validate credit card
-const card = await creditCardValidator.execute({
+const card = await creditCardValidator.invoke({
   cardNumber: '4532-1488-0343-6467'
 });
 console.log(card.valid); // true (passes Luhn check)
@@ -650,7 +650,7 @@ interface Tool<TInput, TOutput> {
 Most tools return a result object with a `success` field:
 
 ```typescript
-const result = await someTool.execute({ ... });
+const result = await someTool.invoke({ ... });
 
 if (result.success) {
   console.log(result.data);
@@ -667,7 +667,7 @@ All tools are fully typed with TypeScript:
 import { httpGet } from '@agentforge/tools';
 
 // TypeScript knows the input type
-const result = await httpGet.execute({
+const result = await httpGet.invoke({
   url: 'https://api.example.com',
   headers: { 'Authorization': 'Bearer token' }
 });
@@ -733,7 +733,7 @@ const customTools = createSlackTools({
 });
 
 // Use custom tools
-await customTools.sendMessage.execute({
+await customTools.sendMessage.invoke({
   channel: 'general',
   message: 'Hello from custom bot!'
 });

--- a/packages/tools/src/web/web-search/TESTING.md
+++ b/packages/tools/src/web/web-search/TESTING.md
@@ -99,7 +99,7 @@ OPENAI_API_KEY=your-openai-api-key
 ```typescript
 import { webSearch } from '@agentforge/tools';
 
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'TypeScript programming language',
   maxResults: 10,
 });
@@ -113,7 +113,7 @@ console.log(result.results.length); // Number of results
 ```typescript
 import { webSearch } from '@agentforge/tools';
 
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'Latest AI developments 2026',
   maxResults: 10,
   preferSerper: true, // Use Serper if available
@@ -127,7 +127,7 @@ console.log(result.source); // 'serper' or 'duckduckgo'
 ```typescript
 import { webSearch } from '@agentforge/tools';
 
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'Python programming',
   maxResults: 5,
   timeout: 5000, // 5 second timeout
@@ -139,7 +139,7 @@ const result = await webSearch.execute({
 ```typescript
 import { webSearch } from '@agentforge/tools';
 
-const result = await webSearch.execute({
+const result = await webSearch.invoke({
   query: 'JavaScript frameworks',
   maxResults: 50, // Request up to 50 results
 });
@@ -153,7 +153,7 @@ import { webSearch } from '@agentforge/tools';
 const queries = ['TypeScript', 'Rust', 'Go'];
 const results = await Promise.all(
   queries.map((query) =>
-    webSearch.execute({
+    webSearch.invoke({
       query,
       maxResults: 5,
     })


### PR DESCRIPTION
Updates all documentation files to use invoke() as the primary method.

Changes:
- Updated 15 markdown files
- Replaced all .execute( with .invoke( in documentation
- All 997 tests passing

Part of Phase 6 of the invoke migration plan.
Depends on PR #17, #18, #19, and #20 (all merged).