### PR TITLE
feat(st-02004): implement type-safe update tool

### DIFF
--- a/docs/st02004-type-safe-update-tool.md
+++ b/docs/st02004-type-safe-update-tool.md
@@ -1,0 +1,103 @@
+# ST-02004: Type-Safe UPDATE Tool
+
+**Status:** 👀 In Review  
+**PR:** [#35](https://github.com/TVScoundrel/agentforge/pull/35)  
+**Epic:** 02 - Query Operations  
+**Priority:** P0
+
+## Overview
+
+Implemented a type-safe UPDATE tool that provides structured update operations with explicit safety controls. The tool requires WHERE conditions by default, supports optional optimistic locking, and returns affected-row count for caller visibility.
+
+## Implementation
+
+### Core Components
+
+1. **Shared UPDATE Query Builder**
+   - `packages/tools/src/data/relational/query/query-builder.ts`
+   - Added `buildUpdateQuery()` with:
+     - validated table/column identifiers
+     - parameterized SET clauses
+     - WHERE condition support (`eq`, `ne`, `gt`, `lt`, `gte`, `lte`, `like`, `in`, `notIn`, `isNull`, `isNotNull`)
+     - full-table update protection (requires explicit `allowFullTableUpdate` override)
+     - optional optimistic-lock condition appended to WHERE
+
+2. **Relational UPDATE Tool Module** (`packages/tools/src/data/relational/tools/relational-update/`)
+   - `index.ts`: LangGraph tool built with `toolBuilder()` API
+   - `schemas.ts`: Zod validation with safety constraints
+   - `types.ts`: Input/output and response types
+   - `executor.ts`: Query execution, row-count normalization, and optimistic-lock stale detection
+   - `error-utils.ts`: Safe validation/constraint error mapping
+
+3. **Tool Export Integration**
+   - `packages/tools/src/data/relational/tools/index.ts` now exports `relationalUpdate`
+
+## Safety and Behavior
+
+### WHERE Condition Safety
+
+- UPDATE without WHERE is blocked by default
+- Full-table update requires explicit `allowFullTableUpdate: true`
+
+### Row Count Return
+
+- Returns `rowCount` for affected rows across vendors using normalized result extraction
+
+### Optional Optimistic Locking
+
+- Supports `optimisticLock` with `column` + `expectedValue`
+- If no rows are affected under optimistic lock, returns clear stale-update error:
+  - `Update failed: optimistic lock check failed.`
+
+### Constraint Handling
+
+Maps common constraint failures to safe user-facing messages:
+- unique constraint violations
+- foreign key violations
+- NOT NULL violations
+
+## Testing
+
+Added tests under `packages/tools/tests/data/relational/relational-update/`:
+
+- `schema-validation.test.ts`
+- `query-builder.test.ts`
+- `tool-invocation.test.ts`
+- `index.test.ts`
+- `test-utils.ts`
+
+### Coverage Highlights
+
+- schema validation for safety constraints and operator/value consistency
+- query-builder behavior for safe WHERE requirements and full-table override
+- optimistic lock condition behavior and stale-update detection
+- affected-row count behavior via tool invocation
+- full-table update prevention test coverage
+
+## Usage Example
+
+```typescript
+import { createLogger } from '@agentforge/core';
+import { relationalUpdate } from '@agentforge/tools';
+
+const logger = createLogger('my-app');
+
+const result = await relationalUpdate.invoke({
+  table: 'users',
+  data: { status: 'inactive' },
+  where: [{ column: 'id', operator: 'eq', value: 123 }],
+  optimisticLock: { column: 'version', expectedValue: 5 },
+  vendor: 'postgresql',
+  connectionString: process.env.DATABASE_URL!,
+});
+
+if (result.success) {
+  logger.info('Update completed', { rowCount: result.rowCount });
+} else {
+  logger.error('Update failed', { error: result.error });
+}
+```
+
+## Dependencies
+
+- ✅ ST-02003 (Type-Safe INSERT Tool) - merged 2026-02-19

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -19,4 +19,12 @@ export {
   type InsertReturningOptions,
   type InsertQueryInput,
   type BuiltInsertQuery,
+  buildUpdateQuery,
+  type UpdateValue,
+  type UpdateData,
+  type UpdateWhereOperator,
+  type UpdateWhereCondition,
+  type UpdateOptimisticLock,
+  type UpdateQueryInput,
+  type BuiltUpdateQuery,
 } from './query-builder.js';

--- a/packages/tools/src/data/relational/tools/index.ts
+++ b/packages/tools/src/data/relational/tools/index.ts
@@ -6,4 +6,5 @@
 export { relationalQuery } from './relational-query.js';
 export { relationalSelect } from './relational-select/index.js';
 export { relationalInsert } from './relational-insert/index.js';
+export { relationalUpdate } from './relational-update/index.js';
 export { relationalGetSchema } from './relational-get-schema.js';

--- a/packages/tools/src/data/relational/tools/relational-update/error-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/error-utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Helpers for classifying safe validation and constraint errors in relational-update.
+ */
+
+const SAFE_UPDATE_VALIDATION_PATTERNS = [
+  'must not be empty',
+  'contains invalid characters',
+  'Update data must be an object',
+  'Update data must not be empty',
+  'must not be undefined',
+  'WHERE conditions are required for UPDATE queries',
+  'null is only allowed with isNull/isNotNull operators',
+  'operator requires a string or number value',
+  'operator requires a non-empty array value',
+  'operator requires a string value',
+  'must not include value',
+  'Optimistic lock expectedValue must not be empty',
+  'optimistic lock check failed',
+  'WHERE conditions are required unless allowFullTableUpdate is true',
+] as const;
+
+const CONSTRAINT_VIOLATION_PATTERNS = [
+  {
+    pattern: /(unique constraint|duplicate key|duplicate entry)/i,
+    message: 'Update failed: unique constraint violation.',
+  },
+  {
+    pattern: /(foreign key constraint|violates foreign key constraint)/i,
+    message: 'Update failed: foreign key constraint violation.',
+  },
+  {
+    pattern: /(not null constraint|cannot be null)/i,
+    message: 'Update failed: NOT NULL constraint violation.',
+  },
+] as const;
+
+export function isSafeUpdateValidationError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return SAFE_UPDATE_VALIDATION_PATTERNS.some((pattern) => error.message.includes(pattern));
+}
+
+export function getUpdateConstraintViolationMessage(error: unknown): string | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  for (const entry of CONSTRAINT_VIOLATION_PATTERNS) {
+    if (entry.pattern.test(error.message)) {
+      return entry.message;
+    }
+  }
+
+  return null;
+}
+
+export function isSafeUpdateError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return isSafeUpdateValidationError(error) || getUpdateConstraintViolationMessage(error) !== null;
+}

