### PR TITLE
feat(st-04001): implement transaction support

### DIFF
--- a/docs/relational-transaction-examples.md
+++ b/docs/relational-transaction-examples.md
@@ -1,0 +1,51 @@
+# Relational Transaction Examples
+
+This document shows how to use the relational transaction helper for multi-step operations.
+
+## Basic Transaction
+
+```ts
+import { ConnectionManager } from '@agentforge/tools/data/relational/connection';
+import { withTransaction } from '@agentforge/tools/data/relational/query';
+import { sql } from 'drizzle-orm';
+
+const manager = new ConnectionManager({
+  vendor: 'postgresql',
+  connection: process.env.DATABASE_URL!,
+});
+
+await manager.connect();
+
+await withTransaction(manager, async (transaction) => {
+  await transaction.execute(sql`UPDATE accounts SET balance = balance - ${100} WHERE id = ${1}`);
+  await transaction.execute(sql`UPDATE accounts SET balance = balance + ${100} WHERE id = ${2}`);
+});
+```
+
+## Nested Transaction with Savepoint
+
+```ts
+await withTransaction(manager, async (transaction) => {
+  await transaction.execute(sql`INSERT INTO orders (id, status) VALUES (${1001}, ${'pending'})`);
+
+  await transaction.withSavepoint(async (nested) => {
+    await nested.execute(sql`INSERT INTO order_items (order_id, sku) VALUES (${1001}, ${'SKU-1'})`);
+    await nested.execute(sql`INSERT INTO order_items (order_id, sku) VALUES (${1001}, ${'SKU-2'})`);
+  });
+});
+```
+
+## Isolation Level and Timeout
+
+```ts
+await withTransaction(
+  manager,
+  async (transaction) => {
+    await transaction.execute(sql`UPDATE inventory SET reserved = reserved + ${1} WHERE product_id = ${42}`);
+  },
+  {
+    isolationLevel: 'serializable',
+    timeoutMs: 5000,
+  }
+);
+```

