### PR TITLE
feat(st-02003): implement type-safe insert tool

### DIFF
--- a/docs/st02003-type-safe-insert-tool.md
+++ b/docs/st02003-type-safe-insert-tool.md
@@ -1,0 +1,100 @@
+# ST-02003: Type-Safe INSERT Tool
+
+**Status:** 🚧 Draft PR  
+**PR:** [#34](https://github.com/TVScoundrel/agentforge/pull/34)  
+**Epic:** 02 - Query Operations  
+**Priority:** P0
+
+## Overview
+
+Implemented a type-safe INSERT tool that provides structured single-row and batch insert operations without requiring raw SQL. The tool supports configurable return behavior (`none`, `id`, `row`), validates input payloads, and returns clear constraint-violation messages for common database errors.
+
+## Implementation
+
+### Core Components
+
+1. **Shared INSERT Query Builder**
+   - `packages/tools/src/data/relational/query/query-builder.ts`
+   - Builds parameterized INSERT SQL for single-row and batch inputs
+   - Handles default values in batch mode by emitting `DEFAULT` for missing columns
+   - Applies vendor-aware `RETURNING` behavior
+
+2. **Relational INSERT Tool Module** (`packages/tools/src/data/relational/tools/relational-insert/`)
+   - `index.ts`: LangGraph tool built with `toolBuilder()` API
+   - `schemas.ts`: Zod validation schema for insert payloads and returning options
+   - `types.ts`: Shared input/output types
+   - `executor.ts`: Execution, result normalization, and ID derivation
+   - `error-utils.ts`: Safe error classification for validation and constraint violations
+
+3. **Tool Export Integration**
+   - `packages/tools/src/data/relational/tools/index.ts` now exports `relationalInsert`
+
+## Supported Behaviors
+
+### Single-Row and Batch Inserts
+
+- Accepts one row object or an array of row objects
+- Supports mixed-shape batch rows by using the union of columns and `DEFAULT` for omitted fields
+
+### Returning Modes
+
+- `none` (default): returns row count only
+- `id`: returns inserted IDs (from `RETURNING`, explicit input IDs, or vendor metadata fallback)
+- `row`: returns full inserted rows for vendors that support `RETURNING`
+
+### Vendor-Specific RETURNING Differences
+
+- PostgreSQL / SQLite: use `RETURNING`
+- MySQL: `RETURNING row` is rejected with a clear message; `id` mode falls back to insert metadata where available
+
+### Validation and Error Handling
+
+- Validates table and column identifiers
+- Validates payload shape and returning config
+- Maps common constraint errors to clear, safe messages:
+  - unique constraint violations
+  - foreign key violations
+  - NOT NULL violations
+
+## Testing
+
+Added tests under `packages/tools/tests/data/relational/relational-insert/`:
+
+- `schema-validation.test.ts`
+- `query-builder.test.ts`
+- `tool-invocation.test.ts`
+- `index.test.ts`
+- `test-utils.ts`
+
+### Coverage Highlights
+
+- Valid/invalid schema cases
+- Single insert and batch insert execution
+- Default values and auto-increment behavior
+- `RETURNING id` and `RETURNING row` behavior
+- Constraint-violation error classification
+- MySQL-specific unsupported `RETURNING row` behavior
+
+## Usage Example
+
+```typescript
+import { relationalInsert } from '@agentforge/tools';
+
+const result = await relationalInsert.invoke({
+  table: 'users',
+  data: { name: 'Alice', email: 'alice@example.com' },
+  returning: { mode: 'id', idColumn: 'id' },
+  vendor: 'postgresql',
+  connectionString: process.env.DATABASE_URL!,
+});
+
+if (result.success) {
+  console.log(result.rowCount, result.insertedIds);
+} else {
+  console.error(result.error);
+}
+```
+
+## Dependencies
+
+- ✅ ST-02002 (Type-Safe SELECT Tool) - merged 2026-02-18

--- a/docs/st02003-type-safe-insert-tool.md
+++ b/docs/st02003-type-safe-insert-tool.md
@@ -78,7 +78,10 @@ Added tests under `packages/tools/tests/data/relational/relational-insert/`:
 ## Usage Example
 
 ```typescript
+import { createLogger } from '@agentforge/core';
 import { relationalInsert } from '@agentforge/tools';
+
+const logger = createLogger('my-app');
 
 const result = await relationalInsert.invoke({
   table: 'users',
@@ -89,9 +92,12 @@ const result = await relationalInsert.invoke({
 });
 
 if (result.success) {
-  console.log(result.rowCount, result.insertedIds);
+  logger.info('Insert completed', {
+    rowCount: result.rowCount,
+    insertedIds: result.insertedIds,
+  });
 } else {
-  console.error(result.error);
+  logger.error('Insert failed', { error: result.error });
 }
 ```
 

--- a/docs/st02003-type-safe-insert-tool.md
+++ b/docs/st02003-type-safe-insert-tool.md
@@ -1,6 +1,6 @@
 # ST-02003: Type-Safe INSERT Tool
 
-**Status:** 🚧 Draft PR  
+**Status:** ✅ Ready for Review  
 **PR:** [#34](https://github.com/TVScoundrel/agentforge/pull/34)  
 **Epic:** 02 - Query Operations  
 **Priority:** P0

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -10,4 +10,13 @@ export type {
 } from './types.js';
 
 export { executeQuery } from './query-executor.js';
-
+export {
+  buildInsertQuery,
+  type InsertValue,
+  type InsertRow,
+  type InsertData,
+  type InsertReturningMode,
+  type InsertReturningOptions,
+  type InsertQueryInput,
+  type BuiltInsertQuery,
+} from './query-builder.js';

--- a/packages/tools/src/data/relational/query/query-builder.ts
+++ b/packages/tools/src/data/relational/query/query-builder.ts
@@ -10,7 +10,7 @@ import {
   quoteQualifiedIdentifier,
   validateIdentifier,
   validateQualifiedIdentifier,
-} from '../tools/relational-select/identifier-utils.js';
+} from '../utils/identifier-utils.js';
 
 /**
  * Supported scalar values for INSERT payloads.

--- a/packages/tools/src/data/relational/query/query-builder.ts
+++ b/packages/tools/src/data/relational/query/query-builder.ts
@@ -1,0 +1,199 @@
+/**
+ * Query builder helpers for relational CRUD operations.
+ * @module query/query-builder
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import type { DatabaseVendor } from '../types.js';
+import {
+  quoteIdentifier,
+  quoteQualifiedIdentifier,
+  validateIdentifier,
+  validateQualifiedIdentifier,
+} from '../tools/relational-select/identifier-utils.js';
+
+/**
+ * Supported scalar values for INSERT payloads.
+ */
+export type InsertValue = string | number | boolean | null;
+
+/**
+ * One INSERT row payload.
+ */
+export type InsertRow = Record<string, InsertValue>;
+
+/**
+ * INSERT payload input shape.
+ */
+export type InsertData = InsertRow | InsertRow[];
+
+/**
+ * INSERT RETURNING behavior.
+ */
+export type InsertReturningMode = 'none' | 'id' | 'row';
+
+/**
+ * INSERT RETURNING configuration.
+ */
+export interface InsertReturningOptions {
+  mode?: InsertReturningMode;
+  idColumn?: string;
+}
+
+/**
+ * Builder input for INSERT queries.
+ */
+export interface InsertQueryInput {
+  table: string;
+  data: InsertData;
+  returning?: InsertReturningOptions;
+  vendor: DatabaseVendor;
+}
+
+/**
+ * Built INSERT query with normalized metadata used by execution layer.
+ */
+export interface BuiltInsertQuery {
+  query: SQL;
+  rows: InsertRow[];
+  returningMode: InsertReturningMode;
+  idColumn: string;
+  supportsReturning: boolean;
+}
+
+const DEFAULT_ID_COLUMN = 'id';
+
+function normalizeInsertRows(data: InsertData): InsertRow[] {
+  const rows = Array.isArray(data) ? data : [data];
+
+  if (rows.length === 0) {
+    throw new Error('Insert data must not be an empty array');
+  }
+
+  rows.forEach((row, rowIndex) => {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error(`Insert row at index ${rowIndex} must be an object`);
+    }
+  });
+
+  return rows;
+}
+
+function collectOrderedColumns(rows: InsertRow[]): string[] {
+  const seen = new Set<string>();
+  const orderedColumns: string[] = [];
+
+  rows.forEach((row) => {
+    Object.keys(row).forEach((column) => {
+      if (!seen.has(column)) {
+        seen.add(column);
+        orderedColumns.push(column);
+      }
+    });
+  });
+
+  return orderedColumns;
+}
+
+function buildValuesTuple(columns: string[], row: InsertRow): SQL {
+  const valueFragments = columns.map((column) => {
+    if (!Object.prototype.hasOwnProperty.call(row, column)) {
+      return sql.raw('DEFAULT');
+    }
+
+    const value = row[column];
+
+    if (value === undefined) {
+      throw new Error(`Insert value for column "${column}" must not be undefined`);
+    }
+
+    return sql`${value}`;
+  });
+
+  return sql.join(
+    [sql.raw('('), sql.join(valueFragments, sql.raw(', ')), sql.raw(')')],
+    sql.raw('')
+  );
+}
+
+function buildInsertValuesQuery(
+  table: string,
+  columns: string[],
+  rows: InsertRow[],
+  vendor: DatabaseVendor
+): SQL {
+  const quotedTable = quoteQualifiedIdentifier(table, vendor);
+  const quotedColumns = columns.map((column) => quoteIdentifier(column, vendor)).join(', ');
+
+  const rowTuples = rows.map((row) => buildValuesTuple(columns, row));
+
+  return sql.join(
+    [
+      sql.raw(`INSERT INTO ${quotedTable} (${quotedColumns}) VALUES `),
+      sql.join(rowTuples, sql.raw(', ')),
+    ],
+    sql.raw('')
+  );
+}
+
+function buildInsertDefaultValuesQuery(
+  table: string,
+  rowCount: number,
+  vendor: DatabaseVendor
+): SQL {
+  if (rowCount > 1) {
+    throw new Error('Batch INSERT with only DEFAULT VALUES is not supported');
+  }
+
+  const quotedTable = quoteQualifiedIdentifier(table, vendor);
+  return sql.raw(`INSERT INTO ${quotedTable} DEFAULT VALUES`);
+}
+
+/**
+ * Build a safe parameterized INSERT query from structured input.
+ */
+export function buildInsertQuery(input: InsertQueryInput): BuiltInsertQuery {
+  validateQualifiedIdentifier(input.table, 'Table name');
+
+  const rows = normalizeInsertRows(input.data);
+  const columns = collectOrderedColumns(rows);
+
+  const returningMode: InsertReturningMode = input.returning?.mode ?? 'none';
+  const idColumn = input.returning?.idColumn ?? DEFAULT_ID_COLUMN;
+  const supportsReturning = input.vendor === 'postgresql' || input.vendor === 'sqlite';
+
+  if (returningMode === 'id') {
+    validateIdentifier(idColumn, 'Returning id column');
+  } else if (input.returning?.idColumn) {
+    throw new Error('returning.idColumn can only be provided when returning.mode is "id"');
+  }
+
+  if (returningMode === 'row' && input.vendor === 'mysql') {
+    throw new Error('Returning full rows is not supported for mysql. Use returning.mode "id" or "none".');
+  }
+
+  columns.forEach((column) => validateIdentifier(column, 'Insert column'));
+
+  let query = columns.length > 0
+    ? buildInsertValuesQuery(input.table, columns, rows, input.vendor)
+    : buildInsertDefaultValuesQuery(input.table, rows.length, input.vendor);
+
+  if (returningMode !== 'none' && supportsReturning) {
+    if (returningMode === 'id') {
+      query = sql.join(
+        [query, sql.raw(` RETURNING ${quoteIdentifier(idColumn, input.vendor)}`)],
+        sql.raw('')
+      );
+    } else {
+      query = sql.join([query, sql.raw(' RETURNING *')], sql.raw(''));
+    }
+  }
+
+  return {
+    query,
+    rows,
+    returningMode,
+    idColumn,
+    supportsReturning,
+  };
+}

