### PR TITLE
feat(st-02005): implement type-safe delete tool

### DIFF
--- a/docs/st02005-type-safe-delete-tool.md
+++ b/docs/st02005-type-safe-delete-tool.md
@@ -1,0 +1,47 @@
+# ST-02005: Type-Safe DELETE Tool
+
+**Status:** 🚧 Draft PR  
+**Epic:** 02 - Query Execution and CRUD Operations
+
+## Overview
+
+Implemented a type-safe `relational-delete` tool with explicit safety controls, optional soft-delete mode, and clear foreign-key constraint handling.
+
+## Implementation Summary
+
+1. Shared DELETE query-builder support
+- Added `buildDeleteQuery(...)` in `packages/tools/src/data/relational/query/query-builder.ts`.
+- Supports WHERE conditions and full-table-delete safety gate (`allowFullTableDelete`).
+- Supports soft-delete behavior by generating UPDATE against a configurable column.
+
+2. New tool module
+- `packages/tools/src/data/relational/tools/relational-delete/index.ts`
+- `packages/tools/src/data/relational/tools/relational-delete/schemas.ts`
+- `packages/tools/src/data/relational/tools/relational-delete/types.ts`
+- `packages/tools/src/data/relational/tools/relational-delete/executor.ts`
+- `packages/tools/src/data/relational/tools/relational-delete/error-utils.ts`
+
+3. Tool export integration
+- Exported `relationalDelete` from `packages/tools/src/data/relational/tools/index.ts`.
+
+## Behavior and Safety
+
+- DELETE without WHERE is blocked by default.
+- Full-table delete requires explicit `allowFullTableDelete: true`.
+- Returns affected-row count (`rowCount`).
+- Soft delete is supported via `softDelete` options (default column `deleted_at`).
+- Foreign-key constraint violations return safe user-facing errors.
+- `cascade: true` adds actionable guidance for DB-level `ON DELETE CASCADE` configuration.
+
+## Tests Added
+
+- `packages/tools/tests/data/relational/relational-delete/index.test.ts`
+- `packages/tools/tests/data/relational/relational-delete/schema-validation.test.ts`
+- `packages/tools/tests/data/relational/relational-delete/query-builder.test.ts`
+- `packages/tools/tests/data/relational/relational-delete/tool-invocation.test.ts`
+- `packages/tools/tests/data/relational/relational-delete/test-utils.ts`
+
+## Validation
+
+- `pnpm test --run packages/tools/tests/data/relational/relational-delete/index.test.ts`
+- `pnpm test --run packages/tools/tests/data/relational`

--- a/docs/st02005-type-safe-delete-tool.md
+++ b/docs/st02005-type-safe-delete-tool.md
@@ -1,6 +1,6 @@
 # ST-02005: Type-Safe DELETE Tool
 
