### PR TITLE
fix(lint): resolve baseline lint errors

### DIFF
--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -140,11 +140,11 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
   // Note: Empty workers array is allowed - workers can be registered later with registerWorkers()
 
   // Create the graph
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   const workflow = new StateGraph(MultiAgentState);
 
   // Configure supervisor model with structured output
-  let supervisorConfig = { ...supervisor, maxIterations, verbose };
+  const supervisorConfig = { ...supervisor, maxIterations, verbose };
   if (supervisor.model) {
     let configuredModel = supervisor.model;
 
@@ -251,11 +251,11 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
   };
 
   // Set entry point
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   workflow.setEntryPoint('supervisor');
 
   // Add edges from supervisor
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   workflow.addConditionalEdges('supervisor', supervisorRouter, [
     'aggregator',
     END,
@@ -264,12 +264,12 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
 
   // Add edges from workers back to supervisor
   for (const workerId of workerIds) {
-    // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+    // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
     workflow.addConditionalEdges(workerId, workerRouter, ['supervisor']);
   }
 
   // Add edge from aggregator to end
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   workflow.addConditionalEdges('aggregator', aggregatorRouter, [END]);
 
   // Compile the graph with checkpointer if provided
@@ -524,4 +524,3 @@ export function createWorkersRegistry(workers: Array<{ id: string; capabilities:
   }
   return registry;
 }
-

--- a/packages/patterns/src/plan-execute/agent.ts
+++ b/packages/patterns/src/plan-execute/agent.ts
@@ -91,7 +91,7 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
     : async (state: PlanExecuteStateType) => ({ status: 'executing' as const });
 
   // Create the graph
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   const workflow = new StateGraph(PlanExecuteState)
     .addNode('planner', plannerNode)
     .addNode('executor', executorNode)
@@ -184,4 +184,3 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
   // Compile with checkpointer if provided
   return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
 }
-

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -168,7 +168,7 @@ export function createReActAgent(
 
   // ===== Build the Graph =====
 
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   const workflow: StateGraph<ReActStateType> = new StateGraph(ReActState)
     .addNode(REASONING_NODE, reasoningNode)
     .addNode(ACTION_NODE, actionNode)
@@ -190,4 +190,3 @@ export function createReActAgent(
 
   return workflow.compile(checkpointerConfig) as any;
 }
-

--- a/packages/patterns/src/reflection/agent.ts
+++ b/packages/patterns/src/reflection/agent.ts
@@ -127,7 +127,7 @@ export function createReflectionAgent(config: ReflectionAgentConfig) {
   };
 
   // Create the graph
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   const workflow = new StateGraph(ReflectionState)
     .addNode('generator', generatorNode)
     .addNode('reflector', reflectorNode)
@@ -168,4 +168,3 @@ export function createReflectionAgent(config: ReflectionAgentConfig) {
   // Compile with checkpointer if provided
   return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
 }
-

--- a/packages/patterns/src/shared/agent-builder.ts
+++ b/packages/patterns/src/shared/agent-builder.ts
@@ -129,7 +129,7 @@ export function buildAgent(config: AgentBuilderConfig): CompiledStateGraph<any, 
   } = config;
 
   // Create the workflow
-  // @ts-ignore - LangGraph's complex generic types don't infer well with createStateAnnotation
+  // @ts-expect-error - LangGraph's complex generic types don't infer well with createStateAnnotation
   const workflow = new StateGraph(state);
 
   // Add all nodes
@@ -157,4 +157,3 @@ export function buildAgent(config: AgentBuilderConfig): CompiledStateGraph<any, 
   // Compile with checkpointer if provided
   return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
 }
-