--- a/packages/tools/src/data/relational/tools/index.ts
+++ b/packages/tools/src/data/relational/tools/index.ts
@@ -5,4 +5,5 @@
 
 export { relationalQuery } from './relational-query.js';
 export { relationalSelect } from './relational-select/index.js';
+export { relationalInsert } from './relational-insert/index.js';
 export { relationalGetSchema } from './relational-get-schema.js';

--- a/packages/tools/src/data/relational/tools/relational-insert/error-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/error-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for classifying safe validation and constraint errors in relational-insert.
+ */
+
+const SAFE_INSERT_VALIDATION_PATTERNS = [
+  'must not be empty',
+  'contains invalid characters',
+  'must be an object',
+  'must not be an empty array',
+  'must not be undefined',
+  'idColumn can only be provided',
+  'Returning full rows is not supported for mysql',
+  'Batch INSERT with only DEFAULT VALUES is not supported',
+] as const;
+
+const CONSTRAINT_VIOLATION_PATTERNS = [
+  {
+    pattern: /(unique constraint|duplicate key|duplicate entry)/i,
+    message: 'Insert failed: unique constraint violation.',
+  },
+  {
+    pattern: /(foreign key constraint|violates foreign key constraint)/i,
+    message: 'Insert failed: foreign key constraint violation.',
+  },
+  {
+    pattern: /(not null constraint|cannot be null)/i,
+    message: 'Insert failed: NOT NULL constraint violation.',
+  },
+] as const;
+
+export function isSafeInsertValidationError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return SAFE_INSERT_VALIDATION_PATTERNS.some((pattern) => error.message.includes(pattern));
+}
+
+export function getConstraintViolationMessage(error: unknown): string | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  for (const entry of CONSTRAINT_VIOLATION_PATTERNS) {
+    if (entry.pattern.test(error.message)) {
+      return entry.message;
+    }
+  }
+
+  return null;
+}
+
+export function isSafeInsertError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return isSafeInsertValidationError(error) || getConstraintViolationMessage(error) !== null;
+}