--- a/packages/tools/src/data/relational/tools/relational-update/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/executor.ts
@@ -1,0 +1,108 @@
+/**
+ * Query executor for relational UPDATE operations
+ * @module tools/relational-update/executor
+ */
+
+import { createLogger } from '@agentforge/core';
+import { buildUpdateQuery } from '../../query/query-builder.js';
+import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { RelationalUpdateInput, UpdateResult } from './types.js';
+import { getUpdateConstraintViolationMessage, isSafeUpdateValidationError } from './error-utils.js';
+
+const logger = createLogger('agentforge:tools:data:relational:update');
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeAffectedRows(result: unknown): number {
+  if (Array.isArray(result)) {
+    if (result.length > 0 && result[0] && typeof result[0] === 'object') {
+      const first = result[0] as Record<string, unknown>;
+      const affectedRows = toNumber(first.affectedRows) ?? toNumber(first.rowCount) ?? toNumber(first.changes);
+      if (affectedRows !== undefined) {
+        return affectedRows;
+      }
+    }
+    return result.length;
+  }
+
+  if (result && typeof result === 'object') {
+    const resultRecord = result as Record<string, unknown>;
+    return toNumber(resultRecord.rowCount)
+      ?? toNumber(resultRecord.affectedRows)
+      ?? toNumber(resultRecord.changes)
+      ?? (Array.isArray(resultRecord.rows) ? resultRecord.rows.length : 0);
+  }
+
+  return 0;
+}
+
+/**
+ * Execute an UPDATE query using the shared query builder.
+ */
+export async function executeUpdate(
+  manager: ConnectionManager,
+  input: RelationalUpdateInput
+): Promise<UpdateResult> {
+  const startTime = Date.now();
+
+  logger.debug('Building UPDATE query', {
+    vendor: input.vendor,
+    table: input.table,
+    hasWhere: !!input.where?.length,
+    allowFullTableUpdate: input.allowFullTableUpdate,
+    hasOptimisticLock: !!input.optimisticLock,
+  });
+
+  try {
+    const built = buildUpdateQuery({
+      table: input.table,
+      data: input.data,
+      where: input.where,
+      allowFullTableUpdate: input.allowFullTableUpdate,
+      optimisticLock: input.optimisticLock,
+      vendor: input.vendor,
+    });
+
+    const rawResult = await manager.execute(built.query);
+    const rowCount = normalizeAffectedRows(rawResult);
+    const executionTime = Date.now() - startTime;
+
+    if (built.usesOptimisticLock && rowCount === 0) {
+      throw new Error('Update failed: optimistic lock check failed.');
+    }
+
+    logger.debug('UPDATE query executed successfully', {
+      vendor: input.vendor,
+      table: input.table,
+      rowCount,
+      executionTime,
+    });
+
+    return {
+      rowCount,
+      executionTime,
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+
+    logger.error('UPDATE query execution failed', {
+      vendor: input.vendor,
+      table: input.table,
+      error: error instanceof Error ? error.message : String(error),
+      executionTime,
+    });
+
+    const constraintMessage = getUpdateConstraintViolationMessage(error);
+    if (constraintMessage) {
+      throw new Error(constraintMessage, { cause: error });
+    }
+
+    if (isSafeUpdateValidationError(error)) {
+      throw error;
+    }
+
+    throw new Error('UPDATE query failed. See logs for details.', { cause: error });
+  }
+}

--- a/packages/tools/src/data/relational/tools/relational-update/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Relational UPDATE Tool
+ *
+ * Type-safe UPDATE operations using Drizzle ORM query builder.
+ * Supports WHERE conditions, full-table update protection, and optimistic locking.
+ *
+ * @module tools/relational-update
+ */
+
+import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { ConnectionManager } from '../../connection/connection-manager.js';
+import { relationalUpdateSchema } from './schemas.js';
+import { executeUpdate } from './executor.js';
+import type { RelationalUpdateInput, UpdateResponse } from './types.js';
+import { isSafeUpdateError } from './error-utils.js';
+
+// Re-export types and schemas for external use
+export * from './types.js';
+export * from './schemas.js';
+
+/**
+ * Relational UPDATE Tool
+ *
+ * Execute type-safe UPDATE queries using Drizzle ORM query builder.
+ */
+export const relationalUpdate = toolBuilder()
+  .name('relational-update')
+  .displayName('Relational UPDATE')
+  .description('Execute type-safe UPDATE queries with WHERE conditions and full-table update protection')
+  .category(ToolCategory.DATABASE)
+  .tags(['database', 'sql', 'update', 'postgresql', 'mysql', 'sqlite'])
+  .schema(relationalUpdateSchema)
+  .example({
+    description: 'Update one row by condition',
+    input: {
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 123 }],
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/mydb',
+    },
+  })
+  .example({
+    description: 'Optimistic lock update',
+    input: {
+      table: 'users',
+      data: { status: 'active' },
+      where: [{ column: 'id', operator: 'eq', value: 123 }],
+      optimisticLock: { column: 'version', expectedValue: 5 },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    },
+  })
+  .implement(async (input: RelationalUpdateInput): Promise<UpdateResponse> => {
+    const manager = new ConnectionManager({
+      vendor: input.vendor,
+      connection: input.connectionString,
+    });
+
+    try {
+      await manager.connect();
+
+      const result = await executeUpdate(manager, input);
+
+      return {
+        success: true,
+        rowCount: result.rowCount,
+        executionTime: result.executionTime,
+      };
+    } catch (error) {
+      let errorMessage = 'Failed to execute UPDATE query. Please verify your input and database connection.';
+
+      if (isSafeUpdateError(error)) {
+        errorMessage = error.message;
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+        rowCount: 0,
+      };
+    } finally {
+      await manager.disconnect();
+    }
+  })
+  .build();