--- a/docs/relational-transaction-examples.md
+++ b/docs/relational-transaction-examples.md
@@ -5,8 +5,7 @@ This document shows how to use the relational transaction helper for multi-step 
 ## Basic Transaction
 
 ```ts
-import { ConnectionManager } from '@agentforge/tools/data/relational/connection';
-import { withTransaction } from '@agentforge/tools/data/relational/query';
+import { ConnectionManager, withTransaction } from '@agentforge/tools';
 import { sql } from 'drizzle-orm';
 
 const manager = new ConnectionManager({

--- a/docs/st04001-transaction-support.md
+++ b/docs/st04001-transaction-support.md
@@ -1,0 +1,51 @@
+# ST-04001: Transaction Support
+
+**Status:** 🚧 Draft PR  
+**Epic:** 04 - Advanced Features and Optimization
+
+## Overview
+
+Implemented foundational transaction support for relational operations with:
+- single-connection transaction execution
+- commit/rollback lifecycle handling
+- nested savepoints
+- isolation level and timeout options
+- transaction context plumbing for query and CRUD executors
+
+## Implementation Summary
+
+1. Transaction primitives
+- Added `packages/tools/src/data/relational/query/transaction.ts`.
+- Exposed `withTransaction(...)` and `TransactionContext`.
+- Supports:
+  - automatic `BEGIN` + `COMMIT` on success
+  - automatic `ROLLBACK` on failure
+  - nested savepoints via `withSavepoint(...)`
+  - isolation level options
+  - timeout option (`timeoutMs`)
+
+2. Dedicated connection/session execution
+- Added `executeInConnection(...)` to `ConnectionManager`:
+  - PostgreSQL: acquires a pooled client for callback scope
+  - MySQL: acquires a pooled connection for callback scope
+  - SQLite: uses existing single-connection session
+- Added `getVendor()` helper for transaction initialization logic.
+
+3. Transaction context support in executors
+- Added optional execution context (`transaction`) to:
+  - `query-executor`
+  - `relational-select` executor
+  - `relational-insert` executor
+  - `relational-update` executor
+  - `relational-delete` executor
+- When provided, queries execute through transaction context instead of the manager.
+
+4. Documentation and examples
+- Added examples: `docs/relational-transaction-examples.md`.
+
+## Validation
+
+- `pnpm test --run packages/tools/tests/data/relational/transaction.test.ts packages/tools/tests/data/relational/relational-delete/index.test.ts packages/tools/tests/data/relational/relational-update/index.test.ts packages/tools/tests/data/relational/relational-insert/index.test.ts`
+  - relational CRUD suites passed
+  - transaction integration suite is conditionally skipped when native SQLite bindings are unavailable
+- `pnpm --filter @agentforge/tools lint` (0 errors, warnings-only baseline)

--- a/docs/st04001-transaction-support.md
+++ b/docs/st04001-transaction-support.md
@@ -1,6 +1,6 @@
 # ST-04001: Transaction Support
 
-**Status:** 🚧 Draft PR  
+**Status:** 👀 In Review  
 **Epic:** 04 - Advanced Features and Optimization
 
 ## Overview

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -612,7 +612,7 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     callback: (execute: (query: SQL) => Promise<unknown>) => Promise<T>
   ): Promise<T> {
     if (!this.client || !this.db) {
-      throw new Error('Database not initialized. Call initialize() first.');
+      throw new Error('Database not initialized. Call connect() first.');
     }
 
     if (this.vendor === 'sqlite') {

--- a/packages/tools/src/data/relational/query/index.ts
+++ b/packages/tools/src/data/relational/query/index.ts
@@ -6,7 +6,8 @@
 export type {
   QueryParams,
   QueryInput,
-  QueryExecutionResult
+  QueryExecutionResult,
+  SqlExecutor,
 } from './types.js';
 
 export { executeQuery } from './query-executor.js';
@@ -51,3 +52,10 @@ export {
   type StreamingMemoryUsage,
   type StreamingBenchmarkResult,
 } from './stream-executor.js';
+
+export {
+  withTransaction,
+  type TransactionOptions,
+  type TransactionIsolationLevel,
+  type TransactionContext,
+} from './transaction.js';

--- a/packages/tools/src/data/relational/query/transaction.ts
+++ b/packages/tools/src/data/relational/query/transaction.ts
@@ -1,0 +1,289 @@
+/**
+ * Transaction helpers for relational databases.
+ * @module query/transaction
+ */
+
+import { createLogger } from '@agentforge/core';
+import { sql, type SQL } from 'drizzle-orm';
+import type { ConnectionManager } from '../connection/connection-manager.js';
+import type { DatabaseVendor } from '../types.js';
+import type { SqlExecutor } from './types.js';
+
+const logger = createLogger('agentforge:tools:data:relational:transaction');
+
+let transactionSequence = 0;
+
+export type TransactionIsolationLevel =
+  | 'read uncommitted'
+  | 'read committed'
+  | 'repeatable read'
+  | 'serializable';
+
+export interface TransactionOptions {
+  isolationLevel?: TransactionIsolationLevel;
+  timeoutMs?: number;
+}
+
+interface ResolvedTransactionOptions {
+  isolationLevel?: TransactionIsolationLevel;
+  timeoutMs?: number;
+}
+
+export interface TransactionContext extends SqlExecutor {
+  id: string;
+  vendor: DatabaseVendor;
+  isActive(): boolean;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+  createSavepoint(name?: string): Promise<string>;
+  rollbackToSavepoint(name: string): Promise<void>;
+  releaseSavepoint(name: string): Promise<void>;
+  withSavepoint<T>(operation: (transaction: TransactionContext) => Promise<T>, name?: string): Promise<T>;
+}
+
+function toSqlIsolationLevel(level: TransactionIsolationLevel): string {
+  switch (level) {
+    case 'read uncommitted':
+      return 'READ UNCOMMITTED';
+    case 'read committed':
+      return 'READ COMMITTED';
+    case 'repeatable read':
+      return 'REPEATABLE READ';
+    case 'serializable':
+      return 'SERIALIZABLE';
+  }
+}
+
+function resolveOptions(options?: TransactionOptions): ResolvedTransactionOptions {
+  if (!options) {
+    return {};
+  }
+
+  if (options.timeoutMs !== undefined && (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)) {
+    throw new Error('Transaction timeout must be a positive number');
+  }
+
+  return {
+    isolationLevel: options.isolationLevel,
+    timeoutMs: options.timeoutMs,
+  };
+}
+
+function withTimeout<T>(operation: Promise<T>, timeoutMs?: number): Promise<T> {
+  if (!timeoutMs) {
+    return operation;
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Transaction timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    operation
+      .then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+class ManagedTransaction implements TransactionContext {
+  public readonly id: string;
+  public readonly vendor: DatabaseVendor;
+  private readonly options: ResolvedTransactionOptions;
+  private readonly executeQuery: (query: SQL) => Promise<unknown>;
+  private completed = false;
+  private savepointCounter = 0;
+
+  constructor(args: {
+    id: string;
+    vendor: DatabaseVendor;
+    executeQuery: (query: SQL) => Promise<unknown>;
+    options: ResolvedTransactionOptions;
+  }) {
+    this.id = args.id;
+    this.vendor = args.vendor;
+    this.executeQuery = args.executeQuery;
+    this.options = args.options;
+  }
+
+  isActive(): boolean {
+    return !this.completed;
+  }
+
+  async execute(query: SQL): Promise<unknown> {
+    if (!this.isActive()) {
+      throw new Error('Transaction is no longer active');
+    }
+
+    return this.executeQuery(query);
+  }
+
+  async begin(): Promise<void> {
+    await this.executeQuery(sql.raw('BEGIN'));
+    await this.applyIsolationLevel();
+  }
+
+  async commit(): Promise<void> {
+    if (!this.isActive()) {
+      return;
+    }
+
+    await this.executeQuery(sql.raw('COMMIT'));
+    this.completed = true;
+  }
+
+  async rollback(): Promise<void> {
+    if (!this.isActive()) {
+      return;
+    }
+
+    await this.executeQuery(sql.raw('ROLLBACK'));
+    this.completed = true;
+  }
+
+  async createSavepoint(name?: string): Promise<string> {
+    if (!this.isActive()) {
+      throw new Error('Transaction is no longer active');
+    }
+
+    const savepointName = name ?? `sp_${++this.savepointCounter}`;
+    await this.executeQuery(sql.raw(`SAVEPOINT ${savepointName}`));
+    return savepointName;
+  }
+
+  async rollbackToSavepoint(name: string): Promise<void> {
+    if (!this.isActive()) {
+      throw new Error('Transaction is no longer active');
+    }
+
+    await this.executeQuery(sql.raw(`ROLLBACK TO SAVEPOINT ${name}`));
+  }
+
+  async releaseSavepoint(name: string): Promise<void> {
+    if (!this.isActive()) {
+      throw new Error('Transaction is no longer active');
+    }
+
+    await this.executeQuery(sql.raw(`RELEASE SAVEPOINT ${name}`));
+  }
+
+  async withSavepoint<T>(
+    operation: (transaction: TransactionContext) => Promise<T>,
+    name?: string
+  ): Promise<T> {
+    const savepointName = await this.createSavepoint(name);
+
+    try {
+      const result = await operation(this);
+      await this.releaseSavepoint(savepointName);
+      return result;
+    } catch (error) {
+      await this.rollbackToSavepoint(savepointName);
+      try {
+        await this.releaseSavepoint(savepointName);
+      } catch {
+        // Ignore release errors after rollback-to-savepoint.
+      }
+      throw error;
+    }
+  }
+
+  private async applyIsolationLevel(): Promise<void> {
+    if (!this.options.isolationLevel) {
+      return;
+    }
+
+    const isolationSql = toSqlIsolationLevel(this.options.isolationLevel);
+
+    if (this.vendor === 'sqlite') {
+      if (this.options.isolationLevel === 'read uncommitted') {
+        await this.executeQuery(sql.raw('PRAGMA read_uncommitted = 1'));
+      } else {
+        // SQLite defaults to SERIALIZABLE-like behavior for transactions.
+        logger.debug('Ignoring SQLite isolation level override', {
+          transactionId: this.id,
+          isolationLevel: this.options.isolationLevel,
+        });
+      }
+      return;
+    }
+
+    await this.executeQuery(sql.raw(`SET TRANSACTION ISOLATION LEVEL ${isolationSql}`));
+  }
+}
+
+/**
+ * Execute a callback inside a database transaction.
+ *
+ * Automatically commits on success and rolls back on failure.
+ */
+export async function withTransaction<T>(
+  manager: ConnectionManager,
+  operation: (transaction: TransactionContext) => Promise<T>,
+  options?: TransactionOptions
+): Promise<T> {
+  const startTime = Date.now();
+  const resolvedOptions = resolveOptions(options);
+  const transactionId = `tx-${++transactionSequence}`;
+  const vendor = manager.getVendor();
+
+  logger.debug('Starting transaction', {
+    transactionId,
+    vendor,
+    isolationLevel: resolvedOptions.isolationLevel,
+    timeoutMs: resolvedOptions.timeoutMs,
+  });
+
+  return manager.executeInConnection(async (executeQuery) => {
+    const transaction = new ManagedTransaction({
+      id: transactionId,
+      vendor,
+      executeQuery,
+      options: resolvedOptions,
+    });
+
+    await transaction.begin();
+
+    try {
+      const result = await withTimeout(operation(transaction), resolvedOptions.timeoutMs);
+
+      if (transaction.isActive()) {
+        await transaction.commit();
+      }
+
+      logger.debug('Transaction committed', {
+        transactionId,
+        vendor,
+        duration: Date.now() - startTime,
+      });
+
+      return result;
+    } catch (error) {
+      if (transaction.isActive()) {
+        try {
+          await transaction.rollback();
+        } catch (rollbackError) {
+          logger.error('Transaction rollback failed', {
+            transactionId,
+            vendor,
+            error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+          });
+        }
+      }
+
+      logger.error('Transaction failed', {
+        transactionId,
+        vendor,
+        duration: Date.now() - startTime,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      throw error;
+    }
+  });
+}

--- a/packages/tools/src/data/relational/query/types.ts
+++ b/packages/tools/src/data/relational/query/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DatabaseVendor } from '../types.js';
+import type { SQL } from 'drizzle-orm';
 
 /**
  * Query parameters for parameterized SQL execution
@@ -38,3 +39,10 @@ export interface QueryExecutionResult {
   executionTime: number;
 }
 
+/**
+ * Minimal SQL executor abstraction.
+ * Used by ConnectionManager and transaction contexts.
+ */
+export interface SqlExecutor {
+  execute(query: SQL): Promise<unknown>;
+}

--- a/packages/tools/src/data/relational/tools/relational-delete/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor.ts
@@ -6,10 +6,15 @@
 import { createLogger } from '@agentforge/core';
 import { buildDeleteQuery } from '../../query/query-builder.js';
 import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { TransactionContext } from '../../query/transaction.js';
 import type { RelationalDeleteInput, DeleteResult } from './types.js';
 import { getDeleteConstraintViolationMessage, isSafeDeleteValidationError } from './error-utils.js';
 
 const logger = createLogger('agentforge:tools:data:relational:delete');
+
+export interface DeleteExecutionContext {
+  transaction?: TransactionContext;
+}
 
 function toNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
@@ -43,7 +48,8 @@ function normalizeAffectedRows(result: unknown): number {
  */
 export async function executeDelete(
   manager: ConnectionManager,
-  input: RelationalDeleteInput
+  input: RelationalDeleteInput,
+  context?: DeleteExecutionContext
 ): Promise<DeleteResult> {
   const startTime = Date.now();
 
@@ -65,7 +71,8 @@ export async function executeDelete(
       vendor: input.vendor,
     });
 
-    const rawResult = await manager.execute(built.query);
+    const executor = context?.transaction ?? manager;
+    const rawResult = await executor.execute(built.query);
     const rowCount = normalizeAffectedRows(rawResult);
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/tools/relational-select/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/executor.ts
@@ -54,6 +54,8 @@ export async function executeSelect(
   });
 
   try {
+    const executor = context?.transaction ?? manager;
+
     if (input.streaming?.enabled) {
       const streamOptions = {
         chunkSize: input.streaming.chunkSize,
@@ -73,10 +75,10 @@ export async function executeSelect(
         });
       }
 
-      const streamResult = await executeStreamingSelect(manager, streamInput, streamOptions);
+      const streamResult = await executeStreamingSelect(executor, streamInput, streamOptions);
 
       const benchmark = input.streaming.benchmark
-        ? await benchmarkStreamingSelectMemory(manager, streamInput, streamOptions)
+        ? await benchmarkStreamingSelectMemory(executor, streamInput, streamOptions)
         : undefined;
 
       const executionTime = Date.now() - startTime;
@@ -111,7 +113,6 @@ export async function executeSelect(
     const query = buildSelectQuery(input);
 
     // Execute query
-    const executor = context?.transaction ?? manager;
     const result = await executor.execute(query);
 
     const executionTime = Date.now() - startTime;

--- a/packages/tools/tests/data/relational/transaction-timeout-and-savepoint.test.ts
+++ b/packages/tools/tests/data/relational/transaction-timeout-and-savepoint.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { ConnectionManager } from '../../../src/data/relational/connection/connection-manager.js';
+import { withTransaction } from '../../../src/data/relational/query/transaction.js';
+
+function createMockManager(vendor: 'sqlite' | 'mysql' = 'sqlite') {
+  let executeCallCount = 0;
+
+  const manager = {
+    getVendor: () => vendor,
+    executeInConnection: async <T>(
+      callback: (execute: (query: ReturnType<typeof sql.raw>) => Promise<unknown>) => Promise<T>
+    ): Promise<T> => {
+      return callback(async () => {
+        executeCallCount += 1;
+        return [];
+      });
+    },
+  } as unknown as ConnectionManager;
+
+  return {
+    manager,
+    getExecuteCallCount: () => executeCallCount,
+  };
+}
+
+describe('transaction timeout and savepoint safety', () => {
+  it('rejects invalid savepoint names', async () => {
+    const { manager } = createMockManager();
+
+    await expect(
+      withTransaction(manager, async (transaction) => {
+        await transaction.createSavepoint('bad name with spaces');
+      })
+    ).rejects.toThrow('Invalid savepoint name');
+  });
+
+  it('prevents late execute calls after timeout cancellation', async () => {
+    const { manager, getExecuteCallCount } = createMockManager();
+    let lateExecutionError: Error | null = null;
+
+    await expect(
+      withTransaction(
+        manager,
+        async (transaction) => {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          try {
+            await transaction.execute(sql.raw('SELECT 1'));
+          } catch (error) {
+            lateExecutionError = error as Error;
+          }
+        },
+        { timeoutMs: 5 }
+      )
+    ).rejects.toThrow('Transaction timed out after 5ms');
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(lateExecutionError).toBeInstanceOf(Error);
+    expect(lateExecutionError?.message).toContain('Transaction timed out after 5ms');
+    // BEGIN + ROLLBACK only; late execute() must be blocked before hitting executor.
+    expect(getExecuteCallCount()).toBe(2);
+  });
+});

--- a/packages/tools/tests/data/relational/transaction.test.ts
+++ b/packages/tools/tests/data/relational/transaction.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Transaction helper tests.
+ */
+
+import { beforeAll, beforeEach, afterAll, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../src/data/relational/connection/connection-manager.js';
+import { withTransaction } from '../../../src/data/relational/query/transaction.js';
+import type { ConnectionConfig } from '../../../src/data/relational/connection/types.js';
+
+const hasSQLiteBindings = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3');
+    const db = new Database(':memory:');
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe('Relational Transactions', () => {
+  let manager: ConnectionManager;
+
+  beforeAll(async () => {
+    if (!hasSQLiteBindings) return;
+
+    const config: ConnectionConfig = {
+      vendor: 'sqlite',
+      connection: ':memory:',
+    };
+
+    manager = new ConnectionManager(config);
+    await manager.connect();
+    await manager.execute(sql.raw('CREATE TABLE tx_users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)'));
+  });
+
+  beforeEach(async () => {
+    if (!hasSQLiteBindings) return;
+    await manager.execute(sql.raw('DELETE FROM tx_users'));
+  });
+
+  afterAll(async () => {
+    if (!hasSQLiteBindings) return;
+    await manager.disconnect();
+  });
+
+  it.skipIf(!hasSQLiteBindings)('commits on success', async () => {
+    await withTransaction(manager, async (transaction) => {
+      await transaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${1}, ${'alice'})`);
+    });
+
+    const rows = await manager.execute(sql.raw('SELECT id, name FROM tx_users ORDER BY id'));
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows).toEqual([{ id: 1, name: 'alice' }]);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('rolls back on failure', async () => {
+    await expect(
+      withTransaction(manager, async (transaction) => {
+        await transaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${1}, ${'alice'})`);
+        throw new Error('forced failure');
+      })
+    ).rejects.toThrow('forced failure');
+
+    const rows = await manager.execute(sql.raw('SELECT id, name FROM tx_users ORDER BY id'));
+    expect(rows).toEqual([]);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('supports nested savepoints', async () => {
+    await withTransaction(manager, async (transaction) => {
+      await transaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${1}, ${'outer'})`);
+
+      await expect(
+        transaction.withSavepoint(async (nestedTransaction) => {
+          await nestedTransaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${2}, ${'inner'})`);
+          throw new Error('inner failure');
+        })
+      ).rejects.toThrow('inner failure');
+
+      await transaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${3}, ${'outer-2'})`);
+    });
+
+    const rows = await manager.execute(sql.raw('SELECT id, name FROM tx_users ORDER BY id'));
+    expect(rows).toEqual([
+      { id: 1, name: 'outer' },
+      { id: 3, name: 'outer-2' },
+    ]);
+  });
+
+  it.skipIf(!hasSQLiteBindings)('rolls back when timeout is exceeded', async () => {
+    await expect(
+      withTransaction(
+        manager,
+        async (transaction) => {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          await transaction.execute(sql`INSERT INTO tx_users (id, name) VALUES (${1}, ${'late'})`);
+        },
+        { timeoutMs: 5 }
+      )
+    ).rejects.toThrow('Transaction timed out after 5ms');
+
+    const rows = await manager.execute(sql.raw('SELECT id, name FROM tx_users ORDER BY id'));
+    expect(rows).toEqual([]);
+  });
+});

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -6,7 +6,7 @@
 
 ### Checklist
 - [x] Create branch `feat/st-04001-transaction-support`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title (PR #39)
 - [ ] Create `packages/tools/src/data/relational/query/transaction.ts`
 - [ ] Define `Transaction` interface
 - [ ] Implement transaction wrapper for multiple operations

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -25,9 +25,9 @@
 - [x] Test nested transactions
 - [x] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added transaction integration coverage and retained CRUD regression coverage)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR ready for review