-**Status:** 🚧 Draft PR  
+**Status:** 👀 In Review  
 **Epic:** 02 - Query Execution and CRUD Operations
 
 ## Overview

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -32,6 +32,11 @@ export {
   type UpdateOptimisticLock,
   type UpdateQueryInput,
   type BuiltUpdateQuery,
+  buildDeleteQuery,
+  type DeleteWhereCondition,
+  type DeleteSoftDeleteOptions,
+  type DeleteQueryInput,
+  type BuiltDeleteQuery,
 } from './query-builder.js';
 
 export {

--- a/packages/tools/src/data/relational/tools/index.ts
+++ b/packages/tools/src/data/relational/tools/index.ts
@@ -7,4 +7,5 @@ export { relationalQuery } from './relational-query.js';
 export { relationalSelect } from './relational-select/index.js';
 export { relationalInsert } from './relational-insert/index.js';
 export { relationalUpdate } from './relational-update/index.js';
+export { relationalDelete } from './relational-delete/index.js';
 export { relationalGetSchema } from './relational-get-schema.js';

--- a/packages/tools/src/data/relational/tools/relational-delete/error-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/error-utils.ts
@@ -7,7 +7,10 @@ const SAFE_DELETE_VALIDATION_PATTERNS = [
   'contains invalid characters',
   'WHERE conditions are required for DELETE queries',
   'WHERE conditions are required unless allowFullTableDelete is true',
+  'value is required for this operator',
   'null is only allowed with isNull/isNotNull operators',
+  'operator requires a value',
+  'operator requires a string or number value',
   'operator requires a string value',
   'operator requires a non-empty array value',
   'must not include value',
@@ -15,7 +18,7 @@ const SAFE_DELETE_VALIDATION_PATTERNS = [
 
 const CONSTRAINT_VIOLATION_PATTERNS = [
   {
-    pattern: /(foreign key constraint|violates foreign key constraint|constraint failed)/i,
+    pattern: /(foreign key constraint|violates foreign key constraint|foreign key mismatch|a foreign key constraint fails)/i,
     message: 'Delete failed: foreign key constraint violation.',
   },
 ] as const;

--- a/packages/tools/src/data/relational/tools/relational-delete/error-utils.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/error-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * Helpers for classifying safe validation and constraint errors in relational-delete.
+ */
+
+const SAFE_DELETE_VALIDATION_PATTERNS = [
+  'must not be empty',
+  'contains invalid characters',
+  'WHERE conditions are required for DELETE queries',
+  'WHERE conditions are required unless allowFullTableDelete is true',
+  'null is only allowed with isNull/isNotNull operators',
+  'operator requires a string value',
+  'operator requires a non-empty array value',
+  'must not include value',
+] as const;
+
+const CONSTRAINT_VIOLATION_PATTERNS = [
+  {
+    pattern: /(foreign key constraint|violates foreign key constraint|constraint failed)/i,
+    message: 'Delete failed: foreign key constraint violation.',
+  },
+] as const;
+
+export function isSafeDeleteValidationError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return SAFE_DELETE_VALIDATION_PATTERNS.some((pattern) => error.message.includes(pattern));
+}
+
+export function getDeleteConstraintViolationMessage(error: unknown, cascade: boolean): string | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  for (const entry of CONSTRAINT_VIOLATION_PATTERNS) {
+    if (entry.pattern.test(error.message)) {
+      if (cascade) {
+        return `${entry.message} Verify database-level ON DELETE CASCADE is configured for related foreign keys.`;
+      }
+      return entry.message;
+    }
+  }
+
+  return null;
+}
+
+export function isSafeDeleteError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return isSafeDeleteValidationError(error) || error.message.startsWith('Delete failed:');
+}

--- a/packages/tools/src/data/relational/tools/relational-delete/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor.ts
@@ -1,0 +1,109 @@
+/**
+ * Query executor for relational DELETE operations
+ * @module tools/relational-delete/executor
+ */
+
+import { createLogger } from '@agentforge/core';
+import { buildDeleteQuery } from '../../query/query-builder.js';
+import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { RelationalDeleteInput, DeleteResult } from './types.js';
+import { getDeleteConstraintViolationMessage, isSafeDeleteValidationError } from './error-utils.js';
+
+const logger = createLogger('agentforge:tools:data:relational:delete');
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeAffectedRows(result: unknown): number {
+  if (Array.isArray(result)) {
+    if (result.length > 0 && result[0] && typeof result[0] === 'object') {
+      const first = result[0] as Record<string, unknown>;
+      const affectedRows = toNumber(first.affectedRows) ?? toNumber(first.rowCount) ?? toNumber(first.changes);
+      if (affectedRows !== undefined) {
+        return affectedRows;
+      }
+    }
+    return result.length;
+  }
+
+  if (result && typeof result === 'object') {
+    const resultRecord = result as Record<string, unknown>;
+    return toNumber(resultRecord.rowCount)
+      ?? toNumber(resultRecord.affectedRows)
+      ?? toNumber(resultRecord.changes)
+      ?? (Array.isArray(resultRecord.rows) ? resultRecord.rows.length : 0);
+  }
+
+  return 0;
+}
+
+/**
+ * Execute a DELETE query using the shared query builder.
+ */
+export async function executeDelete(
+  manager: ConnectionManager,
+  input: RelationalDeleteInput
+): Promise<DeleteResult> {
+  const startTime = Date.now();
+
+  logger.debug('Building DELETE query', {
+    vendor: input.vendor,
+    table: input.table,
+    hasWhere: !!input.where?.length,
+    allowFullTableDelete: input.allowFullTableDelete,
+    cascade: input.cascade,
+    softDelete: !!input.softDelete,
+  });
+
+  try {
+    const built = buildDeleteQuery({
+      table: input.table,
+      where: input.where,
+      allowFullTableDelete: input.allowFullTableDelete,
+      softDelete: input.softDelete,
+      vendor: input.vendor,
+    });
+
+    const rawResult = await manager.execute(built.query);
+    const rowCount = normalizeAffectedRows(rawResult);
+    const executionTime = Date.now() - startTime;
+
+    logger.debug('DELETE query executed successfully', {
+      vendor: input.vendor,
+      table: input.table,
+      rowCount,
+      executionTime,
+      softDelete: built.usesSoftDelete,
+      cascade: input.cascade,
+    });
+
+    return {
+      rowCount,
+      executionTime,
+      softDeleted: built.usesSoftDelete,
+    };
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+
+    logger.error('DELETE query execution failed', {
+      vendor: input.vendor,
+      table: input.table,
+      error: error instanceof Error ? error.message : String(error),
+      executionTime,
+      cascade: input.cascade,
+      softDelete: !!input.softDelete,
+    });
+
+    const constraintMessage = getDeleteConstraintViolationMessage(error, input.cascade);
+    if (constraintMessage) {
+      throw new Error(constraintMessage, { cause: error });
+    }
+
+    if (isSafeDeleteValidationError(error)) {
+      throw error;
+    }
+
+    throw new Error('DELETE query failed. See logs for details.', { cause: error });
+  }
+}