--- a/packages/tools/src/data/relational/tools/relational-update/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/schemas.ts
@@ -1,0 +1,172 @@
+/**
+ * Zod schemas for relational UPDATE operations
+ * @module tools/relational-update/schemas
+ */
+
+import { z } from 'zod';
+import { VALID_QUALIFIED_IDENTIFIER_PATTERN } from '../../utils/identifier-utils.js';
+
+/**
+ * Scalar values accepted for UPDATE payloads.
+ */
+export const updateValueSchema = z.union([
+  z.string().describe('String value'),
+  z.number().describe('Numeric value'),
+  z.boolean().describe('Boolean value'),
+  z.null().describe('Null value'),
+]).describe('Scalar value for an UPDATE column');
+
+/**
+ * UPDATE payload schema.
+ */
+export const updateDataSchema = z.record(
+  z.string().min(1, 'Column name must not be empty').describe('Column name'),
+  updateValueSchema
+).superRefine((value, ctx) => {
+  if (Object.keys(value).length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Update data must not be empty',
+    });
+  }
+}).describe('Object containing column-value pairs to update');
+
+/**
+ * WHERE condition operators.
+ */
+export const updateWhereOperatorSchema = z.enum([
+  'eq',
+  'ne',
+  'gt',
+  'lt',
+  'gte',
+  'lte',
+  'like',
+  'in',
+  'notIn',
+  'isNull',
+  'isNotNull',
+]);
+
+/**
+ * WHERE condition schema.
+ */
+export const updateWhereConditionSchema = z.object({
+  column: z.string().min(1, 'Column name must not be empty').describe('Column name to filter on'),
+  operator: updateWhereOperatorSchema.describe('Comparison operator'),
+  value: z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.union([z.string(), z.number()])),
+    z.null(),
+  ]).optional().describe('Value to compare against (not required for isNull/isNotNull)'),
+}).superRefine((value, ctx) => {
+  const op = value.operator;
+
+  if (op === 'isNull' || op === 'isNotNull') {
+    if (value.value !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: 'value must not be provided when using isNull or isNotNull operator',
+      });
+    }
+    return;
+  }
+
+  if (value.value === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'value is required for this operator',
+    });
+    return;
+  }
+
+  if (op === 'in' || op === 'notIn') {
+    if (!Array.isArray(value.value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: `${op === 'in' ? 'IN' : 'NOT IN'} operator requires an array value`,
+      });
+    } else if (value.value.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: `${op === 'in' ? 'IN' : 'NOT IN'} operator requires a non-empty array value`,
+      });
+    }
+    return;
+  }
+
+  if (value.value === null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'null is only allowed with isNull/isNotNull operators',
+    });
+    return;
+  }
+
+  if (op === 'like' && typeof value.value !== 'string') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'LIKE operator requires a string value',
+    });
+    return;
+  }
+
+  if ((op === 'gt' || op === 'lt' || op === 'gte' || op === 'lte') &&
+      typeof value.value !== 'string' &&
+      typeof value.value !== 'number') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: `${op.toUpperCase()} operator requires a string or number value`,
+    });
+  }
+});
+
+/**
+ * Optimistic lock schema.
+ */
+export const updateOptimisticLockSchema = z.object({
+  column: z.string().min(1, 'Optimistic lock column must not be empty').describe('Version or lock column name'),
+  expectedValue: z.union([
+    z.string().describe('Expected string version value'),
+    z.number().describe('Expected numeric version value'),
+  ]).describe('Expected current value for the lock column'),
+}).describe('Optional optimistic lock condition');
+
+/**
+ * Relational UPDATE tool input schema.
+ */
+export const relationalUpdateSchema = z.object({
+  table: z.string()
+    .min(1, 'Table name is required')
+    .regex(
+      VALID_QUALIFIED_IDENTIFIER_PATTERN,
+      'Table name contains invalid characters. Only alphanumeric characters, underscores, and dots (for schema qualification) are allowed.'
+    )
+    .describe('Table name to update (schema-qualified names supported, e.g. public.users)'),
+  data: updateDataSchema.describe('Columns and values to update'),
+  where: z.array(updateWhereConditionSchema).optional().describe('WHERE conditions (combined with AND)'),
+  allowFullTableUpdate: z.boolean().default(false).describe('Explicitly allow UPDATE without WHERE conditions'),
+  optimisticLock: updateOptimisticLockSchema.optional().describe('Optional optimistic locking condition'),
+  vendor: z.enum(['postgresql', 'mysql', 'sqlite']).describe('Database vendor'),
+  connectionString: z.string().min(1, 'Database connection string is required').describe('Database connection string'),
+}).superRefine((value, ctx) => {
+  const hasWhere = (value.where?.length ?? 0) > 0;
+  const hasOptimisticLock = !!value.optimisticLock;
+
+  if (!value.allowFullTableUpdate && !hasWhere && !hasOptimisticLock) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['where'],
+      message: 'WHERE conditions are required unless allowFullTableUpdate is true',
+    });
+  }
+});