--- a/packages/tools/examples/neo4j-embedding-test.mjs
+++ b/packages/tools/examples/neo4j-embedding-test.mjs
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /**
  * Neo4j Embedding Tools Test
  * 
@@ -18,6 +19,8 @@ import {
   neo4jVectorSearchWithEmbedding,
   neo4jPool,
 } from '../dist/index.js';
+
+const { console, setTimeout } = globalThis;
 
 console.log('🚀 Testing Neo4j Embedding Tools\n');
 
@@ -161,4 +164,3 @@ try {
   console.log('\n👋 Disconnecting from Neo4j');
   await neo4jPool.close();
 }
-

--- a/packages/tools/examples/neo4j-test.mjs
+++ b/packages/tools/examples/neo4j-test.mjs
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /**
  * Neo4j Tools Test Script
  * 
@@ -11,6 +12,8 @@ import {
   neo4jFindNodes,
   neo4jPool,
 } from '../dist/index.js';
+
+const { console, process } = globalThis;
 
 async function main() {
   console.log('🚀 Testing Neo4j Tools\n');
@@ -96,4 +99,3 @@ async function main() {
 }
 
 main();
-

--- a/packages/tools/src/data/transformer/types.ts
+++ b/packages/tools/src/data/transformer/types.ts
@@ -60,7 +60,4 @@ export const objectOmitSchema = z.object({
 /**
  * Transformer tools configuration
  */
-export interface TransformerToolsConfig {
-  // No specific configuration needed for transformer tools
-}
-
+export type TransformerToolsConfig = Record<string, never>;