+- [x] Run full test suite before finalizing the PR and record results (`pnpm test --run` -> 113 passed, 5 skipped files; 1342 passed, 147 skipped tests)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results (`pnpm lint` -> 0 errors; warnings-only baseline across workspace)
+- [x] Mark PR ready for review (PR #39 marked ready on 2026-02-20)
 - [ ] Wait for merge
 
 ---

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -7,22 +7,22 @@
 ### Checklist
 - [x] Create branch `feat/st-04001-transaction-support`
 - [x] Create draft PR with story ID in title (PR #39)
-- [ ] Create `packages/tools/src/data/relational/query/transaction.ts`
-- [ ] Define `Transaction` interface
-- [ ] Implement transaction wrapper for multiple operations
-- [ ] Add automatic rollback on error
-- [ ] Add commit on success
-- [ ] Implement nested transaction support using savepoints
-- [ ] Add transaction isolation level configuration (READ COMMITTED, SERIALIZABLE, etc.)
-- [ ] Add timeout handling for long transactions
-- [ ] Create transaction context for passing to tools
-- [ ] Update existing tools to support transaction context (optional parameter)
-- [ ] Add transaction logging
-- [ ] Create example usage in docs/
-- [ ] Create unit tests for transaction logic
-- [ ] Create integration tests with real databases
-- [ ] Test rollback scenarios
-- [ ] Test nested transactions
+- [x] Create `packages/tools/src/data/relational/query/transaction.ts`
+- [x] Define `Transaction` interface
+- [x] Implement transaction wrapper for multiple operations
+- [x] Add automatic rollback on error
+- [x] Add commit on success
+- [x] Implement nested transaction support using savepoints
+- [x] Add transaction isolation level configuration (READ COMMITTED, SERIALIZABLE, etc.)
+- [x] Add timeout handling for long transactions
+- [x] Create transaction context for passing to tools
+- [x] Update existing tools to support transaction context (optional parameter)
+- [x] Add transaction logging
+- [x] Create example usage in docs/ (`docs/relational-transaction-examples.md`)
+- [x] Create unit tests for transaction logic (`packages/tools/tests/data/relational/transaction.test.ts`)
+- [x] Create integration tests with real databases (`packages/tools/tests/data/relational/transaction.test.ts` with SQLite path)
+- [x] Test rollback scenarios
+- [x] Test nested transactions
 - [ ] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [ ] Run full test suite before finalizing the PR and record results

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -5,7 +5,7 @@
 **Branch:** `feat/st-04001-transaction-support`
 
 ### Checklist
-- [ ] Create branch `feat/st-04001-transaction-support`
+- [x] Create branch `feat/st-04001-transaction-support`
 - [ ] Create draft PR with story ID in title
 - [ ] Create `packages/tools/src/data/relational/query/transaction.ts`
 - [ ] Define `Transaction` interface

--- a/planning/checklists/epic-04-story-tasks.md
+++ b/planning/checklists/epic-04-story-tasks.md
@@ -23,8 +23,8 @@
 - [x] Create integration tests with real databases (`packages/tools/tests/data/relational/transaction.test.ts` with SQLite path)
 - [x] Test rollback scenarios
 - [x] Test nested transactions
-- [ ] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Add or update story documentation at docs/st04001-transaction-support.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required (added transaction integration coverage and retained CRUD regression coverage)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR ready for review

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-20
-**Active Story:** None (ST-02005 merged; next story selection pending)
+**Active Story:** ST-04001 (In Progress)
 
 ---
 

--- a/planning/features/01-05-relational-database-feature-plan.md
+++ b/planning/features/01-05-relational-database-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-01 through EP-05  
 **Status:** In Progress  
 **Last Updated:** 2026-02-20
-**Active Story:** ST-04001 (In Progress)
+**Active Story:** ST-04001 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 3 stories (ST-05003, ST-04002, ST-05001)
-- **In Progress:** 1 story (ST-04001)
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story (ST-04001)
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories (waiting on dependencies)
 
@@ -40,6 +40,12 @@
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-04001: Implement Transaction Support
 - **Epic:** EP-04
 - **Priority:** P1
@@ -47,12 +53,6 @@
 - **Dependencies:** ST-02005 ✅ (merged 2026-02-20)
 - **Checklist:** `planning/checklists/epic-04-story-tasks.md`
 - **Branch:** `feat/st-04001-transaction-support`
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories (ST-05003, ST-04002, ST-05001, ST-04001)
-- **In Progress:** 0 stories
+- **Ready:** 3 stories (ST-05003, ST-04002, ST-05001)
+- **In Progress:** 1 story (ST-04001)
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories (waiting on dependencies)
@@ -36,18 +36,17 @@
 - **Checklist:** `planning/checklists/epic-05-story-tasks.md`
 - **Note:** Can start test infrastructure in parallel with implementation
 
+---
+
+## In Progress
+
 ### ST-04001: Implement Transaction Support
 - **Epic:** EP-04
 - **Priority:** P1
 - **Estimate:** 6 hours
 - **Dependencies:** ST-02005 ✅ (merged 2026-02-20)
 - **Checklist:** `planning/checklists/epic-04-story-tasks.md`
-
----
-
-## In Progress
-
-_No stories currently in progress_
+- **Branch:** `feat/st-04001-transaction-support`
 
 ---
 


### PR DESCRIPTION
## Story
- ST-04001: Implement Transaction Support

## What Changed
- Added transaction primitives in `packages/tools/src/data/relational/query/transaction.ts`:
  - `withTransaction(...)`
  - `TransactionContext`
  - automatic commit/rollback lifecycle
  - nested savepoint support (`withSavepoint`)
  - isolation level and timeout options
- Extended `ConnectionManager` with single-session execution for transaction scope:
  - `executeInConnection(...)`
  - `getVendor()` helper
- Added optional transaction context support to executors:
  - `packages/tools/src/data/relational/query/query-executor.ts`
  - `packages/tools/src/data/relational/tools/relational-select/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-insert/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-update/executor.ts`
  - `packages/tools/src/data/relational/tools/relational-delete/executor.ts`
- Exported transaction types/helpers through `packages/tools/src/data/relational/query/index.ts`.
- Added transaction test coverage in `packages/tools/tests/data/relational/transaction.test.ts`.
- Added usage examples in `docs/relational-transaction-examples.md` and story notes in `docs/st04001-transaction-support.md`.

## Acceptance Criteria Coverage
- [x] Transaction wrapper and context abstraction
- [x] Automatic rollback on error and commit on success
- [x] Nested transactions via savepoints
- [x] Isolation level and timeout configuration
- [x] Optional transaction context support in query/CRUD executors
- [x] Transaction logging + examples + tests

## Validation Performed
- `pnpm test --run packages/tools/tests/data/relational/transaction.test.ts packages/tools/tests/data/relational/relational-delete/index.test.ts packages/tools/tests/data/relational/relational-update/index.test.ts packages/tools/tests/data/relational/relational-insert/index.test.ts`
- `pnpm test --run` → `113 passed | 5 skipped` files, `1342 passed | 147 skipped` tests
- `pnpm lint` → `0 errors` (warnings-only baseline across workspace)

## Status
- Ready for review.
- Note: `packages/tools/tests/data/relational/transaction.test.ts` is integration coverage with SQLite and is conditionally skipped when native `better-sqlite3` bindings are unavailable in the environment.