--- a/packages/tools/src/data/relational/tools/relational-update/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Type definitions for relational UPDATE operations
+ * @module tools/relational-update/types
+ */
+
+import type { z } from 'zod';
+import type {
+  updateValueSchema,
+  updateDataSchema,
+  updateWhereOperatorSchema,
+  updateWhereConditionSchema,
+  updateOptimisticLockSchema,
+  relationalUpdateSchema,
+} from './schemas.js';
+
+/**
+ * Supported UPDATE value type.
+ */
+export type UpdateValue = z.infer<typeof updateValueSchema>;
+
+/**
+ * UPDATE payload object.
+ */
+export type UpdateData = z.infer<typeof updateDataSchema>;
+
+/**
+ * WHERE operator for UPDATE conditions.
+ */
+export type UpdateWhereOperator = z.infer<typeof updateWhereOperatorSchema>;
+
+/**
+ * WHERE condition for UPDATE query.
+ */
+export type UpdateWhereCondition = z.infer<typeof updateWhereConditionSchema>;
+
+/**
+ * Optimistic lock definition.
+ */
+export type UpdateOptimisticLock = z.infer<typeof updateOptimisticLockSchema>;
+
+/**
+ * Relational UPDATE tool input.
+ */
+export type RelationalUpdateInput = z.infer<typeof relationalUpdateSchema>;
+
+/**
+ * UPDATE execution result.
+ */
+export interface UpdateResult {
+  rowCount: number;
+  executionTime: number;
+}
+
+/**
+ * Tool success response.
+ */
+export interface UpdateSuccessResponse {
+  success: true;
+  rowCount: number;
+  executionTime: number;
+}
+
+/**
+ * Tool error response.
+ */
+export interface UpdateErrorResponse {
+  success: false;
+  error: string;
+  rowCount: 0;
+}
+
+/**
+ * Tool response (success or error).
+ */
+export type UpdateResponse = UpdateSuccessResponse | UpdateErrorResponse;