--- a/packages/tools/src/data/relational/tools/relational-delete/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Relational DELETE Tool
+ *
+ * Type-safe DELETE operations using Drizzle ORM query builder.
+ * Supports WHERE conditions, full-table delete protection, and optional soft delete mode.
+ *
+ * @module tools/relational-delete
+ */
+
+import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { ConnectionManager } from '../../connection/connection-manager.js';
+import { relationalDeleteSchema } from './schemas.js';
+import { executeDelete } from './executor.js';
+import type { RelationalDeleteInput, DeleteResponse } from './types.js';
+import { isSafeDeleteError } from './error-utils.js';
+
+export * from './types.js';
+export * from './schemas.js';
+
+export const relationalDelete = toolBuilder()
+  .name('relational-delete')
+  .displayName('Relational DELETE')
+  .description('Execute type-safe DELETE queries with WHERE conditions and full-table delete protection')
+  .category(ToolCategory.DATABASE)
+  .tags(['database', 'sql', 'delete', 'postgresql', 'mysql', 'sqlite'])
+  .schema(relationalDeleteSchema)
+  .example({
+    description: 'Delete one row by condition',
+    input: {
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 123 }],
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/mydb',
+    },
+  })
+  .example({
+    description: 'Soft delete rows',
+    input: {
+      table: 'users',
+      where: [{ column: 'status', operator: 'eq', value: 'inactive' }],
+      softDelete: { column: 'deleted_at' },
+      vendor: 'sqlite',
+      connectionString: 'data.db',
+    },
+  })
+  .implement(async (input: RelationalDeleteInput): Promise<DeleteResponse> => {
+    const manager = new ConnectionManager({
+      vendor: input.vendor,
+      connection: input.connectionString,
+    });
+
+    try {
+      await manager.connect();
+
+      const result = await executeDelete(manager, input);
+
+      return {
+        success: true,
+        rowCount: result.rowCount,
+        executionTime: result.executionTime,
+        softDeleted: result.softDeleted,
+      };
+    } catch (error) {
+      let errorMessage = 'Failed to execute DELETE query. Please verify your input and database connection.';
+
+      if (isSafeDeleteError(error)) {
+        errorMessage = error.message;
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+        rowCount: 0,
+        softDeleted: false,
+      };
+    } finally {
+      await manager.disconnect();
+    }
+  })
+  .build();

--- a/packages/tools/src/data/relational/tools/relational-delete/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/schemas.ts
@@ -85,6 +85,17 @@ export const deleteWhereConditionSchema = z.object({
       path: ['value'],
       message: 'LIKE operator requires a string value',
     });
+    return;
+  }
+
+  if ((op === 'gt' || op === 'lt' || op === 'gte' || op === 'lte') &&
+      typeof value.value !== 'string' &&
+      typeof value.value !== 'number') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: `${op.toUpperCase()} operator requires a string or number value`,
+    });
   }
 });
 