--- a/packages/tools/src/file/path/types.ts
+++ b/packages/tools/src/file/path/types.ts
@@ -67,7 +67,4 @@ export const pathNormalizeSchema = z.object({
 /**
  * Path utilities configuration
  */
-export interface PathUtilitiesConfig {
-  // No specific configuration needed for path utilities
-}
-
+export type PathUtilitiesConfig = Record<string, never>;

--- a/packages/tools/src/utility/date-time/types.ts
+++ b/packages/tools/src/utility/date-time/types.ts
@@ -52,13 +52,10 @@ export const DateComparisonSchema = z.object({
 /**
  * Configuration for date/time tools
  */
-export interface DateTimeConfig {
-  // Future: Add configuration options if needed
-}
+export type DateTimeConfig = Record<string, never>;
 
 export type CurrentDateTimeInput = z.infer<typeof CurrentDateTimeSchema>;
 export type DateFormatterInput = z.infer<typeof DateFormatterSchema>;
 export type DateArithmeticInput = z.infer<typeof DateArithmeticSchema>;
 export type DateDifferenceInput = z.infer<typeof DateDifferenceSchema>;
 export type DateComparisonInput = z.infer<typeof DateComparisonSchema>;
-

--- a/packages/tools/src/utility/math/types.ts
+++ b/packages/tools/src/utility/math/types.ts
@@ -40,12 +40,9 @@ export const StatisticsSchema = z.object({
 /**
  * Configuration for math operations tools
  */
-export interface MathOperationsConfig {
-  // Future: Add configuration options if needed
-}
+export type MathOperationsConfig = Record<string, never>;
 
 export type CalculatorInput = z.infer<typeof CalculatorSchema>;
 export type MathFunctionsInput = z.infer<typeof MathFunctionsSchema>;
 export type RandomNumberInput = z.infer<typeof RandomNumberSchema>;
 export type StatisticsInput = z.infer<typeof StatisticsSchema>;
-

--- a/packages/tools/src/utility/string/types.ts
+++ b/packages/tools/src/utility/string/types.ts
@@ -68,9 +68,7 @@ export const StringLengthSchema = z.object({
 /**
  * Configuration for string utility tools
  */
-export interface StringUtilitiesConfig {
-  // Future: Add configuration options if needed
-}
+export type StringUtilitiesConfig = Record<string, never>;
 
 export type StringCaseConverterInput = z.infer<typeof StringCaseConverterSchema>;
 export type StringTrimInput = z.infer<typeof StringTrimSchema>;
@@ -79,4 +77,3 @@ export type StringSplitInput = z.infer<typeof StringSplitSchema>;
 export type StringJoinInput = z.infer<typeof StringJoinSchema>;
 export type StringSubstringInput = z.infer<typeof StringSubstringSchema>;
 export type StringLengthInput = z.infer<typeof StringLengthSchema>;
-

--- a/packages/tools/src/utility/validation/types.ts
+++ b/packages/tools/src/utility/validation/types.ts
@@ -51,9 +51,7 @@ export const UuidValidatorSchema = z.object({
 /**
  * Configuration for validation tools
  */
-export interface ValidationConfig {
-  // Future: Add configuration options if needed
-}
+export type ValidationConfig = Record<string, never>;
 
 export type EmailValidatorInput = z.infer<typeof EmailValidatorSchema>;
 export type UrlValidatorSimpleInput = z.infer<typeof UrlValidatorSimpleSchema>;
@@ -61,4 +59,3 @@ export type PhoneValidatorInput = z.infer<typeof PhoneValidatorSchema>;
 export type CreditCardValidatorInput = z.infer<typeof CreditCardValidatorSchema>;
 export type IpValidatorInput = z.infer<typeof IpValidatorSchema>;
 export type UuidValidatorInput = z.infer<typeof UuidValidatorSchema>;
-

--- a/packages/tools/src/web/html-parser/types.ts
+++ b/packages/tools/src/web/html-parser/types.ts
@@ -9,9 +9,7 @@ import { z } from 'zod';
 /**
  * HTML parser tools configuration
  */
-export interface HtmlParserToolsConfig {
-  // No specific config needed for HTML parser tools currently
-}
+export type HtmlParserToolsConfig = Record<string, never>;
 
 /**
  * HTML parser input schema
@@ -39,4 +37,3 @@ export const extractImagesSchema = z.object({
   html: z.string().describe('The HTML content to extract images from'),
   baseUrl: z.string().url().optional().describe('Optional base URL to resolve relative image URLs'),
 });
-

--- a/packages/tools/src/web/url-validator/types.ts
+++ b/packages/tools/src/web/url-validator/types.ts
@@ -23,9 +23,7 @@ export interface UrlValidationResult {
 /**
  * URL validator tools configuration
  */
-export interface UrlValidatorToolsConfig {
-  // No specific config needed for URL validator tools currently
-}
+export type UrlValidatorToolsConfig = Record<string, never>;
 
 /**
  * URL validator input schema
@@ -52,4 +50,3 @@ export const urlBuilderSchema = z.object({
 export const urlQueryParserSchema = z.object({
   input: z.string().describe('URL or query string to parse (e.g., "?foo=bar&baz=qux" or full URL)'),
 });
-


### PR DESCRIPTION
## Summary
Resolves the repository lint **error baseline** so `pnpm lint` completes successfully (warnings-only output).

## Why
Recent story work surfaced unrelated lint blockers in baseline code. This PR isolates those fixes so feature/story PRs are not forced to include out-of-scope cleanup.

## What Changed
- Fixed Node-global `no-undef` errors in example scripts by binding globals from `globalThis`.
- Replaced empty config interfaces that violated `@typescript-eslint/no-empty-object-type` with `Record<string, never>` type aliases.
- Fixed `packages/patterns` lint errors by replacing `@ts-ignore` with `@ts-expect-error` where appropriate and resolving one `prefer-const` issue.

## Files Updated
- `packages/tools/examples/neo4j-embedding-test.mjs`
- `packages/tools/examples/neo4j-test.mjs`
- `packages/tools/src/data/transformer/types.ts`
- `packages/tools/src/file/path/types.ts`
- `packages/tools/src/utility/date-time/types.ts`
- `packages/tools/src/utility/math/types.ts`
- `packages/tools/src/utility/string/types.ts`
- `packages/tools/src/utility/validation/types.ts`
- `packages/tools/src/web/html-parser/types.ts`
- `packages/tools/src/web/url-validator/types.ts`
- `packages/patterns/src/multi-agent/agent.ts`
- `packages/patterns/src/plan-execute/agent.ts`
- `packages/patterns/src/react/agent.ts`
- `packages/patterns/src/reflection/agent.ts`
- `packages/patterns/src/shared/agent-builder.ts`

## Validation
- `pnpm lint` ✅ (0 lint errors, warnings remain)
- `pnpm test --run` ✅ (`94` passed files, `2` skipped; `1152` passed tests, `74` skipped)

## Scope Notes
- This PR is intentionally limited to baseline lint error remediation.
- It does not change planned feature behavior.