--- a/packages/tools/tests/data/relational/relational-update/index.test.ts
+++ b/packages/tools/tests/data/relational/relational-update/index.test.ts
@@ -1,0 +1,9 @@
+/**
+ * Relational UPDATE Tool Tests
+ *
+ * Main test suite that imports all relational-update test modules.
+ */
+
+import './schema-validation.test.js';
+import './query-builder.test.js';
+import './tool-invocation.test.js';

--- a/packages/tools/tests/data/relational/relational-update/query-builder.test.ts
+++ b/packages/tools/tests/data/relational/relational-update/query-builder.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Query Builder Tests for Relational UPDATE
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import { buildUpdateQuery } from '../../../../src/data/relational/query/query-builder.js';
+import type { ConnectionConfig } from '../../../../src/data/relational/connection/types.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+function extractRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result as Array<Record<string, unknown>>;
+  }
+
+  if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown[] }).rows)) {
+    return (result as { rows: Array<Record<string, unknown>> }).rows;
+  }
+
+  return [];
+}
+
+describe('Relational UPDATE - Query Builder', () => {
+  let manager: ConnectionManager;
+
+  beforeAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    const config: ConnectionConfig = {
+      vendor: 'sqlite',
+      connection: ':memory:',
+    };
+
+    manager = new ConnectionManager(config);
+    await manager.connect();
+
+    await manager.execute(sql.raw(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE,
+        status TEXT DEFAULT 'active',
+        version INTEGER DEFAULT 1
+      );
+    `));
+
+    await manager.execute(sql.raw(`
+      INSERT INTO users (name, email, status, version)
+      VALUES
+        ('Alice', 'alice@example.com', 'active', 1),
+        ('Bob', 'bob@example.com', 'active', 1);
+    `));
+  });
+
+  afterAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    await manager.disconnect();
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should build and execute UPDATE with WHERE', async () => {
+    const built = buildUpdateQuery({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'email', operator: 'eq', value: 'alice@example.com' }],
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT status
+      FROM users
+      WHERE email = 'alice@example.com'
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'inactive' });
+  });
+
+  it('should reject UPDATE without WHERE by default', () => {
+    expect(() =>
+      buildUpdateQuery({
+        table: 'users',
+        data: { status: 'inactive' },
+        vendor: 'sqlite',
+      })
+    ).toThrow(/WHERE conditions are required for UPDATE queries/i);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should allow full-table update when explicitly enabled', async () => {
+    const built = buildUpdateQuery({
+      table: 'users',
+      data: { status: 'archived' },
+      allowFullTableUpdate: true,
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT DISTINCT status
+      FROM users
+      ORDER BY status
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'archived' });
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should include optimistic lock condition', async () => {
+    await manager.execute(sql.raw(`
+      UPDATE users
+      SET status = 'active', version = 1
+      WHERE email = 'bob@example.com'
+    `));
+
+    const built = buildUpdateQuery({
+      table: 'users',
+      data: { status: 'inactive', version: 2 },
+      where: [{ column: 'email', operator: 'eq', value: 'bob@example.com' }],
+      optimisticLock: { column: 'version', expectedValue: 1 },
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT status, version
+      FROM users
+      WHERE email = 'bob@example.com'
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      status: 'inactive',
+      version: 2,
+    });
+  });
+
+  it('should reject empty update data', () => {
+    expect(() =>
+      buildUpdateQuery({
+        table: 'users',
+        data: {},
+        where: [{ column: 'id', operator: 'eq', value: 1 }],
+        vendor: 'sqlite',
+      })
+    ).toThrow(/Update data must not be empty/i);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-update/schema-validation.test.ts
+++ b/packages/tools/tests/data/relational/relational-update/schema-validation.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Schema Validation Tests for Relational UPDATE Tool
+ */
+
+import { describe, it, expect } from 'vitest';
+import { relationalUpdate } from '../../../../src/data/relational/tools/relational-update/index.js';
+
+describe('Relational UPDATE - Schema Validation', () => {
+  it('should accept valid UPDATE with WHERE condition', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject UPDATE without WHERE when allowFullTableUpdate is false', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept UPDATE without WHERE when allowFullTableUpdate is true', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      allowFullTableUpdate: true,
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept optimistic lock without explicit WHERE conditions', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      optimisticLock: { column: 'version', expectedValue: 2 },
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty update data', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: {},
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-array value for IN operator', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'in', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject value for isNull operator', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'deleted_at', operator: 'isNull', value: 'x' }],
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject malformed table name', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users; DROP TABLE users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty connection string', () => {
+    const result = relationalUpdate.schema.safeParse({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-update/test-utils.ts
+++ b/packages/tools/tests/data/relational/relational-update/test-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Test utilities for relational UPDATE tests
+ * @module tests/relational-update/test-utils
+ */
+
+/**
+ * Check if better-sqlite3 native bindings are available.
+ */
+export const hasSQLiteBindings = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const db = new Database(':memory:');
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+})();

--- a/packages/tools/tests/data/relational/relational-update/tool-invocation.test.ts
+++ b/packages/tools/tests/data/relational/relational-update/tool-invocation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tool Invocation Tests for Relational UPDATE Tool
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { relationalUpdate } from '../../../../src/data/relational/tools/relational-update/index.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+async function createTestDatabase(): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3');
+  const path = await import('path');
+  const os = await import('os');
+  const fs = await import('fs');
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relational-update-test-'));
+  const dbPath = path.join(tmpDir, 'test.db');
+
+  const db = new Database(dbPath);
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      status TEXT DEFAULT 'active',
+      version INTEGER DEFAULT 1
+    );
+    INSERT INTO users (name, email, status, version)
+    VALUES
+      ('Alice', 'alice@example.com', 'active', 1),
+      ('Bob', 'bob@example.com', 'active', 1),
+      ('Carol', 'carol@example.com', 'active', 1);
+  `);
+  db.close();
+
+  return dbPath;
+}
+
+describe('Relational UPDATE - Tool Invocation', () => {
+  let dbPath: string | undefined;
+
+  const getDbPath = (): string => {
+    if (!dbPath) {
+      throw new Error('SQLite test database path was not initialized');
+    }
+    return dbPath;
+  };
+
+  beforeAll(async () => {
+    if (hasSQLiteBindings) {
+      dbPath = await createTestDatabase();
+    }
+  });
+
+  afterAll(async () => {
+    if (dbPath) {
+      const fs = await import('fs');
+      const path = await import('path');
+      try {
+        fs.unlinkSync(dbPath);
+        fs.rmdirSync(path.dirname(dbPath));
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should update one row with WHERE condition', async () => {
+    const result = await relationalUpdate.invoke({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'email', operator: 'eq', value: 'alice@example.com' }],
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(1);
+    if (result.success) {
+      expect(result.executionTime).toBeGreaterThan(0);
+    }
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should prevent full-table update by default', async () => {
+    const result = await relationalUpdate.invoke({
+      table: 'users',
+      data: { status: 'inactive' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/WHERE conditions are required/i);
+    expect(result.rowCount).toBe(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should allow full-table update when explicitly enabled', async () => {
+    const result = await relationalUpdate.invoke({
+      table: 'users',
+      data: { status: 'archived' },
+      allowFullTableUpdate: true,
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support optimistic locking and detect stale updates', async () => {
+    const first = await relationalUpdate.invoke({
+      table: 'users',
+      data: { version: 2, status: 'active' },
+      where: [{ column: 'email', operator: 'eq', value: 'bob@example.com' }],
+      optimisticLock: { column: 'version', expectedValue: 1 },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(first.success).toBe(true);
+    expect(first.rowCount).toBe(1);
+
+    const stale = await relationalUpdate.invoke({
+      table: 'users',
+      data: { version: 3, status: 'inactive' },
+      where: [{ column: 'email', operator: 'eq', value: 'bob@example.com' }],
+      optimisticLock: { column: 'version', expectedValue: 1 },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(stale.success).toBe(false);
+    expect(stale.error).toBe('Update failed: optimistic lock check failed.');
+    expect(stale.rowCount).toBe(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should return clear error for unique constraint violations', async () => {
+    const result = await relationalUpdate.invoke({
+      table: 'users',
+      data: { email: 'alice@example.com' },
+      where: [{ column: 'email', operator: 'eq', value: 'carol@example.com' }],
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Update failed: unique constraint violation.');
+    expect(result.rowCount).toBe(0);
+  });
+});

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -99,27 +99,27 @@
 **Branch:** `feat/st-02004-type-safe-update-tool`
 
 ### Checklist
-- [ ] Create branch `feat/st-02004-type-safe-update-tool`
-- [ ] Create draft PR with story ID in title
-- [ ] Extend query builder with UPDATE support
-- [ ] Add support for WHERE conditions (required for safety)
-- [ ] Add support for returning count of affected rows
-- [ ] Create `packages/tools/src/data/relational/tools/relational-update.ts`
-- [ ] Define Zod schema for tool input (table, data, where, allowFullTableUpdate)
-- [ ] Implement tool function using query builder
-- [ ] Add type validation for update data
-- [ ] Prevent accidental full-table updates (require explicit flag)
-- [ ] Add optimistic locking support (optional, version field)
-- [ ] Handle constraint violations
-- [ ] Export tool from `tools/index.ts`
-- [ ] Create unit tests for UPDATE query builder
-- [ ] Create unit tests for relational-update tool
-- [ ] Test full-table update prevention
-- [ ] Add or update story documentation at docs/st02004-type-safe-update-tool.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR ready for review
+- [x] Create branch `feat/st-02004-type-safe-update-tool`
+- [x] Create draft PR with story ID in title (PR #35)
+- [x] Extend query builder with UPDATE support
+- [x] Add support for WHERE conditions (required for safety)
+- [x] Add support for returning count of affected rows
+- [x] Create relational-update tool module at `packages/tools/src/data/relational/tools/relational-update/`
+- [x] Define Zod schema for tool input (table, data, where, allowFullTableUpdate)
+- [x] Implement tool function using query builder
+- [x] Add type validation for update data
+- [x] Prevent accidental full-table updates (require explicit flag)
+- [x] Add optimistic locking support (optional, version field)
+- [x] Handle constraint violations
+- [x] Export tool from `tools/index.ts`
+- [x] Create unit tests for UPDATE query builder
+- [x] Create unit tests for relational-update tool
+- [x] Test full-table update prevention
+- [x] Add or update story documentation at docs/st02004-type-safe-update-tool.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added relational-update schema + query-builder + tool invocation tests)
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1234 passed, 121 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (0 errors; warnings-only baseline outside story scope)
+- [x] Mark PR ready for review (PR #35 marked ready on 2026-02-19)
 - [ ] Wait for merge
 
 ---

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-19
-**Active Story:** ST-02004 (Ready)
+**Active Story:** ST-02004 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories (ST-04003, ST-03002, ST-05003, ST-02004, ST-04002)
+- **Ready:** 4 stories (ST-04003, ST-03002, ST-05003, ST-04002)
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story (ST-02004)
 - **Blocked:** 0 stories
 - **Backlog:** 5 stories (waiting on dependencies)
 
@@ -35,13 +35,6 @@
 - **Dependencies:** ST-02006 ✅ (merged 2026-02-19), ST-03001 ✅ (merged 2026-02-19)
 - **Checklist:** `planning/checklists/epic-05-story-tasks.md`
 
-### ST-02004: Implement Type-Safe UPDATE Tool
-- **Epic:** EP-02
-- **Priority:** P0
-- **Estimate:** 4 hours
-- **Dependencies:** ST-02003 ✅ (merged 2026-02-19)
-- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
-
 ### ST-04002: Implement Batch Operations
 - **Epic:** EP-04
 - **Priority:** P2
@@ -59,7 +52,14 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+### ST-02004: Implement Type-Safe UPDATE Tool
+- **Epic:** EP-02
+- **Priority:** P0
+- **Estimate:** 4 hours
+- **Dependencies:** ST-02003 ✅ (merged 2026-02-19)
+- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
+- **Branch:** `feat/st-02004-type-safe-update-tool`
+- **PR:** [#35](https://github.com/TVScoundrel/agentforge/pull/35)
 
 ---
 


### PR DESCRIPTION
## Story
- ST-02004: Implement Type-Safe UPDATE Tool

## What Changed
- Added shared UPDATE query-builder support in `packages/tools/src/data/relational/query/query-builder.ts`.
- Added new `relational-update` tool module:
  - `packages/tools/src/data/relational/tools/relational-update/index.ts`
  - `packages/tools/src/data/relational/tools/relational-update/schemas.ts`
  - `packages/tools/src/data/relational/tools/relational-update/types.ts`
  - `packages/tools/src/data/relational/tools/relational-update/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-update/error-utils.ts`
- Exported `relationalUpdate` from `packages/tools/src/data/relational/tools/index.ts`.
- Added UPDATE tests:
  - `packages/tools/tests/data/relational/relational-update/query-builder.test.ts`
  - `packages/tools/tests/data/relational/relational-update/schema-validation.test.ts`
  - `packages/tools/tests/data/relational/relational-update/tool-invocation.test.ts`
  - `packages/tools/tests/data/relational/relational-update/index.test.ts`

## Acceptance Criteria Coverage
- [x] `relational-update` tool with query builder support
- [x] WHERE conditions support and full-table update safety gate
- [x] Return affected-row count
- [x] Type validation for update payloads
- [x] Constraint violation error handling
- [x] Optional optimistic locking support

## Validation Performed
- `pnpm test --run packages/tools/tests/data/relational/relational-update/index.test.ts`
- `pnpm test --run packages/tools/tests/data/relational`
- `pnpm --filter @agentforge/tools lint`
- `pnpm test --run` -> 1234 passed, 121 skipped
- `pnpm lint` -> 0 errors (warnings-only baseline outside ST-02004 scope)

## Status
- Ready for review.
