### PR TITLE
feat(st-04003): implement result streaming

### DIFF
--- a/docs/st04003-result-streaming.md
+++ b/docs/st04003-result-streaming.md
@@ -1,0 +1,79 @@
+# ST-04003: Result Streaming for Relational SELECT
+
+**Status:** 🚧 Draft PR  
+**PR:** [#36](https://github.com/TVScoundrel/agentforge/pull/36)  
+**Epic:** 04 - Advanced Features and Optimization
+
+## Overview
+
+Implemented chunked result streaming for `relational-select` so large SELECT operations can be processed with bounded memory behavior.
+
+## What Was Added
+
+1. `packages/tools/src/data/relational/query/stream-executor.ts`
+- `streamSelectChunks(...)` for chunked async iteration.
+- `createSelectReadableStream(...)` for Node.js `Readable` integration.
+- `executeStreamingSelect(...)` for chunk processing + memory monitoring.
+- `benchmarkStreamingSelectMemory(...)` for streaming vs non-streaming memory benchmark output.
+
+2. Shared SELECT query builder in `packages/tools/src/data/relational/query/query-builder.ts`
+- `buildSelectQuery(...)` moved into shared query utilities.
+
+3. Streaming option in `relational-select`
+- `streaming.enabled`
+- `streaming.chunkSize`
+- `streaming.maxRows`
+- `streaming.sampleSize`
+- `streaming.benchmark`
+
+4. Response metadata
+- `streaming.chunkCount`
+- `streaming.streamedRowCount`
+- `streaming.sampledRowCount`
+- `streaming.memoryUsage`
+- optional `streaming.benchmark`
+
+## Example Usage
+
+```typescript
+import { relationalSelect } from '@agentforge/tools';
+
+const result = await relationalSelect.invoke({
+  table: 'events',
+  orderBy: [{ column: 'id', direction: 'asc' }],
+  streaming: {
+    enabled: true,
+    chunkSize: 250,
+    sampleSize: 25,
+    maxRows: 10000,
+    benchmark: true,
+  },
+  vendor: 'postgresql',
+  connectionString: process.env.DATABASE_URL!,
+});
+
+if (result.success && result.streaming?.enabled) {
+  console.log({
+    streamedRows: result.streaming.streamedRowCount,
+    sampledRows: result.streaming.sampledRowCount,
+    chunkCount: result.streaming.chunkCount,
+    peakHeap: result.streaming.memoryUsage.peakHeapUsed,
+    benchmark: result.streaming.benchmark,
+  });
+}
+```
+
+## Streaming vs Regular SELECT
+
+Use regular SELECT when:
+- expected result set is small
+- caller needs all rows in response payload
+
+Use streaming mode when:
+- expected result set is large
+- you want chunked execution with bounded in-process memory growth
+- you want benchmark metadata to compare streaming vs non-streaming behavior
+
+## Validation
+
+- `pnpm test --run packages/tools/tests/data/relational/relational-select/index.test.ts`

--- a/docs/st04003-result-streaming.md
+++ b/docs/st04003-result-streaming.md
@@ -1,6 +1,6 @@
 # ST-04003: Result Streaming for Relational SELECT
 
-**Status:** 🚧 Draft PR  
+**Status:** 👀 In Review  
 **PR:** [#36](https://github.com/TVScoundrel/agentforge/pull/36)  
 **Epic:** 04 - Advanced Features and Optimization
 
@@ -73,6 +73,15 @@ Use streaming mode when:
 - expected result set is large
 - you want chunked execution with bounded in-process memory growth
 - you want benchmark metadata to compare streaming vs non-streaming behavior
+
+## Operational Notes
+
+- Streaming currently uses LIMIT/OFFSET paging under the hood. This is portable, but large offsets can become slower on some databases.
+- Benchmark mode is intended for side-effect-free SELECT queries only.
+- Enabling `streaming.benchmark` executes the query up to three times overall:
+  - once for the returned streaming result
+  - once for regular (non-streaming) benchmark measurement
+  - once for streaming benchmark measurement
 
 ## Validation
 

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -35,6 +35,7 @@ export {
 } from './query-builder.js';
 
 export {
+  DEFAULT_CHUNK_SIZE,
   streamSelectChunks,
   createSelectReadableStream,
   executeStreamingSelect,

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -11,6 +11,11 @@ export type {
 
 export { executeQuery } from './query-executor.js';
 export {
+  buildSelectQuery,
+  type SelectOrderDirection,
+  type SelectOrderBy,
+  type SelectWhereCondition,
+  type SelectQueryInput,
   buildInsertQuery,
   type InsertValue,
   type InsertRow,
@@ -28,3 +33,15 @@ export {
   type UpdateQueryInput,
   type BuiltUpdateQuery,
 } from './query-builder.js';
+
+export {
+  streamSelectChunks,
+  createSelectReadableStream,
+  executeStreamingSelect,
+  benchmarkStreamingSelectMemory,
+  type StreamingSelectOptions,
+  type StreamingSelectChunk,
+  type StreamingSelectResult,
+  type StreamingMemoryUsage,
+  type StreamingBenchmarkResult,
+} from './stream-executor.js';

--- a/packages/tools/src/data/relational/query/stream-executor.ts
+++ b/packages/tools/src/data/relational/query/stream-executor.ts
@@ -1,0 +1,344 @@
+/**
+ * Streaming SELECT executor for large result sets.
+ * @module query/stream-executor
+ */
+
+import { Readable } from 'node:stream';
+import { createLogger } from '@agentforge/core';
+import type { ConnectionManager } from '../connection/connection-manager.js';
+import { buildSelectQuery, type SelectQueryInput } from './query-builder.js';
+
+const logger = createLogger('agentforge:tools:data:relational:stream');
+
+const DEFAULT_CHUNK_SIZE = 100;
+const MAX_CHUNK_SIZE = 5000;
+const DEFAULT_SAMPLE_SIZE = 50;
+
+/**
+ * Memory usage information captured during streaming execution.
+ */
+export interface StreamingMemoryUsage {
+  startHeapUsed: number;
+  peakHeapUsed: number;
+  endHeapUsed: number;
+  deltaHeapUsed: number;
+}
+
+/**
+ * One streamed chunk payload.
+ */
+export interface StreamingSelectChunk {
+  chunkIndex: number;
+  offset: number;
+  rows: unknown[];
+}
+
+/**
+ * Streaming execution options.
+ */
+export interface StreamingSelectOptions {
+  chunkSize?: number;
+  maxRows?: number;
+  sampleSize?: number;
+  collectAllRows?: boolean;
+  signal?: AbortSignal;
+  onChunk?: (chunk: StreamingSelectChunk) => Promise<void> | void;
+}
+
+/**
+ * Streaming execution result.
+ */
+export interface StreamingSelectResult {
+  rows: unknown[];
+  rowCount: number;
+  chunkCount: number;
+  executionTime: number;
+  cancelled: boolean;
+  memoryUsage: StreamingMemoryUsage;
+}
+
+/**
+ * Optional benchmark result comparing regular vs streaming SELECT execution.
+ */
+export interface StreamingBenchmarkResult {
+  nonStreamingExecutionTime: number;
+  nonStreamingPeakHeapUsed: number;
+  streamingExecutionTime: number;
+  streamingPeakHeapUsed: number;
+  memorySavedBytes: number;
+  memorySavedPercent: number;
+}
+
+function normalizeBoundedInt(
+  value: number | undefined,
+  fieldName: string,
+  min: number,
+  max: number,
+  fallback: number
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${fieldName} must be an integer between ${min} and ${max}`);
+  }
+
+  return value;
+}
+
+function normalizePositiveInt(
+  value: number | undefined,
+  fieldName: string,
+  fallback?: number
+): number | undefined {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${fieldName} must be a positive integer`);
+  }
+
+  return value;
+}
+
+function extractRows(result: unknown): unknown[] {
+  if (Array.isArray(result)) {
+    return result;
+  }
+
+  return (result as { rows?: unknown[] }).rows ?? [];
+}
+
+function isCancelledError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Stream cancelled by caller');
+}
+
+function resolveTotalRowsLimit(input: SelectQueryInput, options: StreamingSelectOptions): number | undefined {
+  const inputLimit = normalizePositiveInt(input.limit, 'limit');
+  const maxRows = normalizePositiveInt(options.maxRows, 'maxRows');
+
+  if (inputLimit === undefined) {
+    return maxRows;
+  }
+
+  if (maxRows === undefined) {
+    return inputLimit;
+  }
+
+  return Math.min(inputLimit, maxRows);
+}
+
+/**
+ * Yield SELECT rows chunk-by-chunk using LIMIT/OFFSET pagination.
+ */
+export async function* streamSelectChunks(
+  manager: ConnectionManager,
+  input: SelectQueryInput,
+  options: StreamingSelectOptions = {}
+): AsyncGenerator<StreamingSelectChunk> {
+  const chunkSize = normalizeBoundedInt(options.chunkSize, 'chunkSize', 1, MAX_CHUNK_SIZE, DEFAULT_CHUNK_SIZE);
+  const baseOffset = input.offset ?? 0;
+  const totalRowsLimit = resolveTotalRowsLimit(input, options);
+
+  let processedRows = 0;
+  let chunkIndex = 0;
+
+  while (true) {
+    if (options.signal?.aborted) {
+      throw new Error('Stream cancelled by caller.');
+    }
+
+    const remainingRows = totalRowsLimit === undefined ? chunkSize : totalRowsLimit - processedRows;
+    if (remainingRows <= 0) {
+      return;
+    }
+
+    const pageLimit = Math.min(chunkSize, remainingRows);
+    const pageOffset = baseOffset + processedRows;
+
+    const query = buildSelectQuery({
+      ...input,
+      limit: pageLimit,
+      offset: pageOffset,
+    });
+
+    const result = await manager.execute(query);
+    const rows = extractRows(result);
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    yield {
+      chunkIndex,
+      offset: pageOffset,
+      rows,
+    };
+
+    processedRows += rows.length;
+    chunkIndex += 1;
+
+    if (rows.length < pageLimit) {
+      return;
+    }
+  }
+}
+
+/**
+ * Create a Node.js Readable stream that emits SELECT chunks in object mode.
+ */
+export function createSelectReadableStream(
+  manager: ConnectionManager,
+  input: SelectQueryInput,
+  options: StreamingSelectOptions = {}
+): Readable {
+  return Readable.from(streamSelectChunks(manager, input, options), {
+    objectMode: true,
+    highWaterMark: 1,
+  });
+}
+
+/**
+ * Execute a SELECT query in streaming mode while tracking memory usage.
+ */
+export async function executeStreamingSelect(
+  manager: ConnectionManager,
+  input: SelectQueryInput,
+  options: StreamingSelectOptions = {}
+): Promise<StreamingSelectResult> {
+  const startTime = Date.now();
+  const collectedRows: unknown[] = [];
+
+  const sampleSize = normalizeBoundedInt(
+    options.sampleSize,
+    'sampleSize',
+    0,
+    5000,
+    DEFAULT_SAMPLE_SIZE
+  );
+
+  let rowCount = 0;
+  let chunkCount = 0;
+  let cancelled = false;
+
+  const startHeapUsed = process.memoryUsage().heapUsed;
+  let peakHeapUsed = startHeapUsed;
+
+  const stream = createSelectReadableStream(manager, input, options);
+  const abortHandler = () => {
+    stream.destroy(new Error('Stream cancelled by caller.'));
+  };
+
+  options.signal?.addEventListener('abort', abortHandler, { once: true });
+
+  try {
+    for await (const chunk of stream as AsyncIterable<StreamingSelectChunk>) {
+      chunkCount += 1;
+      rowCount += chunk.rows.length;
+
+      if (options.collectAllRows) {
+        collectedRows.push(...chunk.rows);
+      } else if (sampleSize > 0 && collectedRows.length < sampleSize) {
+        const remaining = sampleSize - collectedRows.length;
+        collectedRows.push(...chunk.rows.slice(0, remaining));
+      }
+
+      if (options.onChunk) {
+        await options.onChunk(chunk);
+      }
+
+      peakHeapUsed = Math.max(peakHeapUsed, process.memoryUsage().heapUsed);
+    }
+  } catch (error) {
+    if (isCancelledError(error)) {
+      cancelled = true;
+    } else {
+      throw error;
+    }
+  } finally {
+    options.signal?.removeEventListener('abort', abortHandler);
+  }
+
+  const endHeapUsed = process.memoryUsage().heapUsed;
+  peakHeapUsed = Math.max(peakHeapUsed, endHeapUsed);
+
+  const executionTime = Date.now() - startTime;
+
+  logger.debug('Streaming SELECT execution completed', {
+    table: input.table,
+    vendor: input.vendor,
+    chunkCount,
+    rowCount,
+    executionTime,
+    cancelled,
+    chunkSize: options.chunkSize ?? DEFAULT_CHUNK_SIZE,
+  });
+
+  return {
+    rows: collectedRows,
+    rowCount,
+    chunkCount,
+    executionTime,
+    cancelled,
+    memoryUsage: {
+      startHeapUsed,
+      peakHeapUsed,
+      endHeapUsed,
+      deltaHeapUsed: endHeapUsed - startHeapUsed,
+    },
+  };
+}
+
+/**
+ * Benchmark memory usage of regular SELECT execution vs streaming execution.
+ */
+export async function benchmarkStreamingSelectMemory(
+  manager: ConnectionManager,
+  input: SelectQueryInput,
+  options: StreamingSelectOptions = {}
+): Promise<StreamingBenchmarkResult> {
+  const nonStreamingStartHeapUsed = process.memoryUsage().heapUsed;
+  const nonStreamingStartTime = Date.now();
+
+  const nonStreamingResult = await manager.execute(buildSelectQuery(input));
+  const nonStreamingRows = extractRows(nonStreamingResult);
+
+  const nonStreamingExecutionTime = Date.now() - nonStreamingStartTime;
+  const nonStreamingPeakHeapUsed = Math.max(nonStreamingStartHeapUsed, process.memoryUsage().heapUsed);
+
+  const streamingResult = await executeStreamingSelect(manager, input, {
+    ...options,
+    collectAllRows: false,
+    sampleSize: 0,
+  });
+
+  const memorySavedBytes = Math.max(
+    nonStreamingPeakHeapUsed - streamingResult.memoryUsage.peakHeapUsed,
+    0
+  );
+
+  const memorySavedPercent = nonStreamingPeakHeapUsed > 0
+    ? (memorySavedBytes / nonStreamingPeakHeapUsed) * 100
+    : 0;
+
+  logger.debug('Streaming benchmark completed', {
+    table: input.table,
+    vendor: input.vendor,
+    nonStreamingRows: nonStreamingRows.length,
+    nonStreamingExecutionTime,
+    streamingExecutionTime: streamingResult.executionTime,
+    memorySavedBytes,
+    memorySavedPercent,
+  });
+
+  return {
+    nonStreamingExecutionTime,
+    nonStreamingPeakHeapUsed,
+    streamingExecutionTime: streamingResult.executionTime,
+    streamingPeakHeapUsed: streamingResult.memoryUsage.peakHeapUsed,
+    memorySavedBytes,
+    memorySavedPercent,
+  };
+}

--- a/packages/tools/src/data/relational/tools/relational-select/error-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/error-utils.ts
@@ -9,10 +9,13 @@ const SAFE_VALIDATION_ERROR_PATTERNS = [
   'contains invalid characters',
   'requires an array value',
   'requires a non-empty array value',
+  'must be an integer between',
+  'must be a positive integer',
   'null is only allowed with isNull/isNotNull operators',
   'LIKE operator requires a string value',
   'operator requires a string or number value',
   'operator requires a scalar value',
+  'Stream cancelled by caller',
 ] as const;
 
 export function isSafeValidationError(error: unknown): error is Error {
@@ -24,4 +27,3 @@ export function isSafeValidationError(error: unknown): error is Error {
     error.message.includes(pattern)
   );
 }
-

--- a/packages/tools/src/data/relational/tools/relational-select/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/index.ts
@@ -28,6 +28,7 @@ export * from './schemas.js';
  * - WHERE conditions with multiple operators
  * - ORDER BY with ascending/descending
  * - LIMIT and OFFSET for pagination
+ * - Optional chunked streaming mode for large result sets
  * - Result formatting to JSON
  * - Error handling with clear messages
  * 
@@ -76,6 +77,20 @@ export const relationalSelect = toolBuilder()
       connectionString: 'mysql://localhost/shop'
     }
   })