--- a/packages/tools/src/data/relational/tools/relational-insert/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/executor.ts
@@ -1,0 +1,187 @@
+/**
+ * Query executor for relational INSERT operations
+ * @module tools/relational-insert/executor
+ */
+
+import { createLogger } from '@agentforge/core';
+import { buildInsertQuery } from '../../query/query-builder.js';
+import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { InsertResult, RelationalInsertInput } from './types.js';
+import { getConstraintViolationMessage, isSafeInsertValidationError } from './error-utils.js';
+
+const logger = createLogger('agentforge:tools:data:relational:insert');
+
+interface NormalizedExecutionResult {
+  rows: unknown[];
+  rowCount: number;
+  insertId?: number;
+  lastInsertRowid?: number;
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeExecutionResult(result: unknown): NormalizedExecutionResult {
+  if (Array.isArray(result)) {
+    if (result.length > 0 && isPlainObject(result[0])) {
+      const first = result[0];
+      const affectedRows = toNumber(first.affectedRows) ?? toNumber(first.rowCount) ?? toNumber(first.changes);
+      const insertId = toNumber(first.insertId);
+      const lastInsertRowid = toNumber(first.lastInsertRowid);
+
+      if (affectedRows !== undefined || insertId !== undefined || lastInsertRowid !== undefined) {
+        return {
+          rows: [],
+          rowCount: affectedRows ?? 0,
+          insertId,
+          lastInsertRowid,
+        };
+      }
+    }
+
+    return {
+      rows: result,
+      rowCount: result.length,
+    };
+  }
+
+  if (isPlainObject(result)) {
+    const rows = Array.isArray(result.rows) ? result.rows : [];
+    const rowCount = toNumber(result.rowCount)
+      ?? toNumber(result.affectedRows)
+      ?? toNumber(result.changes)
+      ?? rows.length;
+
+    return {
+      rows,
+      rowCount,
+      insertId: toNumber(result.insertId),
+      lastInsertRowid: toNumber(result.lastInsertRowid),
+    };
+  }
+
+  return {
+    rows: [],
+    rowCount: 0,
+  };
+}
+
+function deriveInsertedIds(options: {
+  idColumn: string;
+  inputRows: Array<Record<string, unknown>>;
+  returnedRows: unknown[];
+  rowCount: number;
+  insertId?: number;
+  lastInsertRowid?: number;
+}): Array<number | string> {
+  const { idColumn, inputRows, returnedRows, rowCount, insertId, lastInsertRowid } = options;
+
+  if (returnedRows.length > 0) {
+    const idsFromReturn = returnedRows
+      .map((row) => (isPlainObject(row) ? row[idColumn] : undefined))
+      .filter((id): id is number | string => typeof id === 'number' || typeof id === 'string');
+
+    if (idsFromReturn.length > 0) {
+      return idsFromReturn;
+    }
+  }
+
+  if (inputRows.every((row) => typeof row[idColumn] === 'number' || typeof row[idColumn] === 'string')) {
+    return inputRows.map((row) => row[idColumn] as number | string);
+  }
+
+  if (insertId !== undefined && rowCount > 0) {
+    return Array.from({ length: rowCount }, (_, index) => insertId + index);
+  }
+
+  if (lastInsertRowid !== undefined && rowCount > 0) {
+    const startId = lastInsertRowid - rowCount + 1;
+    return Array.from({ length: rowCount }, (_, index) => startId + index);
+  }
+
+  return [];
+}
+
+/**
+ * Execute an INSERT query using the shared query builder.
+ */
+export async function executeInsert(
+  manager: ConnectionManager,
+  input: RelationalInsertInput
+): Promise<InsertResult> {
+  const startTime = Date.now();
+
+  logger.debug('Building INSERT query', {
+    vendor: input.vendor,
+    table: input.table,
+    isBatch: Array.isArray(input.data),
+    returningMode: input.returning?.mode ?? 'none',
+  });
+
+  try {
+    const built = buildInsertQuery({
+      table: input.table,
+      data: input.data,
+      returning: input.returning,
+      vendor: input.vendor,
+    });
+
+    const rawResult = await manager.execute(built.query);
+    const normalized = normalizeExecutionResult(rawResult);
+    const executionTime = Date.now() - startTime;
+
+    const rowCount = normalized.rowCount > 0 ? normalized.rowCount : built.rows.length;
+    const rows = built.returningMode === 'row' ? normalized.rows : [];
+    const insertedIds = built.returningMode === 'id'
+      ? deriveInsertedIds({
+        idColumn: built.idColumn,
+        inputRows: built.rows,
+        returnedRows: normalized.rows,
+        rowCount,
+        insertId: normalized.insertId,
+        lastInsertRowid: normalized.lastInsertRowid,
+      })
+      : [];
+
+    logger.debug('INSERT query executed successfully', {
+      vendor: input.vendor,
+      table: input.table,
+      rowCount,
+      returnedRows: rows.length,
+      returnedIds: insertedIds.length,
+      executionTime,
+    });
+
+    return {
+      rowCount,
+      rows,
+      insertedIds,
+      executionTime,
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+
+    logger.error('INSERT query execution failed', {
+      vendor: input.vendor,
+      table: input.table,
+      error: error instanceof Error ? error.message : String(error),
+      executionTime,
+    });
+
+    const constraintMessage = getConstraintViolationMessage(error);
+    if (constraintMessage) {
+      throw new Error(constraintMessage, { cause: error });
+    }
+
+    if (isSafeInsertValidationError(error)) {
+      throw error;
+    }
+
+    throw new Error('INSERT query failed. See logs for details.', { cause: error });
+  }
+}

--- a/packages/tools/src/data/relational/tools/relational-insert/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/index.ts
@@ -1,0 +1,91 @@
+/**
+ * Relational INSERT Tool
+ *
+ * Type-safe INSERT operations using Drizzle ORM query builder.
+ * Supports single-row and batch inserts with configurable return behavior.
+ *
+ * @module tools/relational-insert
+ */
+
+import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { ConnectionManager } from '../../connection/connection-manager.js';
+import { relationalInsertSchema } from './schemas.js';
+import { executeInsert } from './executor.js';
+import type { InsertResponse, RelationalInsertInput } from './types.js';
+import { isSafeInsertError } from './error-utils.js';
+
+// Re-export types and schemas for external use
+export * from './types.js';
+export * from './schemas.js';
+
+/**
+ * Relational INSERT Tool
+ *
+ * Execute type-safe INSERT queries using Drizzle ORM query builder.
+ */
+export const relationalInsert = toolBuilder()
+  .name('relational-insert')
+  .displayName('Relational INSERT')
+  .description('Execute type-safe INSERT queries with single-row and batch insert support')
+  .category(ToolCategory.DATABASE)
+  .tags(['database', 'sql', 'insert', 'postgresql', 'mysql', 'sqlite'])
+  .schema(relationalInsertSchema)
+  .example({
+    description: 'Insert a single row and return generated ID',
+    input: {
+      table: 'users',
+      data: { name: 'Alice', email: 'alice@example.com' },
+      returning: { mode: 'id', idColumn: 'id' },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/mydb',
+    },
+  })
+  .example({
+    description: 'Batch insert rows',
+    input: {
+      table: 'users',
+      data: [
+        { name: 'Bob', email: 'bob@example.com' },
+        { name: 'Carol', email: 'carol@example.com' },
+      ],
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    },
+  })
+  .implement(async (input: RelationalInsertInput): Promise<InsertResponse> => {
+    const manager = new ConnectionManager({
+      vendor: input.vendor,
+      connection: input.connectionString,
+    });
+
+    try {
+      await manager.connect();
+
+      const result = await executeInsert(manager, input);
+
+      return {
+        success: true,
+        rowCount: result.rowCount,
+        insertedIds: result.insertedIds,
+        rows: result.rows,
+        executionTime: result.executionTime,
+      };
+    } catch (error) {
+      let errorMessage = 'Failed to execute INSERT query. Please verify your input and database connection.';
+
+      if (isSafeInsertError(error)) {
+        errorMessage = error.message;
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+        rowCount: 0,
+        insertedIds: [],
+        rows: [],
+      };
+    } finally {
+      await manager.disconnect();
+    }
+  })
+  .build();

--- a/packages/tools/src/data/relational/tools/relational-insert/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/schemas.ts
@@ -4,11 +4,7 @@
  */
 
 import { z } from 'zod';
-
-/**
- * Valid schema-qualified identifier pattern (e.g., "public.users")
- */
-const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+import { VALID_QUALIFIED_IDENTIFIER_PATTERN } from '../../utils/identifier-utils.js';
 
 /**
  * Scalar values accepted for INSERT payloads.

--- a/packages/tools/src/data/relational/tools/relational-insert/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/schemas.ts
@@ -1,0 +1,72 @@
+/**
+ * Zod schemas for relational INSERT operations
+ * @module tools/relational-insert/schemas
+ */
+
+import { z } from 'zod';
+
+/**
+ * Valid schema-qualified identifier pattern (e.g., "public.users")
+ */
+const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+
+/**
+ * Scalar values accepted for INSERT payloads.
+ */
+export const insertValueSchema = z.union([
+  z.string().describe('String value'),
+  z.number().describe('Numeric value'),
+  z.boolean().describe('Boolean value'),
+  z.null().describe('Null value'),
+]).describe('Scalar value for an INSERT column');
+
+/**
+ * INSERT row payload schema.
+ *
+ * Empty objects are allowed to support INSERT ... DEFAULT VALUES.
+ */
+export const insertRowSchema = z.record(
+  z.string().min(1, 'Column name must not be empty').describe('Column name'),
+  insertValueSchema
+).describe('One row object where keys are column names and values are scalar values');
+
+/**
+ * INSERT RETURNING mode schema.
+ */
+export const insertReturningModeSchema = z.enum(['none', 'id', 'row']);
+
+/**
+ * INSERT RETURNING options schema.
+ */
+export const insertReturningSchema = z.object({
+  mode: insertReturningModeSchema.default('none').describe('Returning mode: none, id, or full row'),
+  idColumn: z.string().min(1, 'idColumn must not be empty').optional().describe('Primary key column to return when mode is "id"'),
+}).superRefine((value, ctx) => {
+  if (value.idColumn && value.mode !== 'id') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['idColumn'],
+      message: 'idColumn can only be provided when returning.mode is "id"',
+    });
+  }
+});
+
+/**
+ * Relational INSERT tool input schema.
+ */
+export const relationalInsertSchema = z.object({
+  table: z.string()
+    .min(1, 'Table name is required')
+    .regex(
+      VALID_QUALIFIED_IDENTIFIER_PATTERN,
+      'Table name contains invalid characters. Only alphanumeric characters, underscores, and dots (for schema qualification) are allowed.'
+    )
+    .describe('Table name to insert into (schema-qualified names supported, e.g. public.users)'),
+  data: z.union([
+    insertRowSchema,
+    z.array(insertRowSchema).min(1, 'Insert data array must not be empty'),
+  ]).describe('Single row object or array of row objects to insert'),
+  returning: insertReturningSchema.optional().describe('Optional RETURNING behavior'),
+  vendor: z.enum(['postgresql', 'mysql', 'sqlite']).describe('Database vendor'),
+  connectionString: z.string().min(1, 'Database connection string is required').describe('Database connection string'),
+});