--- a/packages/tools/src/data/relational/tools/relational-delete/schemas.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/schemas.ts
@@ -1,0 +1,120 @@
+/**
+ * Zod schemas for relational DELETE operations
+ * @module tools/relational-delete/schemas
+ */
+
+import { z } from 'zod';
+import { VALID_QUALIFIED_IDENTIFIER_PATTERN } from '../../utils/identifier-utils.js';
+
+export const deleteWhereOperatorSchema = z.enum([
+  'eq',
+  'ne',
+  'gt',
+  'lt',
+  'gte',
+  'lte',
+  'like',
+  'in',
+  'notIn',
+  'isNull',
+  'isNotNull',
+]);
+
+export const deleteWhereConditionSchema = z.object({
+  column: z.string().min(1, 'Column name must not be empty').describe('Column name to filter on'),
+  operator: deleteWhereOperatorSchema.describe('Comparison operator'),
+  value: z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.union([z.string(), z.number()])),
+    z.null(),
+  ]).optional().describe('Value to compare against (not required for isNull/isNotNull)'),
+}).superRefine((value, ctx) => {
+  const op = value.operator;
+
+  if (op === 'isNull' || op === 'isNotNull') {
+    if (value.value !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: 'value must not be provided when using isNull or isNotNull operator',
+      });
+    }
+    return;
+  }
+
+  if (value.value === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'value is required for this operator',
+    });
+    return;
+  }
+
+  if (op === 'in' || op === 'notIn') {
+    if (!Array.isArray(value.value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: `${op === 'in' ? 'IN' : 'NOT IN'} operator requires an array value`,
+      });
+    } else if (value.value.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: `${op === 'in' ? 'IN' : 'NOT IN'} operator requires a non-empty array value`,
+      });
+    }
+    return;
+  }
+
+  if (value.value === null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'null is only allowed with isNull/isNotNull operators',
+    });
+    return;
+  }
+
+  if (op === 'like' && typeof value.value !== 'string') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'LIKE operator requires a string value',
+    });
+  }
+});
+
+export const deleteSoftDeleteSchema = z.object({
+  column: z.string().min(1, 'Soft delete column must not be empty').default('deleted_at').describe('Column to write deletion timestamp/value into'),
+  value: z.union([z.string(), z.number()]).optional().describe('Optional explicit value for the soft-delete column (defaults to ISO timestamp)'),
+}).describe('Enable soft delete by updating a column instead of physically deleting rows');
+
+export const relationalDeleteSchema = z.object({
+  table: z.string()
+    .min(1, 'Table name is required')
+    .regex(
+      VALID_QUALIFIED_IDENTIFIER_PATTERN,
+      'Table name contains invalid characters. Only alphanumeric characters, underscores, and dots (for schema qualification) are allowed.'
+    )
+    .describe('Table name to delete from (schema-qualified names supported, e.g. public.users)'),
+  where: z.array(deleteWhereConditionSchema).optional().describe('WHERE conditions (combined with AND)'),
+  allowFullTableDelete: z.boolean().default(false).describe('Explicitly allow DELETE without WHERE conditions'),
+  cascade: z.boolean().default(false).describe('Enable cascade-aware error messaging for foreign key constraints'),
+  softDelete: deleteSoftDeleteSchema.optional().describe('Use soft-delete semantics instead of hard DELETE'),
+  vendor: z.enum(['postgresql', 'mysql', 'sqlite']).describe('Database vendor'),
+  connectionString: z.string().min(1, 'Database connection string is required').describe('Database connection string'),
+}).superRefine((value, ctx) => {
+  const hasWhere = (value.where?.length ?? 0) > 0;
+
+  if (!value.allowFullTableDelete && !hasWhere) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['where'],
+      message: 'WHERE conditions are required unless allowFullTableDelete is true',
+    });
+  }
+});

--- a/packages/tools/src/data/relational/tools/relational-delete/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Type definitions for relational DELETE operations
+ * @module tools/relational-delete/types
+ */
+
+import type { z } from 'zod';
+import type {
+  deleteWhereOperatorSchema,
+  deleteWhereConditionSchema,
+  deleteSoftDeleteSchema,
+  relationalDeleteSchema,
+} from './schemas.js';
+
+export type DeleteWhereOperator = z.infer<typeof deleteWhereOperatorSchema>;
+export type DeleteWhereCondition = z.infer<typeof deleteWhereConditionSchema>;
+export type DeleteSoftDeleteOptions = z.infer<typeof deleteSoftDeleteSchema>;
+
+export type RelationalDeleteInput = z.infer<typeof relationalDeleteSchema>;
+
+export interface DeleteResult {
+  rowCount: number;
+  executionTime: number;
+  softDeleted: boolean;
+}
+
+export interface DeleteSuccessResponse {
+  success: true;
+  rowCount: number;
+  executionTime: number;
+  softDeleted: boolean;
+}
+
+export interface DeleteErrorResponse {
+  success: false;
+  error: string;
+  rowCount: 0;
+  softDeleted: false;
+}
+
+export type DeleteResponse = DeleteSuccessResponse | DeleteErrorResponse;