+  .example({
+    description: 'SELECT with streaming mode',
+    input: {
+      table: 'events',
+      orderBy: [{ column: 'id', direction: 'asc' }],
+      streaming: {
+        enabled: true,
+        chunkSize: 250,
+        sampleSize: 25
+      },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/analytics'
+    }
+  })
   .implement(async (input: RelationalSelectInput): Promise<SelectResponse> => {
     const manager = new ConnectionManager({
       vendor: input.vendor,
@@ -94,7 +109,8 @@ export const relationalSelect = toolBuilder()
         success: true,
         rows: result.rows,
         rowCount: result.rowCount,
-        executionTime: result.executionTime
+        executionTime: result.executionTime,
+        streaming: result.streaming,
       };
     } catch (error) {
       let errorMessage = 'Failed to execute SELECT query. Please verify your input and database connection.';

--- a/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
@@ -1,103 +1,27 @@
 /**
- * Query builder for relational SELECT operations
+ * Query builder adapter for relational SELECT operations.
  * @module tools/relational-select/query-builder
  */
 
-import { sql, type SQL } from 'drizzle-orm';
-import type { RelationalSelectInput, WhereCondition } from './types.js';
-import type { DatabaseVendor } from '../../types.js';
-import { validateIdentifier, validateQualifiedIdentifier, quoteIdentifier, quoteQualifiedIdentifier } from '../../utils/identifier-utils.js';
+import {
+  buildSelectQuery as buildSharedSelectQuery,
+  type SelectQueryInput,
+} from '../../query/query-builder.js';
+import type { RelationalSelectInput } from './types.js';
 
 /**
- * Build a WHERE condition SQL fragment
+ * Build a complete SELECT query using shared query builder utilities.
  */
-function buildWhereCondition(condition: WhereCondition, vendor?: DatabaseVendor): SQL {
-  validateIdentifier(condition.column, 'WHERE column');
-  const column = sql.raw(quoteIdentifier(condition.column, vendor));
+export function buildSelectQuery(input: RelationalSelectInput) {
+  const queryInput: SelectQueryInput = {
+    table: input.table,
+    columns: input.columns,
+    where: input.where,
+    orderBy: input.orderBy,
+    limit: input.limit,
+    offset: input.offset,
+    vendor: input.vendor,
+  };
 
-  switch (condition.operator) {
-    case 'eq':
-      return sql`${column} = ${condition.value}`;
-    case 'ne':
-      return sql`${column} != ${condition.value}`;
-    case 'gt':
-      return sql`${column} > ${condition.value}`;
-    case 'lt':
-      return sql`${column} < ${condition.value}`;
-    case 'gte':
-      return sql`${column} >= ${condition.value}`;
-    case 'lte':
-      return sql`${column} <= ${condition.value}`;
-    case 'like':
-      return sql`${column} LIKE ${condition.value}`;
-    case 'in': {
-      if (!Array.isArray(condition.value) || condition.value.length === 0) {
-        throw new Error(`IN operator requires a non-empty array value for column ${condition.column}`);
-      }
-      const inValues = condition.value.map((v) => sql`${v}`);
-      return sql`${column} IN (${sql.join(inValues, sql.raw(', '))})`;
-    }
-    case 'notIn': {
-      if (!Array.isArray(condition.value) || condition.value.length === 0) {
-        throw new Error(`NOT IN operator requires a non-empty array value for column ${condition.column}`);
-      }
-      const notInValues = condition.value.map((v) => sql`${v}`);
-      return sql`${column} NOT IN (${sql.join(notInValues, sql.raw(', '))})`;
-    }
-    case 'isNull':
-      return sql`${column} IS NULL`;
-    case 'isNotNull':
-      return sql`${column} IS NOT NULL`;
-  }
-}
-
-/**
- * Build a complete SELECT query using Drizzle's sql template
- */
-export function buildSelectQuery(input: RelationalSelectInput): SQL {
-  // Start with SELECT clause
-  let query = sql.raw('SELECT ');
-
-  // Add columns
-  if (input.columns && input.columns.length > 0) {
-    input.columns.forEach(c => validateIdentifier(c, 'SELECT column'));
-    query = sql.join([query, sql.raw(input.columns.map(c => quoteIdentifier(c, input.vendor)).join(', '))], sql.raw(''));
-  } else {
-    query = sql.join([query, sql.raw('*')], sql.raw(''));
-  }
-
-  // Add FROM clause
-  validateQualifiedIdentifier(input.table, 'Table name');
-  query = sql.join([query, sql.raw(` FROM ${quoteQualifiedIdentifier(input.table, input.vendor)}`)], sql.raw(''));
-
-  // Add WHERE conditions
-  if (input.where && input.where.length > 0) {
-    const whereConditions: SQL[] = input.where.map(w => buildWhereCondition(w, input.vendor));
-
-    if (whereConditions.length > 0) {
-      query = sql.join([query, sql.raw(' WHERE '), sql.join(whereConditions, sql.raw(' AND '))], sql.raw(''));
-    }
-  }
-
-  // Add ORDER BY
-  if (input.orderBy && input.orderBy.length > 0) {
-    const orderClauses = input.orderBy.map(order => {
-      validateIdentifier(order.column, 'ORDER BY column');
-      const direction = order.direction.toUpperCase();
-      return sql.raw(`${quoteIdentifier(order.column, input.vendor)} ${direction}`);
-    });
-    query = sql.join([query, sql.raw(' ORDER BY '), sql.join(orderClauses, sql.raw(', '))], sql.raw(''));
-  }
-
-  // Add LIMIT
-  if (input.limit !== undefined) {
-    query = sql.join([query, sql` LIMIT ${input.limit}`], sql.raw(''));
-  }
-
-  // Add OFFSET
-  if (input.offset !== undefined) {
-    query = sql.join([query, sql` OFFSET ${input.offset}`], sql.raw(''));
-  }
-
-  return query;
+  return buildSharedSelectQuery(queryInput);
 }

--- a/packages/tools/src/data/relational/tools/relational-select/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/schemas.ts
@@ -139,7 +139,7 @@ export const streamingOptionsSchema = z.object({
   chunkSize: z.number().int().min(1).max(5000).optional().describe('Rows fetched per chunk (default: 100)'),
   maxRows: z.number().int().positive().optional().describe('Optional cap on streamed rows'),
   sampleSize: z.number().int().min(0).max(5000).optional().describe('Number of rows to include in the response payload'),
-  benchmark: z.boolean().optional().default(false).describe('Run memory benchmark comparing regular vs streaming execution')
+  benchmark: z.boolean().optional().default(false).describe('Run memory benchmark comparing regular vs streaming execution (adds two extra query executions; use side-effect-free SELECT statements)')
 });
 
 /**

--- a/packages/tools/src/data/relational/tools/relational-select/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/schemas.ts
@@ -132,6 +132,17 @@ export const orderBySchema = z.object({
 });
 
 /**
+ * Optional streaming configuration
+ */
+export const streamingOptionsSchema = z.object({
+  enabled: z.boolean().default(true).describe('Enable chunked streaming mode for large result sets'),
+  chunkSize: z.number().int().min(1).max(5000).optional().describe('Rows fetched per chunk (default: 100)'),
+  maxRows: z.number().int().positive().optional().describe('Optional cap on streamed rows'),
+  sampleSize: z.number().int().min(0).max(5000).optional().describe('Number of rows to include in the response payload'),
+  benchmark: z.boolean().optional().default(false).describe('Run memory benchmark comparing regular vs streaming execution')
+});
+
+/**
  * Relational SELECT tool input schema
  */
 export const relationalSelectSchema = z.object({
@@ -147,6 +158,7 @@ export const relationalSelectSchema = z.object({
   orderBy: z.array(orderBySchema).optional().describe('ORDER BY clauses'),
   limit: z.number().int().positive().optional().describe('Maximum number of rows to return'),
   offset: z.number().int().nonnegative().optional().describe('Number of rows to skip'),
+  streaming: streamingOptionsSchema.optional().describe('Optional streaming mode configuration'),
   vendor: z.enum(['postgresql', 'mysql', 'sqlite']).describe('Database vendor'),
   connectionString: z.string().min(1, 'Database connection string is required').describe('Database connection string')
 });

--- a/packages/tools/src/data/relational/tools/relational-select/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/types.ts
@@ -9,6 +9,7 @@ import type {
   whereConditionSchema, 
   orderDirectionSchema, 
   orderBySchema, 
+  streamingOptionsSchema,
   relationalSelectSchema 
 } from './schemas.js';
 
@@ -33,6 +34,47 @@ export type OrderDirection = z.infer<typeof orderDirectionSchema>;
 export type OrderBy = z.infer<typeof orderBySchema>;
 
 /**
+ * Streaming options
+ */
+export type StreamingOptions = z.infer<typeof streamingOptionsSchema>;
+
+/**
+ * Streaming memory usage metadata.
+ */
+export interface StreamingMemoryUsage {
+  startHeapUsed: number;
+  peakHeapUsed: number;
+  endHeapUsed: number;
+  deltaHeapUsed: number;
+}
+
+/**
+ * Optional streaming benchmark metadata.
+ */
+export interface StreamingBenchmarkMetadata {
+  nonStreamingExecutionTime: number;
+  nonStreamingPeakHeapUsed: number;
+  streamingExecutionTime: number;
+  streamingPeakHeapUsed: number;
+  memorySavedBytes: number;
+  memorySavedPercent: number;
+}
+
+/**
+ * Streaming execution metadata.
+ */
+export interface StreamingMetadata {
+  enabled: true;
+  chunkSize: number;
+  chunkCount: number;
+  sampledRowCount: number;
+  streamedRowCount: number;
+  cancelled: boolean;
+  memoryUsage: StreamingMemoryUsage;
+  benchmark?: StreamingBenchmarkMetadata;
+}
+
+/**
  * Relational SELECT tool input
  */
 export type RelationalSelectInput = z.infer<typeof relationalSelectSchema>;
@@ -44,6 +86,7 @@ export interface SelectResult {
   rows: unknown[];
   rowCount: number;
   executionTime: number;
+  streaming?: StreamingMetadata;
 }
 
 /**
@@ -54,6 +97,7 @@ export interface SelectSuccessResponse {
   rows: unknown[];
   rowCount: number;
   executionTime: number;
+  streaming?: StreamingMetadata;
 }
 
 /**
@@ -70,4 +114,3 @@ export interface SelectErrorResponse {
  * Tool response (success or error)
  */
 export type SelectResponse = SelectSuccessResponse | SelectErrorResponse;
-

--- a/packages/tools/src/data/relational/tools/relational-select/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/types.ts
@@ -4,6 +4,10 @@
  */
 
 import type { z } from 'zod';
+import type {
+  StreamingBenchmarkResult,
+  StreamingMemoryUsage as QueryStreamingMemoryUsage,
+} from '../../query/index.js';
 import type { 
   whereOperatorSchema, 
   whereConditionSchema, 
@@ -38,27 +42,12 @@ export type OrderBy = z.infer<typeof orderBySchema>;
  */
 export type StreamingOptions = z.infer<typeof streamingOptionsSchema>;
 
-/**
- * Streaming memory usage metadata.
- */
-export interface StreamingMemoryUsage {
-  startHeapUsed: number;
-  peakHeapUsed: number;
-  endHeapUsed: number;
-  deltaHeapUsed: number;
-}
+export type StreamingMemoryUsage = QueryStreamingMemoryUsage;
 
 /**
  * Optional streaming benchmark metadata.
  */
-export interface StreamingBenchmarkMetadata {
-  nonStreamingExecutionTime: number;
-  nonStreamingPeakHeapUsed: number;
-  streamingExecutionTime: number;
-  streamingPeakHeapUsed: number;
-  memorySavedBytes: number;
-  memorySavedPercent: number;
-}
+export type StreamingBenchmarkMetadata = StreamingBenchmarkResult;
 
 /**
  * Streaming execution metadata.

--- a/packages/tools/tests/data/relational/relational-select/index.test.ts
+++ b/packages/tools/tests/data/relational/relational-select/index.test.ts
@@ -7,5 +7,5 @@
 
 // Import all test suites
 import './schema-validation.test.js';
+import './stream-executor.test.js';
 import './tool-invocation.test.js';
-

--- a/packages/tools/tests/data/relational/relational-select/schema-validation.test.ts
+++ b/packages/tools/tests/data/relational/relational-select/schema-validation.test.ts
@@ -217,4 +217,34 @@ describe('Relational SELECT - Schema Validation', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('should accept streaming configuration', () => {
+    const result = relationalSelect.schema.safeParse({
+      table: 'users',
+      streaming: {
+        enabled: true,
+        chunkSize: 250,
+        sampleSize: 25,
+        maxRows: 1000
+      },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid streaming chunk size', () => {
+    const result = relationalSelect.schema.safeParse({
+      table: 'users',
+      streaming: {
+        enabled: true,
+        chunkSize: 0
+      },
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test'
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/tools/tests/data/relational/relational-select/stream-executor.test.ts
+++ b/packages/tools/tests/data/relational/relational-select/stream-executor.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for relational stream executor helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import {
+  streamSelectChunks,
+  executeStreamingSelect,
+} from '../../../../src/data/relational/query/stream-executor.js';
+import type { SelectQueryInput } from '../../../../src/data/relational/query/query-builder.js';
+
+class MockConnectionManager {
+  private callIndex = 0;
+
+  constructor(private readonly responses: unknown[]) {}
+
+  async execute(): Promise<unknown> {
+    const response = this.responses[this.callIndex] ?? [];
+    this.callIndex += 1;
+    return response;
+  }
+}
+
+const baseInput: SelectQueryInput = {
+  table: 'users',
+  vendor: 'postgresql',
+};
+
+describe('stream-executor', () => {
+  it('should stream rows in chunks until no rows are returned', async () => {
+    const manager = new MockConnectionManager([
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 3 }, { id: 4 }],
+      [{ id: 5 }],
+      [],
+    ]);
+
+    const chunks = [];
+    for await (const chunk of streamSelectChunks(manager as unknown as ConnectionManager, baseInput, { chunkSize: 2 })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]?.rows).toHaveLength(2);
+    expect(chunks[1]?.rows).toHaveLength(2);
+    expect(chunks[2]?.rows).toHaveLength(1);
+  });
+
+  it('should limit sampled rows while still counting all streamed rows', async () => {
+    const manager = new MockConnectionManager([
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 3 }, { id: 4 }],
+      [{ id: 5 }],
+      [],
+    ]);
+
+    const result = await executeStreamingSelect(
+      manager as unknown as ConnectionManager,
+      baseInput,
+      {
+        chunkSize: 2,
+        sampleSize: 2,
+      }
+    );
+
+    expect(result.rowCount).toBe(5);
+    expect(result.chunkCount).toBe(3);
+    expect(result.rows).toHaveLength(2);
+    expect(result.cancelled).toBe(false);
+  });
+
+  it('should stop streaming after abort signal', async () => {
+    const manager = new MockConnectionManager([
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 3 }, { id: 4 }],
+      [{ id: 5 }],
+      [],
+    ]);
+
+    const controller = new AbortController();
+
+    const result = await executeStreamingSelect(
+      manager as unknown as ConnectionManager,
+      baseInput,
+      {
+        chunkSize: 2,
+        signal: controller.signal,
+        onChunk: () => {
+          controller.abort();
+        },
+      }
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.rowCount).toBe(2);
+    expect(result.chunkCount).toBe(1);
+  });
+});

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -6,7 +6,7 @@
 
 ### Checklist
 - [ ] Create branch `feat/st-04001-transaction-support`
-- [x] Create draft PR with story ID in title (PR #36)
+- [ ] Create draft PR with story ID in title
 - [ ] Create `packages/tools/src/data/relational/query/transaction.ts`
 - [ ] Define `Transaction` interface
 - [ ] Implement transaction wrapper for multiple operations
@@ -25,9 +25,9 @@
 - [ ] Test nested transactions
 - [ ] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1248 passed, 127 skipped)
-- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (0 errors; warnings-only baseline outside story scope)
-- [x] Mark PR ready for review (PR #36 marked ready on 2026-02-19)
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Mark PR ready for review
 - [ ] Wait for merge
 
 ---
@@ -87,9 +87,9 @@
 - [x] Test backpressure scenarios
 - [x] Add or update story documentation at docs/st04003-result-streaming.md (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added stream executor unit tests, schema coverage, and large-result integration coverage)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR ready for review
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1248 passed, 127 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (0 errors; warnings-only baseline outside story scope)
+- [x] Mark PR ready for review (PR #36 marked ready on 2026-02-19)
 - [ ] Wait for merge
 
 ---

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -6,7 +6,7 @@
 
 ### Checklist
 - [ ] Create branch `feat/st-04001-transaction-support`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title (PR #36)
 - [ ] Create `packages/tools/src/data/relational/query/transaction.ts`
 - [ ] Define `Transaction` interface
 - [ ] Implement transaction wrapper for multiple operations
@@ -25,8 +25,8 @@
 - [ ] Test nested transactions
 - [ ] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1248 passed, 127 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (0 errors; warnings-only baseline outside story scope)
 - [ ] Mark PR ready for review
 - [ ] Wait for merge
 
@@ -69,24 +69,24 @@
 
 ### Checklist
 - [x] Create branch `feat/st-04003-result-streaming`
-- [ ] Create draft PR with story ID in title
-- [ ] Create `packages/tools/src/data/relational/query/stream-executor.ts`
-- [ ] Implement streaming SELECT results for large datasets
-- [ ] Add configurable chunk size
-- [ ] Implement backpressure handling
-- [ ] Integrate with Node.js Readable streams
-- [ ] Add stream error handling
-- [ ] Add stream cancellation support
-- [ ] Create streaming version of SELECT tool (or add streaming option)
-- [ ] Add memory usage monitoring
-- [ ] Create memory usage benchmarks (streaming vs non-streaming)
-- [ ] Document when to use streaming vs regular queries
-- [ ] Create example usage in docs/
-- [ ] Create unit tests for stream executor
-- [ ] Create integration tests with large result sets
-- [ ] Test backpressure scenarios
-- [ ] Add or update story documentation at docs/st04003-result-streaming.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create draft PR with story ID in title (PR #36)
+- [x] Create `packages/tools/src/data/relational/query/stream-executor.ts`
+- [x] Implement streaming SELECT results for large datasets
+- [x] Add configurable chunk size
+- [x] Implement backpressure handling
+- [x] Integrate with Node.js Readable streams
+- [x] Add stream error handling
+- [x] Add stream cancellation support
+- [x] Create streaming version of SELECT tool (or add streaming option)
+- [x] Add memory usage monitoring
+- [x] Create memory usage benchmarks (streaming vs non-streaming)
+- [x] Document when to use streaming vs regular queries
+- [x] Create example usage in docs/
+- [x] Create unit tests for stream executor
+- [x] Create integration tests with large result sets
+- [x] Test backpressure scenarios
+- [x] Add or update story documentation at docs/st04003-result-streaming.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added stream executor unit tests, schema coverage, and large-result integration coverage)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR ready for review

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -27,7 +27,7 @@
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 1248 passed, 127 skipped)
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results (0 errors; warnings-only baseline outside story scope)
-- [ ] Mark PR ready for review
+- [x] Mark PR ready for review (PR #36 marked ready on 2026-02-19)
 - [ ] Wait for merge
 
 ---

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -68,7 +68,7 @@
 **Branch:** `feat/st-04003-result-streaming`
 
 ### Checklist
-- [ ] Create branch `feat/st-04003-result-streaming`
+- [x] Create branch `feat/st-04003-result-streaming`
 - [ ] Create draft PR with story ID in title
 - [ ] Create `packages/tools/src/data/relational/query/stream-executor.ts`
 - [ ] Implement streaming SELECT results for large datasets
@@ -102,4 +102,3 @@
 - [ ] Result streaming reduces memory usage
 - [ ] All tests passing
 - [ ] Performance benchmarks documented
-

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-19
-**Active Story:** ST-04003 (In Progress)
+**Active Story:** ST-04003 (In Review)
 
 ---
 

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-19
-**Active Story:** None (ST-02004 merged on 2026-02-19; next dependency-ready story: ST-02005)
+**Active Story:** ST-04003 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories (ST-04003, ST-03002, ST-05003, ST-04002, ST-02005)
-- **In Progress:** 0 stories
+- **Ready:** 4 stories (ST-03002, ST-05003, ST-04002, ST-02005)
+- **In Progress:** 1 story (ST-04003)
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories (waiting on dependencies)
@@ -13,13 +13,6 @@
 ---
 
 ## Ready
-
-### ST-04003: Implement Result Streaming
-- **Epic:** EP-04
-- **Priority:** P2
-- **Estimate:** 5 hours
-- **Dependencies:** ST-02002 ✅ (merged 2026-02-18)
-- **Checklist:** `planning/checklists/epic-04-story-tasks.md`
 
 ### ST-03002: Implement Schema Metadata Utilities
 - **Epic:** EP-03
@@ -53,7 +46,13 @@
 
 ## In Progress
 
-_No stories currently in progress_
+### ST-04003: Implement Result Streaming
+- **Epic:** EP-04
+- **Priority:** P2
+- **Estimate:** 5 hours
+- **Dependencies:** ST-02002 ✅ (merged 2026-02-18)
+- **Checklist:** `planning/checklists/epic-04-story-tasks.md`
+- **Branch:** `feat/st-04003-result-streaming`
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 4 stories (ST-03002, ST-05003, ST-04002, ST-02005)
-- **In Progress:** 1 story (ST-04003)
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story (ST-04003)
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories (waiting on dependencies)
 
@@ -46,6 +46,12 @@
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-04003: Implement Result Streaming
 - **Epic:** EP-04
 - **Priority:** P2
@@ -53,12 +59,7 @@
 - **Dependencies:** ST-02002 ✅ (merged 2026-02-18)
 - **Checklist:** `planning/checklists/epic-04-story-tasks.md`
 - **Branch:** `feat/st-04003-result-streaming`
-
----
-
-## In Review
-
-_No stories currently in review_
+- **PR:** [#36](https://github.com/TVScoundrel/agentforge/pull/36)
 
 ---
 


### PR DESCRIPTION
## Story
- ST-04003: Implement Result Streaming

## What Changed
- Added `packages/tools/src/data/relational/query/stream-executor.ts` with:
  - chunked SELECT streaming (`streamSelectChunks`)
  - Node.js `Readable` stream integration (`createSelectReadableStream`)
  - backpressure-aware async chunk processing (`executeStreamingSelect`)
  - cancellation support via `AbortSignal`
  - memory usage monitoring and benchmark helper (`benchmarkStreamingSelectMemory`)
- Added shared `buildSelectQuery` + SELECT types in `packages/tools/src/data/relational/query/query-builder.ts` and exported via `packages/tools/src/data/relational/query/index.ts`.
- Updated `relational-select` to support `streaming` options:
  - `enabled`, `chunkSize`, `maxRows`, `sampleSize`, `benchmark`
  - streaming metadata returned in successful responses.
- Added story documentation at `docs/st04003-result-streaming.md`.

## Acceptance Criteria Coverage
- [x] Streaming SELECT results for large datasets
- [x] Configurable chunk size
- [x] Backpressure handling
- [x] Memory usage benchmarks
- [x] Integration with Node.js streams
- [x] Example usage in documentation

## Validation Performed
- `pnpm test --run packages/tools/tests/data/relational/relational-select/index.test.ts`
- `pnpm test --run` -> 1248 passed, 127 skipped
- `pnpm lint` -> 0 errors (warnings-only baseline outside ST-04003 scope)

## Status
- Ready for review.