--- a/packages/tools/src/data/relational/tools/relational-insert/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Type definitions for relational INSERT operations
+ * @module tools/relational-insert/types
+ */
+
+import type { z } from 'zod';
+import type {
+  insertValueSchema,
+  insertRowSchema,
+  insertReturningModeSchema,
+  insertReturningSchema,
+  relationalInsertSchema,
+} from './schemas.js';
+
+/**
+ * Supported INSERT value type.
+ */
+export type InsertValue = z.infer<typeof insertValueSchema>;
+
+/**
+ * One INSERT row payload.
+ */
+export type InsertRow = z.infer<typeof insertRowSchema>;
+
+/**
+ * RETURNING mode.
+ */
+export type InsertReturningMode = z.infer<typeof insertReturningModeSchema>;
+
+/**
+ * RETURNING configuration.
+ */
+export type InsertReturning = z.infer<typeof insertReturningSchema>;
+
+/**
+ * Relational INSERT tool input.
+ */
+export type RelationalInsertInput = z.infer<typeof relationalInsertSchema>;
+
+/**
+ * INSERT execution result.
+ */
+export interface InsertResult {
+  rowCount: number;
+  insertedIds: Array<number | string>;
+  rows: unknown[];
+  executionTime: number;
+}
+
+/**
+ * Tool success response.
+ */
+export interface InsertSuccessResponse {
+  success: true;
+  rowCount: number;
+  insertedIds: Array<number | string>;
+  rows: unknown[];
+  executionTime: number;
+}
+
+/**
+ * Tool error response.
+ */
+export interface InsertErrorResponse {
+  success: false;
+  error: string;
+  rowCount: 0;
+  insertedIds: [];
+  rows: [];
+}
+
+/**
+ * Tool response (success or error).
+ */
+export type InsertResponse = InsertSuccessResponse | InsertErrorResponse;