--- a/packages/tools/tests/data/relational/relational-delete/error-utils.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/error-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDeleteConstraintViolationMessage,
+  isSafeDeleteValidationError,
+} from '../../../../src/data/relational/tools/relational-delete/error-utils.js';
+
+describe('relational-delete error utils', () => {
+  describe('isSafeDeleteValidationError', () => {
+    it('treats GT/LT/GTE/LTE type errors as safe validation errors', () => {
+      const error = new Error('GT operator requires a string or number value for column age');
+
+      expect(isSafeDeleteValidationError(error)).toBe(true);
+    });
+
+    it('treats EQ/NE missing-value errors as safe validation errors', () => {
+      const error = new Error('EQ operator requires a value for column id');
+
+      expect(isSafeDeleteValidationError(error)).toBe(true);
+    });
+  });
+
+  describe('getDeleteConstraintViolationMessage', () => {
+    it('returns FK guidance for foreign key constraint errors', () => {
+      const error = new Error('FOREIGN KEY constraint failed');
+
+      expect(getDeleteConstraintViolationMessage(error, false)).toBe(
+        'Delete failed: foreign key constraint violation.'
+      );
+      expect(getDeleteConstraintViolationMessage(error, true)).toContain(
+        'Verify database-level ON DELETE CASCADE is configured'
+      );
+    });
+
+    it('does not misclassify non-FK constraint errors', () => {
+      const error = new Error('UNIQUE constraint failed: users.email');
+
+      expect(getDeleteConstraintViolationMessage(error, false)).toBeNull();
+    });
+  });
+});

--- a/packages/tools/tests/data/relational/relational-delete/index.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/index.test.ts
@@ -5,3 +5,4 @@
 import './schema-validation.test.js';
 import './query-builder.test.js';
 import './tool-invocation.test.js';
+import './error-utils.test.js';

--- a/packages/tools/tests/data/relational/relational-delete/index.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/index.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Relational DELETE Tool Tests
+ */
+
+import './schema-validation.test.js';
+import './query-builder.test.js';
+import './tool-invocation.test.js';