--- a/packages/tools/src/data/relational/tools/relational-select/identifier-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/identifier-utils.ts
@@ -1,85 +1,11 @@
 /**
- * SQL identifier validation and quoting utilities
+ * Backward-compatible re-export of shared identifier utilities.
  * @module tools/relational-select/identifier-utils
- *
- * Provides vendor-aware identifier quoting and validation to prevent SQL injection
- * through column names, table names, and other identifiers.
  */
 
-import type { DatabaseVendor } from '../../types.js';
-
-/**
- * Valid SQL identifier pattern
- * Allows alphanumeric characters and underscores (no dots - use validateQualifiedIdentifier for schema-qualified names)
- * This prevents SQL injection through identifier names
- */
-const VALID_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-
-/**
- * Valid schema-qualified identifier pattern (e.g., "public.users")
- */
-const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
-
-/**
- * Validate that a string is a safe SQL identifier
- * @param identifier - The identifier to validate
- * @param context - Description of what the identifier represents (for error messages)
- * @throws {Error} If the identifier contains unsafe characters
- */
-export function validateIdentifier(identifier: string, context: string): void {
-  if (!identifier || identifier.trim().length === 0) {
-    throw new Error(`${context} must not be empty`);
-  }
-
-  if (!VALID_IDENTIFIER_PATTERN.test(identifier)) {
-    throw new Error(
-      `${context} "${identifier}" contains invalid characters. ` +
-      'Only alphanumeric characters and underscores are allowed, must start with a letter or underscore.'
-    );
-  }
-}
-
-/**
- * Validate that a string is a safe SQL identifier, allowing schema-qualified names (e.g., "public.users")
- * @param identifier - The identifier to validate
- * @param context - Description of what the identifier represents (for error messages)
- * @throws {Error} If the identifier contains unsafe characters
- */
-export function validateQualifiedIdentifier(identifier: string, context: string): void {
-  if (!identifier || identifier.trim().length === 0) {
-    throw new Error(`${context} must not be empty`);
-  }
-
-  if (!VALID_QUALIFIED_IDENTIFIER_PATTERN.test(identifier)) {
-    throw new Error(
-      `${context} "${identifier}" contains invalid characters. ` +
-      'Only alphanumeric characters, underscores, and dots (for schema qualification) are allowed.'
-    );
-  }
-}
-
-/**
- * Quote an identifier using vendor-appropriate quoting
- * @param identifier - The validated identifier to quote
- * @param vendor - The database vendor
- * @returns The quoted identifier string
- */
-export function quoteIdentifier(identifier: string, vendor?: DatabaseVendor): string {
-  if (vendor === 'mysql') {
-    // MySQL uses backticks for identifier quoting
-    return `\`${identifier}\``;
-  }
-  // PostgreSQL and SQLite use double quotes (ANSI SQL standard)
-  return `"${identifier}"`;
-}
-
-/**
- * Quote a potentially schema-qualified identifier (e.g., "public.users" → "public"."users")
- * @param qualifiedName - The validated qualified identifier to quote
- * @param vendor - The database vendor
- * @returns The quoted identifier string
- */
-export function quoteQualifiedIdentifier(qualifiedName: string, vendor?: DatabaseVendor): string {
-  const parts = qualifiedName.split('.');
-  return parts.map(part => quoteIdentifier(part, vendor)).join('.');
-}
+export {
+  validateIdentifier,
+  validateQualifiedIdentifier,
+  quoteIdentifier,
+  quoteQualifiedIdentifier,
+} from '../../utils/identifier-utils.js';

--- a/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
@@ -6,7 +6,7 @@
 import { sql, type SQL } from 'drizzle-orm';
 import type { RelationalSelectInput, WhereCondition } from './types.js';
 import type { DatabaseVendor } from '../../types.js';
-import { validateIdentifier, validateQualifiedIdentifier, quoteIdentifier, quoteQualifiedIdentifier } from './identifier-utils.js';
+import { validateIdentifier, validateQualifiedIdentifier, quoteIdentifier, quoteQualifiedIdentifier } from '../../utils/identifier-utils.js';
 
 /**
  * Build a WHERE condition SQL fragment
@@ -101,4 +101,3 @@ export function buildSelectQuery(input: RelationalSelectInput): SQL {
 
   return query;
 }
-

--- a/packages/tools/src/data/relational/tools/relational-select/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/schemas.ts
@@ -4,11 +4,7 @@
  */
 
 import { z } from 'zod';
-
-/**
- * Valid schema-qualified identifier pattern (e.g., "public.users")
- */
-const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+import { VALID_QUALIFIED_IDENTIFIER_PATTERN } from '../../utils/identifier-utils.js';
 
 /**
  * WHERE condition operator types

--- a/packages/tools/src/data/relational/utils/identifier-utils.ts
+++ b/packages/tools/src/data/relational/utils/identifier-utils.ts
@@ -18,7 +18,7 @@ const VALID_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 /**
  * Valid schema-qualified identifier pattern (e.g., "public.users")
  */
-const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+export const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
 
 /**
  * Validate that a string is a safe SQL identifier

--- a/packages/tools/src/data/relational/utils/identifier-utils.ts
+++ b/packages/tools/src/data/relational/utils/identifier-utils.ts
@@ -1,0 +1,85 @@
+/**
+ * SQL identifier validation and quoting utilities
+ * @module utils/identifier-utils
+ *
+ * Provides vendor-aware identifier quoting and validation to prevent SQL injection
+ * through column names, table names, and other identifiers.
+ */
+
+import type { DatabaseVendor } from '../types.js';
+
+/**
+ * Valid SQL identifier pattern
+ * Allows alphanumeric characters and underscores (no dots - use validateQualifiedIdentifier for schema-qualified names)
+ * This prevents SQL injection through identifier names
+ */
+const VALID_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Valid schema-qualified identifier pattern (e.g., "public.users")
+ */
+const VALID_QUALIFIED_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/;
+
+/**
+ * Validate that a string is a safe SQL identifier
+ * @param identifier - The identifier to validate
+ * @param context - Description of what the identifier represents (for error messages)
+ * @throws {Error} If the identifier contains unsafe characters
+ */
+export function validateIdentifier(identifier: string, context: string): void {
+  if (!identifier || identifier.trim().length === 0) {
+    throw new Error(`${context} must not be empty`);
+  }
+
+  if (!VALID_IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `${context} "${identifier}" contains invalid characters. ` +
+      'Only alphanumeric characters and underscores are allowed, must start with a letter or underscore.'
+    );
+  }
+}
+
+/**
+ * Validate that a string is a safe SQL identifier, allowing schema-qualified names (e.g., "public.users")
+ * @param identifier - The identifier to validate
+ * @param context - Description of what the identifier represents (for error messages)
+ * @throws {Error} If the identifier contains unsafe characters
+ */
+export function validateQualifiedIdentifier(identifier: string, context: string): void {
+  if (!identifier || identifier.trim().length === 0) {
+    throw new Error(`${context} must not be empty`);
+  }
+
+  if (!VALID_QUALIFIED_IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `${context} "${identifier}" contains invalid characters. ` +
+      'Only alphanumeric characters, underscores, and dots (for schema qualification) are allowed.'
+    );
+  }
+}
+
+/**
+ * Quote an identifier using vendor-appropriate quoting
+ * @param identifier - The validated identifier to quote
+ * @param vendor - The database vendor
+ * @returns The quoted identifier string
+ */
+export function quoteIdentifier(identifier: string, vendor?: DatabaseVendor): string {
+  if (vendor === 'mysql') {
+    // MySQL uses backticks for identifier quoting
+    return `\`${identifier}\``;
+  }
+  // PostgreSQL and SQLite use double quotes (ANSI SQL standard)
+  return `"${identifier}"`;
+}
+
+/**
+ * Quote a potentially schema-qualified identifier (e.g., "public.users" → "public"."users")
+ * @param qualifiedName - The validated qualified identifier to quote
+ * @param vendor - The database vendor
+ * @returns The quoted identifier string
+ */
+export function quoteQualifiedIdentifier(qualifiedName: string, vendor?: DatabaseVendor): string {
+  const parts = qualifiedName.split('.');
+  return parts.map((part) => quoteIdentifier(part, vendor)).join('.');
+}

--- a/packages/tools/src/data/relational/utils/index.ts
+++ b/packages/tools/src/data/relational/utils/index.ts
@@ -20,4 +20,5 @@ export {
   validateQualifiedIdentifier,
   quoteIdentifier,
   quoteQualifiedIdentifier,
+  VALID_QUALIFIED_IDENTIFIER_PATTERN,
 } from './identifier-utils.js';

--- a/packages/tools/src/data/relational/utils/index.ts
+++ b/packages/tools/src/data/relational/utils/index.ts
@@ -14,3 +14,10 @@ export {
   validateSqlString,
   enforceParameterizedQueryUsage,
 } from './sql-sanitizer.js';
+
+export {
+  validateIdentifier,
+  validateQualifiedIdentifier,
+  quoteIdentifier,
+  quoteQualifiedIdentifier,
+} from './identifier-utils.js';

--- a/packages/tools/tests/data/relational/relational-insert/index.test.ts
+++ b/packages/tools/tests/data/relational/relational-insert/index.test.ts
@@ -1,0 +1,9 @@
+/**
+ * Relational INSERT Tool Tests
+ *
+ * Main test suite that imports all relational-insert test modules.
+ */
+
+import './schema-validation.test.js';
+import './query-builder.test.js';
+import './tool-invocation.test.js';