--- a/packages/tools/tests/data/relational/relational-delete/query-builder.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/query-builder.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Query Builder Tests for Relational DELETE
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import { buildDeleteQuery } from '../../../../src/data/relational/query/query-builder.js';
+import type { ConnectionConfig } from '../../../../src/data/relational/connection/types.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+function extractRows(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result as Array<Record<string, unknown>>;
+  }
+
+  if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown[] }).rows)) {
+    return (result as { rows: Array<Record<string, unknown>> }).rows;
+  }
+
+  return [];
+}
+
+describe('Relational DELETE - Query Builder', () => {
+  let manager: ConnectionManager;
+
+  beforeAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    const config: ConnectionConfig = {
+      vendor: 'sqlite',
+      connection: ':memory:',
+    };
+
+    manager = new ConnectionManager(config);
+    await manager.connect();
+
+    await manager.execute(sql.raw(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE,
+        deleted_at TEXT
+      );
+    `));
+
+    await manager.execute(sql.raw(`
+      INSERT INTO users (name, email)
+      VALUES
+        ('Alice', 'alice@example.com'),
+        ('Bob', 'bob@example.com');
+    `));
+  });
+
+  afterAll(async () => {
+    if (!hasSQLiteBindings) {
+      return;
+    }
+
+    await manager.disconnect();
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should build and execute DELETE with WHERE', async () => {
+    const built = buildDeleteQuery({
+      table: 'users',
+      where: [{ column: 'email', operator: 'eq', value: 'alice@example.com' }],
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT email FROM users ORDER BY id
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ email: 'bob@example.com' });
+  });
+
+  it('should reject DELETE without WHERE by default', () => {
+    expect(() =>
+      buildDeleteQuery({
+        table: 'users',
+        vendor: 'sqlite',
+      })
+    ).toThrow(/WHERE conditions are required for DELETE queries/i);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should allow full-table delete when explicitly enabled', async () => {
+    await manager.execute(sql.raw(`
+      INSERT INTO users (name, email)
+      VALUES ('Carol', 'carol@example.com')
+    `));
+
+    const built = buildDeleteQuery({
+      table: 'users',
+      allowFullTableDelete: true,
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`SELECT id FROM users`)));
+    expect(rows).toHaveLength(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should support soft delete mode', async () => {
+    await manager.execute(sql.raw(`
+      INSERT INTO users (name, email)
+      VALUES ('Dave', 'dave@example.com')
+    `));
+
+    const built = buildDeleteQuery({
+      table: 'users',
+      where: [{ column: 'email', operator: 'eq', value: 'dave@example.com' }],
+      softDelete: { column: 'deleted_at', value: '2026-02-19T00:00:00.000Z' },
+      vendor: 'sqlite',
+    });
+
+    await manager.execute(built.query);
+
+    const rows = extractRows(await manager.execute(sql.raw(`
+      SELECT email, deleted_at
+      FROM users
+      WHERE email = 'dave@example.com'
+    `)));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      email: 'dave@example.com',
+      deleted_at: '2026-02-19T00:00:00.000Z',
+    });
+  });
+});

--- a/packages/tools/tests/data/relational/relational-delete/schema-validation.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/schema-validation.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Schema Validation Tests for Relational DELETE Tool
+ */
+
+import { describe, it, expect } from 'vitest';
+import { relationalDelete } from '../../../../src/data/relational/tools/relational-delete/index.js';
+
+describe('Relational DELETE - Schema Validation', () => {
+  it('should accept valid DELETE with WHERE condition', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject DELETE without WHERE when allowFullTableDelete is false', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users',
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept DELETE without WHERE when allowFullTableDelete is true', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users',
+      allowFullTableDelete: true,
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/test',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept soft-delete configuration', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      softDelete: { column: 'deleted_at' },
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject malformed table name', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users; DROP TABLE users',
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: ':memory:',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty connection string', () => {
+    const result = relationalDelete.schema.safeParse({
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+      vendor: 'sqlite',
+      connectionString: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-delete/test-utils.ts
+++ b/packages/tools/tests/data/relational/relational-delete/test-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Test utilities for relational DELETE tests
+ */
+
+export const hasSQLiteBindings = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const db = new Database(':memory:');
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+})();

--- a/packages/tools/tests/data/relational/relational-delete/tool-invocation.test.ts
+++ b/packages/tools/tests/data/relational/relational-delete/tool-invocation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tool Invocation Tests for Relational DELETE Tool
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { relationalDelete } from '../../../../src/data/relational/tools/relational-delete/index.js';
+import { hasSQLiteBindings } from './test-utils.js';
+
+async function createTestDatabase(): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require('better-sqlite3');
+  const path = await import('path');
+  const os = await import('os');
+  const fs = await import('fs');
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relational-delete-test-'));
+  const dbPath = path.join(tmpDir, 'test.db');
+
+  const db = new Database(dbPath);
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      deleted_at TEXT
+    );
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      token TEXT NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    INSERT INTO users (name, email)
+    VALUES
+      ('Alice', 'alice@example.com'),
+      ('Bob', 'bob@example.com'),
+      ('Carol', 'carol@example.com');
+
+    INSERT INTO sessions (user_id, token)
+    VALUES
+      (1, 'session-1'),
+      (1, 'session-2');
+  `);
+  db.close();
+
+  return dbPath;
+}
+
+describe('Relational DELETE - Tool Invocation', () => {
+  let dbPath: string | undefined;
+
+  const getDbPath = (): string => {
+    if (!dbPath) {
+      throw new Error('SQLite test database path was not initialized');
+    }
+    return dbPath;
+  };
+
+  beforeAll(async () => {
+    if (hasSQLiteBindings) {
+      dbPath = await createTestDatabase();
+    }
+  });
+
+  afterAll(async () => {
+    if (dbPath) {
+      const fs = await import('fs');
+      const path = await import('path');
+      try {
+        fs.unlinkSync(dbPath);
+        fs.rmdirSync(path.dirname(dbPath));
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should delete one row with WHERE condition', async () => {
+    const result = await relationalDelete.invoke({
+      table: 'users',
+      where: [{ column: 'email', operator: 'eq', value: 'bob@example.com' }],
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(1);
+    expect(result.softDeleted).toBe(false);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should prevent full-table delete by default', async () => {
+    const result = await relationalDelete.invoke({
+      table: 'users',
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/WHERE conditions are required/i);
+    expect(result.rowCount).toBe(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should allow full-table delete when explicitly enabled', async () => {
+    const result = await relationalDelete.invoke({
+      table: 'sessions',
+      allowFullTableDelete: true,
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should soft-delete rows when configured', async () => {
+    const result = await relationalDelete.invoke({
+      table: 'users',
+      where: [{ column: 'email', operator: 'eq', value: 'carol@example.com' }],
+      softDelete: { column: 'deleted_at', value: '2026-02-19T00:00:00.000Z' },
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rowCount).toBe(1);
+    expect(result.softDeleted).toBe(true);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('should return clear foreign key message and cascade guidance', async () => {
+    const result = await relationalDelete.invoke({
+      table: 'users',
+      where: [{ column: 'email', operator: 'eq', value: 'alice@example.com' }],
+      cascade: true,
+      vendor: 'sqlite',
+      connectionString: getDbPath(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('foreign key constraint violation');
+    expect(result.error).toContain('ON DELETE CASCADE');
+    expect(result.rowCount).toBe(0);
+  });
+});

--- a/packages/tools/tests/data/relational/schema-diff.test.ts
+++ b/packages/tools/tests/data/relational/schema-diff.test.ts
@@ -245,7 +245,7 @@ describe('schema-diff > JSON export/import', () => {
     const lines = json.split('\n');
     // Top-level keys should appear in alphabetical order
     const topKeys = lines
-      .filter((l) => l.match(/^  "/))
+      .filter((l) => l.match(/^ {2}"/))
       .map((l) => l.match(/"([^"]+)"/)![1]);
     const sorted = [...topKeys].sort();
     expect(topKeys).toEqual(sorted);

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -129,24 +129,24 @@
 **Branch:** `feat/st-02005-type-safe-delete-tool`
 
 ### Checklist
-- [ ] Create branch `feat/st-02005-type-safe-delete-tool`
+- [x] Create branch `feat/st-02005-type-safe-delete-tool`
 - [ ] Create draft PR with story ID in title
-- [ ] Extend query builder with DELETE support
-- [ ] Add support for WHERE conditions (required for safety)
-- [ ] Add support for returning count of deleted rows
-- [ ] Create `packages/tools/src/data/relational/tools/relational-delete.ts`
-- [ ] Define Zod schema for tool input (table, where, allowFullTableDelete)
-- [ ] Implement tool function using query builder
-- [ ] Prevent accidental full-table deletes (require explicit flag)
-- [ ] Add cascade delete handling
-- [ ] Add soft delete support (optional, deletedAt field)
-- [ ] Handle foreign key constraint violations
-- [ ] Export tool from `tools/index.ts`
-- [ ] Create unit tests for DELETE query builder
-- [ ] Create unit tests for relational-delete tool
-- [ ] Test full-table delete prevention
-- [ ] Add or update story documentation at docs/st02005-type-safe-delete-tool.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Extend query builder with DELETE support
+- [x] Add support for WHERE conditions (required for safety)
+- [x] Add support for returning count of deleted rows
+- [x] Create relational-delete tool module at `packages/tools/src/data/relational/tools/relational-delete/`
+- [x] Define Zod schema for tool input (table, where, allowFullTableDelete)
+- [x] Implement tool function using query builder
+- [x] Prevent accidental full-table deletes (require explicit flag)
+- [x] Add cascade delete handling
+- [x] Add soft delete support (optional, deletedAt field)
+- [x] Handle foreign key constraint violations
+- [x] Export tool from `tools/index.ts`
+- [x] Create unit tests for DELETE query builder
+- [x] Create unit tests for relational-delete tool
+- [x] Test full-table delete prevention
+- [x] Add or update story documentation at docs/st02005-type-safe-delete-tool.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added relational-delete schema + query-builder + tool invocation tests)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR ready for review

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -130,7 +130,7 @@
 
 ### Checklist
 - [x] Create branch `feat/st-02005-type-safe-delete-tool`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title (PR #38)
 - [x] Extend query builder with DELETE support
 - [x] Add support for WHERE conditions (required for safety)
 - [x] Add support for returning count of deleted rows

--- a/planning/checklists/epic-02-story-tasks.md
+++ b/planning/checklists/epic-02-story-tasks.md
@@ -147,9 +147,9 @@
 - [x] Test full-table delete prevention
 - [x] Add or update story documentation at docs/st02005-type-safe-delete-tool.md (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added relational-delete schema + query-builder + tool invocation tests)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR ready for review
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 112 passed, 4 skipped files; 1334 passed, 143 skipped tests)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (`pnpm lint` -> 0 errors; warnings-only baseline across workspace)
+- [x] Mark PR ready for review (PR #38 marked ready on 2026-02-20)
 - [ ] Wait for merge
 
 ---

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-19
-**Active Story:** None (queue ready for next pick)
+**Active Story:** ST-02005 (In Progress)
 
 ---
 

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -1,9 +1,9 @@
 # Feature Plan: Vendor-Agnostic Relational Database Access Tool
 
 **Epic Range:** EP-01 through EP-05  
-**Status:** In Progress  
-**Last Updated:** 2026-02-19
-**Active Story:** ST-02005 (In Progress)
+**Status:** In Review  
+**Last Updated:** 2026-02-20
+**Active Story:** ST-02005 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories (ST-05003, ST-04002, ST-02005, ST-05001)
-- **In Progress:** 0 stories
+- **Ready:** 3 stories (ST-05003, ST-04002, ST-05001)
+- **In Progress:** 1 story (ST-02005)
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories (waiting on dependencies)
@@ -28,13 +28,6 @@
 - **Dependencies:** ST-02003 ✅ (merged 2026-02-19)
 - **Checklist:** `planning/checklists/epic-04-story-tasks.md`
 
-### ST-02005: Implement Type-Safe DELETE Tool
-- **Epic:** EP-02
-- **Priority:** P0
-- **Estimate:** 3 hours
-- **Dependencies:** ST-02004 ✅ (merged 2026-02-19)
-- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
-
 ### ST-05001: Implement Comprehensive Unit Tests
 - **Epic:** EP-05
 - **Priority:** P0
@@ -47,7 +40,13 @@
 
 ## In Progress
 
-_No stories currently in progress_
+### ST-02005: Implement Type-Safe DELETE Tool
+- **Epic:** EP-02
+- **Priority:** P0
+- **Estimate:** 3 hours
+- **Dependencies:** ST-02004 ✅ (merged 2026-02-19)
+- **Checklist:** `planning/checklists/epic-02-story-tasks.md`
+- **Branch:** `feat/st-02005-type-safe-delete-tool`
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: Relational Database Access Tool
 
-**Last Updated:** 2026-02-19
+**Last Updated:** 2026-02-20
 
 ## Queue Status Summary
 
 - **Ready:** 3 stories (ST-05003, ST-04002, ST-05001)
-- **In Progress:** 1 story (ST-02005)
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story (ST-02005)
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories (waiting on dependencies)
 
@@ -40,6 +40,12 @@
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-02005: Implement Type-Safe DELETE Tool
 - **Epic:** EP-02
 - **Priority:** P0
@@ -47,12 +53,6 @@
 - **Dependencies:** ST-02004 ✅ (merged 2026-02-19)
 - **Checklist:** `planning/checklists/epic-02-story-tasks.md`
 - **Branch:** `feat/st-02005-type-safe-delete-tool`
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 


### PR DESCRIPTION
## Story
- ST-02005: Implement Type-Safe DELETE Tool

## What Changed
- Extended shared query builder with DELETE support in `packages/tools/src/data/relational/query/query-builder.ts`:
  - `buildDeleteQuery(...)`
  - WHERE conditions support
  - full-table delete protection
  - optional soft-delete query generation
- Added new `relational-delete` tool module:
  - `packages/tools/src/data/relational/tools/relational-delete/index.ts`
  - `packages/tools/src/data/relational/tools/relational-delete/schemas.ts`
  - `packages/tools/src/data/relational/tools/relational-delete/types.ts`
  - `packages/tools/src/data/relational/tools/relational-delete/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-delete/error-utils.ts`
- Exported `relationalDelete` from `packages/tools/src/data/relational/tools/index.ts`.
- Added focused tests under `packages/tools/tests/data/relational/relational-delete/`:
  - `query-builder.test.ts`
  - `schema-validation.test.ts`
  - `tool-invocation.test.ts`
  - `index.test.ts`

## Acceptance Criteria Coverage
- [x] `relational-delete` tool with query builder support
- [x] Support for WHERE conditions (required for safety)
- [x] Return count of deleted rows
- [x] Prevent accidental full-table deletes (require explicit flag)
- [x] Cascade delete handling (foreign-key constraint guidance)
- [x] Soft delete support (optional)

## Validation Performed
- `pnpm test --run packages/tools/tests/data/relational/relational-delete/index.test.ts`
- `pnpm test --run packages/tools/tests/data/relational`
- `pnpm test --run` → `112 passed | 4 skipped` files, `1334 passed | 143 skipped` tests
- `pnpm lint` → `0 errors` (warnings-only baseline across workspace)

## Status
- Ready for review.

## Reviewer Note
- Baseline lint fix included in this PR: `packages/tools/tests/data/relational/schema-diff.test.ts` regex updated to satisfy `no-regex-spaces`.