--- a/packages/tools/tests/data/relational/relational-insert/query-builder.test.ts
+++ b/packages/tools/tests/data/relational/relational-insert/query-builder.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Query Builder Tests for Relational INSERT
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import { buildInsertQuery } from '../../../../src/data/relational/query/query-builder.js';
+import type { ConnectionConfig } from '../../../../src/data/relational/connection/types.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+function extractRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result as Array<Record<string, unknown>>;
+  }
+
+  if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown[] }).rows)) {
+    return (result as { rows: Array<Record<string, unknown>> }).rows;
+  }
+
+  return [];
+}
+
+describe('Relational INSERT - Query Builder', () => {
+  let manager: ConnectionManager;
+
+  beforeAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    const config: ConnectionConfig = {
+      vendor: 'sqlite',
+      connection: ':memory:',
+    };
+
+    manager = new ConnectionManager(config);
+    await manager.initialize();
+
+    await manager.execute(sql.raw(`
+      CREATE TABLE test_users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE,
+        status TEXT DEFAULT 'active'
+      );
+    `));
+
+    await manager.execute(sql.raw(`
+      CREATE TABLE test_defaults (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        status TEXT DEFAULT 'active',
+        score INTEGER DEFAULT 0
+      );
+    `));
+  });
+
+  afterAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    await manager.close();
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should build and execute single-row INSERT query', async () => {
+    const built = buildInsertQuery({
+      table: 'test_users',
+      data: { name: 'Alice', email: 'alice@example.com' },
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT name, email, status
+      FROM test_users
+      WHERE email = 'alice@example.com'
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: 'Alice',
+      email: 'alice@example.com',
+      status: 'active',
+    });
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should build and execute batch INSERT query with DEFAULT values for missing columns', async () => {
+    const built = buildInsertQuery({
+      table: 'test_users',
+      data: [
+        { name: 'Bob', email: 'bob@example.com' },
+        { name: 'Carol', email: 'carol@example.com', status: 'inactive' },
+      ],
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT email, status
+      FROM test_users
+      WHERE email IN ('bob@example.com', 'carol@example.com')
+      ORDER BY email ASC
+    `)));
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ email: 'bob@example.com', status: 'active' });
+    expect(rows[1]).toMatchObject({ email: 'carol@example.com', status: 'inactive' });
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support RETURNING id mode for vendors with RETURNING support', async () => {
+    const built = buildInsertQuery({
+      table: 'test_users',
+      data: { name: 'Dave', email: 'dave@example.com' },
+      returning: { mode: 'id', idColumn: 'id' },
+      vendor: 'sqlite',
+    });
+
+    const rows = extractRows(await manager.execute(built.query));
+
+    expect(rows).toHaveLength(1);
+    expect(typeof rows[0].id).toBe('number');
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support RETURNING full rows mode for vendors with RETURNING support', async () => {
+    const built = buildInsertQuery({
+      table: 'test_users',
+      data: { name: 'Eve', email: 'eve@example.com' },
+      returning: { mode: 'row' },
+      vendor: 'sqlite',
+    });
+
+    const rows = extractRows(await manager.execute(built.query));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: 'Eve',
+      email: 'eve@example.com',
+      status: 'active',
+    });
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support DEFAULT VALUES for single-row insert', async () => {
+    const built = buildInsertQuery({
+      table: 'test_defaults',
+      data: {},
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT status, score
+      FROM test_defaults
+      ORDER BY id DESC
+      LIMIT 1
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      status: 'active',
+      score: 0,
+    });
+  });
+
+  it('should reject RETURNING full rows for mysql vendor', () => {
+    expect(() =>
+      buildInsertQuery({
+        table: 'users',
+        data: { name: 'Alice' },
+        returning: { mode: 'row' },
+        vendor: 'mysql',
+      })
+    ).toThrow(/not supported for mysql/i);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-insert/query-builder.test.ts
+++ b/packages/tools/tests/data/relational/relational-insert/query-builder.test.ts
@@ -35,7 +35,7 @@ describe('Relational INSERT - Query Builder', () => {
     };
 
     manager = new ConnectionManager(config);
-    await manager.initialize();
+    await manager.connect();
 
     await manager.execute(sql.raw(`
       CREATE TABLE test_users (
@@ -60,7 +60,7 @@ describe('Relational INSERT - Query Builder', () => {
       return;
     }
 
-    await manager.close();
+    await manager.disconnect();
   });
 
   it.skipIf(!hasSQLiteBindings)('should build and execute single-row INSERT query', async () => {

--- a/packages/tools/tests/data/relational/relational-insert/schema-validation.test.ts
+++ b/packages/tools/tests/data/relational/relational-insert/schema-validation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Schema Validation Tests for Relational INSERT Tool
+ */
+
+import { describe, it, expect } from 'vitest';
+import { relationalInsert } from '../../../../src/data/relational/tools/relational-insert/index.js';
+
+describe('Relational INSERT - Schema Validation', () => {
+  it('should accept valid single-row insert input', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: { name: 'Alice', email: 'alice@example.com' },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid batch insert input', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: [
+        { name: 'Alice', email: 'alice@example.com' },
+        { name: 'Bob', email: 'bob@example.com' },
+      ],
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept empty object row for DEFAULT VALUES inserts', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'defaults_table',
+      data: {},
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty data array', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: [],
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty table name', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: '',
+      data: { name: 'Alice' },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid vendor', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: { name: 'Alice' },
+      vendor: 'invalid',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject idColumn when mode is not id', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: { name: 'Alice' },
+      returning: { mode: 'none', idColumn: 'id' },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept idColumn when mode is id', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: { name: 'Alice' },
+      returning: { mode: 'id', idColumn: 'id' },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject malformed table name', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users; DROP TABLE users',
+      data: { name: 'Alice' },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty connection string', () => {
+    const result = relationalInsert.schema.safeParse({
+      table: 'users',
+      data: { name: 'Alice' },
+      vendor: 'sqlite',
+      connectionString: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-insert/test-utils.ts
+++ b/packages/tools/tests/data/relational/relational-insert/test-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Test utilities for relational INSERT tests
+ * @module tests/relational-insert/test-utils
+ */
+
+/**
+ * Check if better-sqlite3 native bindings are available.
+ */
+export const hasSQLiteBindings = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const db = new Database(':memory:');
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+})();

--- a/packages/tools/tests/data/relational/relational-insert/tool-invocation.test.ts
+++ b/packages/tools/tests/data/relational/relational-insert/tool-invocation.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tool Invocation Tests for Relational INSERT Tool
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { relationalInsert } from '../../../../src/data/relational/tools/relational-insert/index.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+async function createTestDatabase(): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3');
+  const path = await import('path');
+  const os = await import('os');
+  const fs = await import('fs');
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relational-insert-test-'));
+  const dbPath = path.join(tmpDir, 'test.db');
+
+  const db = new Database(dbPath);
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE accounts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL
+    );
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      account_id INTEGER,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      status TEXT DEFAULT 'active',
+      FOREIGN KEY (account_id) REFERENCES accounts(id)
+    );
+    INSERT INTO accounts (name) VALUES ('Acme');
+  `);
+  db.close();
+
+  return dbPath;
+}
+
+describe('Relational INSERT - Tool Invocation', () => {
+  let dbPath: string | undefined;
+
+  const getDbPath = (): string => {
+    if (!dbPath) {
+      throw new Error('SQLite test database path was not initialized');
+    }
+    return dbPath;
+  };
+
+  beforeAll(async () => {
+    if (hasSQLiteBindings) {
+      dbPath = await createTestDatabase();
+    }
+  });
+
+  afterAll(async () => {
+    if (dbPath) {
+      const fs = await import('fs');
+      const path = await import('path');
+      try {
+        fs.unlinkSync(dbPath);
+        fs.rmdirSync(path.dirname(dbPath));
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should insert a single row and return generated ID', async () => {
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: {
+        account_id: 1,
+        name: 'Alice',
+        email: 'alice@example.com',
+      },
+      returning: { mode: 'id', idColumn: 'id' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(1);
+    expect(result.insertedIds).toHaveLength(1);
+    expect(typeof result.insertedIds[0]).toBe('number');
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should insert multiple rows in batch mode', async () => {
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: [
+        { account_id: 1, name: 'Bob', email: 'bob@example.com' },
+        { account_id: 1, name: 'Carol', email: 'carol@example.com', status: 'inactive' },
+      ],
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(2);
+    expect(result.rows).toEqual([]);
+    expect(result.insertedIds).toEqual([]);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should return full inserted rows when returning.mode is row', async () => {
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: { account_id: 1, name: 'Dave', email: 'dave@example.com' },
+      returning: { mode: 'row' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(1);
+    expect(result.rows).toHaveLength(1);
+    const row = result.rows[0] as Record<string, unknown>;
+    expect(row).toMatchObject({
+      name: 'Dave',
+      email: 'dave@example.com',
+      status: 'active',
+    });
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should return clear error for unique constraint violations', async () => {
+    await relationalInsert.invoke({
+      table: 'users',
+      data: { account_id: 1, name: 'Erin', email: 'erin@example.com' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: { account_id: 1, name: 'Erin Duplicate', email: 'erin@example.com' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Insert failed: unique constraint violation.');
+    expect(result.rowCount).toBe(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should return clear error for foreign key constraint violations', async () => {
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: { account_id: 9999, name: 'Ghost', email: 'ghost@example.com' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Insert failed: foreign key constraint violation.');
+    expect(result.rowCount).toBe(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support default values and auto-increment fields', async () => {
+    const result = await relationalInsert.invoke({
+      table: 'users',
+      data: {
+        account_id: 1,
+        name: 'Frank',
+        email: 'frank@example.com',
+      },
+      returning: { mode: 'row' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rows).toHaveLength(1);
+
+    const insertedRow = result.rows[0] as Record<string, unknown>;
+    expect(insertedRow.status).toBe('active');
+    expect(typeof insertedRow.id).toBe('number');
+  });
+});

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -68,27 +68,27 @@
 **Branch:** `feat/st-02003-type-safe-insert-tool`
 
 ### Checklist
-- [ ] Create branch `feat/st-02003-type-safe-insert-tool`
-- [ ] Create draft PR with story ID in title
-- [ ] Extend query builder with INSERT support
-- [ ] Add support for single row insert
-- [ ] Add support for multiple row insert (batch)
-- [ ] Add support for returning inserted row IDs
-- [ ] Add support for returning full inserted rows (configurable)
-- [ ] Create `packages/tools/src/data/relational/tools/relational-insert.ts`
-- [ ] Define Zod schema for tool input (table, data, returning)
-- [ ] Implement tool function using query builder
-- [ ] Add type validation for input data
-- [ ] Add constraint violation error handling (unique, foreign key, etc.)
-- [ ] Add support for default values and auto-increment fields
-- [ ] Handle vendor-specific RETURNING clause differences
-- [ ] Export tool from `tools/index.ts`
-- [ ] Create unit tests for INSERT query builder
-- [ ] Create unit tests for relational-insert tool
-- [ ] Add or update story documentation at docs/st02003-type-safe-insert-tool.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `feat/st-02003-type-safe-insert-tool`
+- [x] Create draft PR with story ID in title (PR #34)
+- [x] Extend query builder with INSERT support
+- [x] Add support for single row insert
+- [x] Add support for multiple row insert (batch)
+- [x] Add support for returning inserted row IDs
+- [x] Add support for returning full inserted rows (configurable)
+- [x] Create relational-insert tool module at `packages/tools/src/data/relational/tools/relational-insert/`
+- [x] Define Zod schema for tool input (table, data, returning)
+- [x] Implement tool function using query builder
+- [x] Add type validation for input data
+- [x] Add constraint violation error handling (unique, foreign key, etc.)
+- [x] Add support for default values and auto-increment fields
+- [x] Handle vendor-specific RETURNING clause differences
+- [x] Export tool from `tools/index.ts`
+- [x] Create unit tests for INSERT query builder
+- [x] Create unit tests for relational-insert tool
+- [x] Add or update story documentation at docs/st02003-type-safe-insert-tool.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added relational-insert query-builder + schema + tool invocation tests)
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1212 passed, 105 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (`pnpm lint` -> 0 errors, warnings-only baseline output across workspace)
 - [ ] Mark PR ready for review
 - [ ] Wait for merge
 

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -89,7 +89,7 @@
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added relational-insert query-builder + schema + tool invocation tests)
 - [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1212 passed, 105 skipped)
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results (`pnpm lint` -> 0 errors, warnings-only baseline output across workspace)
-- [ ] Mark PR ready for review
+- [x] Mark PR ready for review (PR #34: https://github.com/TVScoundrel/agentforge/pull/34)
 - [ ] Wait for merge
 
 ---

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-19
-**Active Story:** ST-02003 (Ready)
+**Active Story:** ST-02003 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,22 +4,15 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories (ST-02003, ST-04003, ST-03002, ST-05003)
+- **Ready:** 3 stories (ST-04003, ST-03002, ST-05003)
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story (ST-02003)
 - **Blocked:** 0 stories
 - **Backlog:** 7 stories (waiting on dependencies)
 
 ---
 
 ## Ready
-
-### ST-02003: Implement Type-Safe INSERT Tool
-- **Epic:** EP-02
-- **Priority:** P0
-- **Estimate:** 4 hours
-- **Dependencies:** ST-02002 ✅ (merged 2026-02-18)
-- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
 
 ### ST-04003: Implement Result Streaming
 - **Epic:** EP-04
@@ -52,7 +45,14 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+### ST-02003: Implement Type-Safe INSERT Tool
+- **Epic:** EP-02
+- **Priority:** P0
+- **Estimate:** 4 hours
+- **Dependencies:** ST-02002 ✅ (merged 2026-02-18)
+- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
+- **Branch:** `feat/st-02003-type-safe-insert-tool`
+- **PR:** #34 https://github.com/TVScoundrel/agentforge/pull/34
 
 ---
 


### PR DESCRIPTION
## Story
- ST-02003: Implement Type-Safe INSERT Tool

## What Changed
- Added shared INSERT query-builder support in `packages/tools/src/data/relational/query/query-builder.ts`.
- Added new `relational-insert` tool module:
  - `packages/tools/src/data/relational/tools/relational-insert/index.ts`
  - `packages/tools/src/data/relational/tools/relational-insert/schemas.ts`
  - `packages/tools/src/data/relational/tools/relational-insert/types.ts`
  - `packages/tools/src/data/relational/tools/relational-insert/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-insert/error-utils.ts`
- Exported `relationalInsert` from `packages/tools/src/data/relational/tools/index.ts`.
- Added INSERT tests:
  - `packages/tools/tests/data/relational/relational-insert/query-builder.test.ts`
  - `packages/tools/tests/data/relational/relational-insert/schema-validation.test.ts`
  - `packages/tools/tests/data/relational/relational-insert/tool-invocation.test.ts`
  - `packages/tools/tests/data/relational/relational-insert/index.test.ts`
- Added story documentation: `docs/st02003-type-safe-insert-tool.md`

## Acceptance Criteria Coverage
- [x] `relational-insert` tool with Drizzle query builder
- [x] Support for single and multiple row inserts
- [x] Return inserted row IDs or full rows (configurable)
- [x] Type validation for input data
- [x] Constraint violation error handling
- [x] Support for default values and auto-increment fields

## Validation Performed
- `pnpm test --run packages/tools/tests/data/relational/relational-insert/index.test.ts`
  - 11 passed, 11 skipped
- `pnpm test --run packages/tools/tests/data/relational`
  - 136 passed, 92 skipped
- `pnpm test --run`
  - 1212 passed, 105 skipped
- `pnpm lint`
  - 0 errors; warnings-only baseline across workspace

## Status
- Ready for review.
