### PR TITLE
ST-06001: Implement SkillRegistry with Folder-Config Auto-Discovery

### DIFF
--- a/docs/st06001-skill-discovery-and-frontmatter.md
+++ b/docs/st06001-skill-discovery-and-frontmatter.md
@@ -1,0 +1,68 @@
+# ST-06001: SkillRegistry with Folder-Config Auto-Discovery
+
+## Summary
+
+Implements `SkillRegistry` in `@agentforge/core` — a folder-config auto-discovery system for Agent Skills following the [Agent Skills Specification](https://agentskills.io/specification). The registry scans configured `skillRoots` directories at construction time, discovers skills with valid `SKILL.md` frontmatter, and exposes a query API parallel to `ToolRegistry`.
+
+## Design Decisions
+
+### Folder-Config Auto-Discovery (vs Programmatic Registration)
+
+Unlike `ToolRegistry` which uses programmatic `register()` calls, `SkillRegistry` uses filesystem-based auto-discovery. Skills are filesystem artifacts (directories with `SKILL.md` files), so configuration is a list of root paths (`skillRoots: string[]`) rather than code-level registration.
+
+### Validation Strategy
+
+Follows the Agent Skills spec strictly:
+- **Name**: 1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, must match parent directory name
+- **Description**: 1-1024 chars, non-empty
+- **Optional fields**: `license`, `compatibility`, `metadata`, `allowed-tools` — parsed but not required
+
+### Duplicate Handling
+
+When the same skill name appears in multiple roots, the first root wins (deterministic precedence by `skillRoots` array order). A `skill:warning` event is emitted for observability.
+
+### Progressive Disclosure
+
+Only YAML frontmatter is parsed at discovery time. The full SKILL.md body content and resource files are deferred to activation (ST-06003).
+
+## Module Structure
+
+```
+packages/core/src/skills/
+├── types.ts      # SkillMetadata, Skill, SkillRegistryConfig, events
+├── parser.ts     # parseSkillContent(), validation functions
+├── scanner.ts    # scanSkillRoot(), scanAllSkillRoots(), expandHome()
+├── registry.ts   # SkillRegistry class
+└── index.ts      # Barrel exports
+```
+
+## API Surface
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+
+const registry = new SkillRegistry({
+  skillRoots: ['~/.copilot/skills', './project-skills'],
+});
+
+registry.get('code-review');      // Skill | undefined
+registry.getAll();                // Skill[]
+registry.has('code-review');      // boolean
+registry.size();                  // number
+registry.getNames();              // string[]
+registry.getScanErrors();         // string[]
+registry.on('skill:discovered', handler);
+registry.off('skill:discovered', handler);
+registry.discover();              // Re-scan all roots
+```
+
+## Test Coverage
+
+- **71 tests** across 3 test files
+- `parser.test.ts`: 34 tests — frontmatter parsing, name/description validation, edge cases
+- `scanner.test.ts`: 10 tests — filesystem scanning with temp directory fixtures
+- `registry.test.ts`: 27 tests — auto-discovery, query API, duplicates, events, re-scan, malformed recovery
+
+## Dependencies Added
+
+- `gray-matter` — YAML frontmatter parsing (MIT, well-maintained, 5M+ weekly npm downloads)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@langchain/core": "^1.1.17",
     "@langchain/langgraph": "^1.1.2",
+    "gray-matter": "^4.0.3",
     "zod": "^3.23.0",
     "zod-to-json-schema": "^3.25.0"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,3 +24,6 @@ export * from './monitoring/index.js';
 
 // Prompt template loader
 export * from './prompt-loader/index.js';
+
+// Skills system
+export * from './skills/index.js';

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Skills system exports
+ */
+
+// Type definitions
+export type {
+  SkillMetadata,
+  Skill,
+  SkillRegistryConfig,
+  SkillEventHandler,
+  SkillParseResult,
+  SkillValidationError,
+} from './types.js';
+
+export { SkillRegistryEvent } from './types.js';
+
+// Parser
+export {
+  parseSkillContent,
+  validateSkillName,
+  validateSkillDescription,
+  validateSkillNameMatchesDir,
+} from './parser.js';
+
+// Scanner
+export {
+  scanSkillRoot,
+  scanAllSkillRoots,
+  expandHome,
+  type SkillCandidate,
+} from './scanner.js';
+
+// Registry
+export { SkillRegistry } from './registry.js';

--- a/packages/core/src/skills/parser.ts
+++ b/packages/core/src/skills/parser.ts
@@ -1,0 +1,194 @@
+/**
+ * SKILL.md Frontmatter Parser
+ *
+ * Parses YAML frontmatter from SKILL.md files and validates
+ * against the Agent Skills specification constraints.
+ *
+ * @see https://agentskills.io/specification
+ */
+
+import matter from 'gray-matter';
+import type { SkillMetadata, SkillParseResult, SkillValidationError } from './types.js';
+
+/**
+ * Skill name validation constraints (per spec).
+ *
+ * - 1-64 characters
+ * - Lowercase alphanumeric and hyphens only
+ * - No leading, trailing, or consecutive hyphens
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const SKILL_NAME_MAX_LENGTH = 64;
+const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+
+/**
+ * Validate the `name` field per the Agent Skills spec.
+ *
+ * @param name - The name value from frontmatter
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillName(name: unknown): SkillValidationError[] {
+  const errors: SkillValidationError[] = [];
+
+  if (name === undefined || name === null) {
+    errors.push({ field: 'name', message: 'name is required' });
+    return errors;
+  }
+
+  if (typeof name !== 'string') {
+    errors.push({ field: 'name', message: 'name must be a string' });
+    return errors;
+  }
+
+  if (name.length === 0) {
+    errors.push({ field: 'name', message: 'name must not be empty' });
+    return errors;
+  }
+
+  if (name.length > SKILL_NAME_MAX_LENGTH) {
+    errors.push({
+      field: 'name',
+      message: `name must be at most ${SKILL_NAME_MAX_LENGTH} characters (got ${name.length})`,
+    });
+    return errors;
+  }
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    errors.push({
+      field: 'name',
+      message: 'name must be lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens',
+    });
+  }
+
+  if (name.includes('--')) {
+    errors.push({
+      field: 'name',
+      message: 'name must not contain consecutive hyphens',
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the `description` field per the Agent Skills spec.
+ *
+ * @param description - The description value from frontmatter
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillDescription(description: unknown): SkillValidationError[] {
+  const errors: SkillValidationError[] = [];
+
+  if (description === undefined || description === null) {
+    errors.push({ field: 'description', message: 'description is required' });
+    return errors;
+  }
+
+  if (typeof description !== 'string') {
+    errors.push({ field: 'description', message: 'description must be a string' });
+    return errors;
+  }
+
+  if (description.trim().length === 0) {
+    errors.push({ field: 'description', message: 'description must not be empty' });
+    return errors;
+  }
+
+  if (description.length > SKILL_DESCRIPTION_MAX_LENGTH) {
+    errors.push({
+      field: 'description',
+      message: `description must be at most ${SKILL_DESCRIPTION_MAX_LENGTH} characters (got ${description.length})`,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate that the skill name matches its parent directory name (per spec).
+ *
+ * @param name - The name from frontmatter
+ * @param dirName - The parent directory name
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillNameMatchesDir(name: string, dirName: string): SkillValidationError[] {
+  if (name !== dirName) {
+    return [{
+      field: 'name',
+      message: `name "${name}" must match parent directory name "${dirName}"`,
+    }];
+  }
+  return [];
+}
+
+/**
+ * Parse and validate a SKILL.md file's raw content.
+ *
+ * Extracts YAML frontmatter using gray-matter, then validates
+ * required and optional fields against spec constraints.
+ *
+ * @param content - Raw file content of the SKILL.md
+ * @param dirName - Parent directory name for name-match validation
+ * @returns Parse result with metadata or error
+ */
+export function parseSkillContent(content: string, dirName: string): SkillParseResult {
+  let parsed: matter.GrayMatterFile<string>;
+
+  try {
+    parsed = matter(content);
+  } catch (err) {
+    return {
+      success: false,
+      error: `Failed to parse frontmatter: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const data = parsed.data;
+
+  // Validate required fields
+  const errors: SkillValidationError[] = [
+    ...validateSkillName(data.name),
+    ...validateSkillDescription(data.description),
+  ];
+
+  // If name is valid, validate it matches directory name
+  if (typeof data.name === 'string' && data.name.length > 0 && SKILL_NAME_PATTERN.test(data.name)) {
+    errors.push(...validateSkillNameMatchesDir(data.name, dirName));
+  }
+
+  if (errors.length > 0) {
+    return {
+      success: false,
+      error: errors.map((e) => `${e.field}: ${e.message}`).join('; '),
+    };
+  }
+
+  // Build metadata from validated fields
+  const metadata: SkillMetadata = {
+    name: data.name as string,
+    description: data.description as string,
+  };
+
+  // Optional fields
+  if (data.license !== undefined) {
+    metadata.license = String(data.license);
+  }
+
+  if (Array.isArray(data.compatibility)) {
+    metadata.compatibility = data.compatibility.map(String);
+  }
+
+  if (data.metadata !== undefined && typeof data.metadata === 'object' && data.metadata !== null) {
+    metadata.metadata = data.metadata as Record<string, unknown>;
+  }
+
+  if (Array.isArray(data['allowed-tools'])) {
+    metadata.allowedTools = data['allowed-tools'].map(String);
+  }
+
+  return {
+    success: true,
+    metadata,
+    body: parsed.content,
+  };
+}

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -1,0 +1,304 @@
+/**
+ * Skill Registry
+ *
+ * Central registry for discovering, storing, and querying Agent Skills.
+ * Mirrors ToolRegistry but uses folder-based auto-discovery instead
+ * of programmatic registration.
+ *
+ * @see https://agentskills.io/specification
+ *
+ * @example
+ * ```ts
+ * const registry = new SkillRegistry({
+ *   skillRoots: ['.agentskills', '~/.agentskills'],
+ * });
+ *
+ * // Query discovered skills
+ * const skill = registry.get('code-review');
+ * const allSkills = registry.getAll();
+ *
+ * // Listen for events
+ * registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (skill) => {
+ *   console.log('Found skill:', skill.metadata.name);
+ * });
+ * ```
+ */
+
+import type {
+  Skill,
+  SkillRegistryConfig,
+  SkillEventHandler,
+} from './types.js';
+import { SkillRegistryEvent } from './types.js';
+import { scanAllSkillRoots } from './scanner.js';
+import { parseSkillContent } from './parser.js';
+import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
+
+const logger = createLogger('agentforge:core:skills:registry', { level: LogLevel.INFO });
+
+/**
+ * Skill Registry — auto-discovers skills from configured folder paths.
+ *
+ * Parallel to ToolRegistry:
+ * | ToolRegistry             | SkillRegistry                            |
+ * |--------------------------|------------------------------------------|
+ * | registry.register(tool)  | new SkillRegistry({ skillRoots })        |
+ * | registry.get('name')     | skillRegistry.get('name')                |
+ * | registry.getAll()        | skillRegistry.getAll()                   |
+ * | registry.has('name')     | skillRegistry.has('name')                |
+ * | registry.size()          | skillRegistry.size()                     |
+ * | registry.generatePrompt()| skillRegistry.generatePrompt() (ST-06002)|
+ */
+export class SkillRegistry {
+  private skills: Map<string, Skill> = new Map();
+  private eventHandlers: Map<SkillRegistryEvent, Set<SkillEventHandler>> = new Map();
+  private readonly config: SkillRegistryConfig;
+  private scanErrors: Array<{ path: string; error: string }> = [];
+
+  /**
+   * Create a SkillRegistry and immediately scan configured roots for skills.
+   *
+   * @param config - Registry configuration with skill root paths
+   *
+   * @example
+   * ```ts
+   * const registry = new SkillRegistry({
+   *   skillRoots: ['.agentskills', '~/.agentskills', './project-skills'],
+   * });
+   * console.log(`Discovered ${registry.size()} skills`);
+   * ```
+   */
+  constructor(config: SkillRegistryConfig) {
+    this.config = config;
+    this.discover();
+  }
+
+  /**
+   * Scan all configured roots and populate the registry.
+   *
+   * Called automatically during construction. Can be called again
+   * to re-scan (clears existing skills first).
+   */
+  discover(): void {
+    this.skills.clear();
+    this.scanErrors = [];
+
+    const candidates = scanAllSkillRoots(this.config.skillRoots);
+
+    let successCount = 0;
+    let warningCount = 0;
+
+    for (const candidate of candidates) {
+      const result = parseSkillContent(candidate.content, candidate.dirName);
+
+      if (!result.success) {
+        warningCount++;
+        this.scanErrors.push({
+          path: candidate.skillPath,
+          error: result.error || 'Unknown parse error',
+        });
+        this.emit(SkillRegistryEvent.SKILL_WARNING, {
+          skillPath: candidate.skillPath,
+          rootPath: candidate.rootPath,
+          error: result.error,
+        });
+        logger.warn('Skipping invalid skill', {
+          skillPath: candidate.skillPath,
+          error: result.error,
+        });
+        continue;
+      }
+
+      const skill: Skill = {
+        metadata: result.metadata!,
+        skillPath: candidate.skillPath,
+        rootPath: candidate.rootPath,
+      };
+
+      // Handle duplicate skill names — first root wins (deterministic precedence)
+      if (this.skills.has(skill.metadata.name)) {
+        const existing = this.skills.get(skill.metadata.name)!;
+        warningCount++;
+        const warningMsg = `Duplicate skill name "${skill.metadata.name}" from "${candidate.rootPath}" — ` +
+          `keeping version from "${existing.rootPath}" (first root takes precedence)`;
+        this.scanErrors.push({
+          path: candidate.skillPath,
+          error: warningMsg,
+        });
+        this.emit(SkillRegistryEvent.SKILL_WARNING, {
+          skillPath: candidate.skillPath,
+          rootPath: candidate.rootPath,
+          duplicateOf: existing.skillPath,
+          error: warningMsg,
+        });
+        logger.warn('Duplicate skill name, keeping first', {
+          name: skill.metadata.name,
+          kept: existing.skillPath,
+          skipped: candidate.skillPath,
+        });
+        continue;
+      }
+
+      this.skills.set(skill.metadata.name, skill);
+      successCount++;
+
+      this.emit(SkillRegistryEvent.SKILL_DISCOVERED, skill);
+      logger.debug('Skill discovered', {
+        name: skill.metadata.name,
+        description: skill.metadata.description.slice(0, 80),
+        skillPath: skill.skillPath,
+      });
+    }
+
+    logger.info('Skill registry populated', {
+      rootsScanned: this.config.skillRoots.length,
+      skillsDiscovered: successCount,
+      warnings: warningCount,
+    });
+  }
+
+  // ─── Query API (parallel to ToolRegistry) ──────────────────────────────
+
+  /**
+   * Get a skill by name.
+   *
+   * @param name - The skill name
+   * @returns The skill, or undefined if not found
+   *
+   * @example
+   * ```ts
+   * const skill = registry.get('code-review');
+   * if (skill) {
+   *   console.log(skill.metadata.description);
+   * }
+   * ```
+   */
+  get(name: string): Skill | undefined {
+    return this.skills.get(name);
+  }
+
+  /**
+   * Get all discovered skills.
+   *
+   * @returns Array of all skills
+   *
+   * @example
+   * ```ts
+   * const allSkills = registry.getAll();
+   * console.log(`Total skills: ${allSkills.length}`);
+   * ```
+   */
+  getAll(): Skill[] {
+    return Array.from(this.skills.values());
+  }
+
+  /**
+   * Check if a skill exists in the registry.
+   *
+   * @param name - The skill name
+   * @returns True if the skill exists
+   *
+   * @example
+   * ```ts
+   * if (registry.has('code-review')) {
+   *   console.log('Skill available!');
+   * }
+   * ```
+   */
+  has(name: string): boolean {
+    return this.skills.has(name);
+  }
+
+  /**
+   * Get the number of discovered skills.
+   *
+   * @returns Number of skills in the registry
+   *
+   * @example
+   * ```ts
+   * console.log(`Registry has ${registry.size()} skills`);
+   * ```
+   */
+  size(): number {
+    return this.skills.size;
+  }
+
+  /**
+   * Get all skill names.
+   *
+   * @returns Array of skill names
+   */
+  getNames(): string[] {
+    return Array.from(this.skills.keys());
+  }
+
+  /**
+   * Get errors/warnings from the last scan.
+   *
+   * Useful for diagnostics and observability.
+   *
+   * @returns Array of scan errors with paths
+   */
+  getScanErrors(): ReadonlyArray<{ path: string; error: string }> {
+    return this.scanErrors;
+  }
+
+  // ─── Event System ──────────────────────────────────────────────────────
+
+  /**
+   * Register an event handler.
+   *
+   * @param event - The event to listen for
+   * @param handler - The handler function
+   *
+   * @example
+   * ```ts
+   * registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (skill) => {
+   *   console.log('Found skill:', skill.metadata.name);
+   * });
+   * ```
+   */
+  on(event: SkillRegistryEvent, handler: SkillEventHandler): void {
+    if (!this.eventHandlers.has(event)) {
+      this.eventHandlers.set(event, new Set());
+    }
+    this.eventHandlers.get(event)!.add(handler);
+  }
+
+  /**
+   * Unregister an event handler.
+   *
+   * @param event - The event to stop listening for
+   * @param handler - The handler function to remove
+   */
+  off(event: SkillRegistryEvent, handler: SkillEventHandler): void {
+    const handlers = this.eventHandlers.get(event);
+    if (handlers) {
+      handlers.delete(handler);
+    }
+  }
+
+  /**
+   * Emit an event to all registered handlers.
+   *
+   * @param event - The event to emit
+   * @param data - The event data
+   * @private
+   */
+  private emit(event: SkillRegistryEvent, data: unknown): void {
+    const handlers = this.eventHandlers.get(event);
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(data);
+        } catch (error) {
+          logger.error('Skill event handler error', {
+            event,
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
+      });
+    }
+  }
+}

--- a/packages/core/src/skills/scanner.ts
+++ b/packages/core/src/skills/scanner.ts
@@ -1,0 +1,130 @@
+/**
+ * Skill Directory Scanner
+ *
+ * Scans configured skill roots for directories containing valid SKILL.md files.
+ * Returns a list of candidate skill paths for the parser to process.
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
+
+const logger = createLogger('agentforge:core:skills:scanner', { level: LogLevel.INFO });
+
+/**
+ * Discovered skill candidate — a directory containing a SKILL.md file.
+ */
+export interface SkillCandidate {
+  /** Absolute path to the skill directory */
+  skillPath: string;
+  /** The parent directory name (expected to match the skill name) */
+  dirName: string;
+  /** Raw content of the SKILL.md file */
+  content: string;
+  /** Which configured root this came from */
+  rootPath: string;
+}
+
+/**
+ * Expand `~` prefix to the user's home directory.
+ */
+export function expandHome(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return resolve(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Scan a single skill root for directories containing SKILL.md.
+ *
+ * @param rootPath - The root directory to scan (may not exist)
+ * @returns Array of valid skill candidates found under this root
+ */
+export function scanSkillRoot(rootPath: string): SkillCandidate[] {
+  const resolvedRoot = resolve(expandHome(rootPath));
+  const candidates: SkillCandidate[] = [];
+
+  if (!existsSync(resolvedRoot)) {
+    logger.debug('Skill root does not exist, skipping', { rootPath: resolvedRoot });
+    return candidates;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(resolvedRoot);
+  } catch (err) {
+    logger.warn('Failed to read skill root directory', {
+      rootPath: resolvedRoot,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return candidates;
+  }
+
+  for (const entry of entries) {
+    const entryPath = resolve(resolvedRoot, entry);
+
+    // Only process directories
+    let stat;
+    try {
+      stat = statSync(entryPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      continue;
+    }
+
+    // Check for SKILL.md inside the directory
+    const skillMdPath = resolve(entryPath, 'SKILL.md');
+    if (!existsSync(skillMdPath)) {
+      continue;
+    }
+
+    // Read the SKILL.md content
+    try {
+      const content = readFileSync(skillMdPath, 'utf-8');
+      candidates.push({
+        skillPath: entryPath,
+        dirName: basename(entryPath),
+        content,
+        rootPath: resolvedRoot,
+      });
+    } catch (err) {
+      logger.warn('Failed to read SKILL.md', {
+        path: skillMdPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  logger.debug('Scanned skill root', {
+    rootPath: resolvedRoot,
+    candidatesFound: candidates.length,
+  });
+
+  return candidates;
+}
+
+/**
+ * Scan multiple skill roots for directories containing SKILL.md.
+ *
+ * @param skillRoots - Array of root paths to scan
+ * @returns Array of all skill candidates found across all roots
+ */
+export function scanAllSkillRoots(skillRoots: string[]): SkillCandidate[] {
+  const allCandidates: SkillCandidate[] = [];
+
+  for (const root of skillRoots) {
+    const candidates = scanSkillRoot(root);
+    allCandidates.push(...candidates);
+  }
+
+  logger.info('Skill discovery complete', {
+    rootsScanned: skillRoots.length,
+    totalCandidates: allCandidates.length,
+  });
+
+  return allCandidates;
+}

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Skill System Types
+ *
+ * Core type definitions for the AgentForge Agent Skills system.
+ * These types align with the Agent Skills specification (https://agentskills.io/specification).
+ */
+
+/**
+ * Parsed metadata from a SKILL.md frontmatter block.
+ *
+ * Required fields: `name`, `description`.
+ * All other fields are optional per the Agent Skills spec.
+ */
+export interface SkillMetadata {
+  /** Skill name (1-64 chars, lowercase alphanumeric + hyphens, must match parent dir name) */
+  name: string;
+  /** Human-readable description (1-1024 chars) */
+  description: string;
+  /** SPDX license identifier */
+  license?: string;
+  /** List of compatible agent frameworks / tool hosts */
+  compatibility?: string[];
+  /** Arbitrary key-value metadata (author, version, etc.) */
+  metadata?: Record<string, unknown>;
+  /** Tools that this skill is allowed to use */
+  allowedTools?: string[];
+}
+
+/**
+ * A fully resolved skill entry in the registry.
+ *
+ * Contains parsed metadata plus internal tracking fields
+ * that are not part of the SKILL.md frontmatter.
+ */
+export interface Skill {
+  /** Parsed frontmatter metadata */
+  metadata: SkillMetadata;
+  /** Absolute path to the skill directory */
+  skillPath: string;
+  /** Which configured skill root this was discovered from */
+  rootPath: string;
+}
+
+/**
+ * Configuration for the SkillRegistry.
+ */
+export interface SkillRegistryConfig {
+  /**
+   * Array of directory paths to scan for skills.
+   *
+   * Each root is scanned for subdirectories containing a valid `SKILL.md`.
+   * Paths may be absolute or relative (resolved against `cwd`).
+   * The `~` prefix is expanded to `$HOME`.
+   *
+   * @example ['.agentskills', '~/.agentskills', './project-skills']
+   */
+  skillRoots: string[];
+}
+
+/**
+ * Events emitted by the SkillRegistry during discovery and usage.
+ */
+export enum SkillRegistryEvent {
+  /** Emitted when a valid skill is discovered during scanning */
+  SKILL_DISCOVERED = 'skill:discovered',
+  /** Emitted when a skill parse or validation issue is encountered */
+  SKILL_WARNING = 'skill:warning',
+}
+
+/**
+ * Event handler type for skill registry events.
+ */
+export type SkillEventHandler = (data: unknown) => void;
+
+/**
+ * Result of parsing a single SKILL.md file.
+ */
+export interface SkillParseResult {
+  /** Whether parsing and validation succeeded */
+  success: boolean;
+  /** Parsed metadata (present when success is true) */
+  metadata?: SkillMetadata;
+  /** The raw markdown body below the frontmatter (present when success is true) */
+  body?: string;
+  /** Error description (present when success is false) */
+  error?: string;
+}
+
+/**
+ * Validation error detail.
+ */
+export interface SkillValidationError {
+  /** Which field failed validation */
+  field: string;
+  /** Human-readable error message */
+  message: string;
+}

--- a/packages/core/tests/skills/parser.test.ts
+++ b/packages/core/tests/skills/parser.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for Skill Frontmatter Parser
+ *
+ * Covers: parseSkillContent, validateSkillName, validateSkillDescription,
+ * validateSkillNameMatchesDir
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSkillContent,
+  validateSkillName,
+  validateSkillDescription,
+  validateSkillNameMatchesDir,
+} from '../../src/skills/parser.js';
+
+describe('validateSkillName', () => {
+  it('should accept valid names', () => {
+    expect(validateSkillName('code-review')).toEqual([]);
+    expect(validateSkillName('a')).toEqual([]);
+    expect(validateSkillName('my-great-skill')).toEqual([]);
+    expect(validateSkillName('abc123')).toEqual([]);
+    expect(validateSkillName('a1b2c3')).toEqual([]);
+  });
+
+  it('should reject undefined/null', () => {
+    expect(validateSkillName(undefined)).toHaveLength(1);
+    expect(validateSkillName(undefined)[0].message).toContain('required');
+    expect(validateSkillName(null)).toHaveLength(1);
+  });
+
+  it('should reject non-string', () => {
+    expect(validateSkillName(42)).toHaveLength(1);
+    expect(validateSkillName(42)[0].message).toContain('must be a string');
+  });
+
+  it('should reject empty string', () => {
+    expect(validateSkillName('')).toHaveLength(1);
+    expect(validateSkillName('')[0].message).toContain('must not be empty');
+  });
+
+  it('should reject names exceeding 64 characters', () => {
+    const longName = 'a'.repeat(65);
+    const errors = validateSkillName(longName);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some(e => e.message.includes('at most 64'))).toBe(true);
+  });
+
+  it('should accept name at exactly 64 characters', () => {
+    const name64 = 'a'.repeat(64);
+    expect(validateSkillName(name64)).toEqual([]);
+  });
+
+  it('should reject uppercase letters', () => {
+    const errors = validateSkillName('Code-Review');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject leading hyphen', () => {
+    const errors = validateSkillName('-code');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject trailing hyphen', () => {
+    const errors = validateSkillName('code-');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject consecutive hyphens', () => {
+    const errors = validateSkillName('code--review');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some(e => e.message.includes('consecutive hyphens'))).toBe(true);
+  });
+
+  it('should reject special characters', () => {
+    expect(validateSkillName('code_review').length).toBeGreaterThanOrEqual(1);
+    expect(validateSkillName('code.review').length).toBeGreaterThanOrEqual(1);
+    expect(validateSkillName('code review').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('validateSkillDescription', () => {
+  it('should accept valid descriptions', () => {
+    expect(validateSkillDescription('A useful skill')).toEqual([]);
+    expect(validateSkillDescription('x')).toEqual([]);
+  });
+
+  it('should reject undefined/null', () => {
+    expect(validateSkillDescription(undefined)).toHaveLength(1);
+    expect(validateSkillDescription(undefined)[0].message).toContain('required');
+    expect(validateSkillDescription(null)).toHaveLength(1);
+  });
+
+  it('should reject non-string', () => {
+    expect(validateSkillDescription(123)).toHaveLength(1);
+    expect(validateSkillDescription(123)[0].message).toContain('must be a string');
+  });
+
+  it('should reject empty/whitespace-only', () => {
+    expect(validateSkillDescription('')).toHaveLength(1);
+    expect(validateSkillDescription('   ')).toHaveLength(1);
+    expect(validateSkillDescription('  ')[0].message).toContain('must not be empty');
+  });
+
+  it('should reject descriptions exceeding 1024 characters', () => {
+    const longDesc = 'a'.repeat(1025);
+    const errors = validateSkillDescription(longDesc);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].message).toContain('at most 1024');
+  });
+
+  it('should accept description at exactly 1024 characters', () => {
+    const desc1024 = 'a'.repeat(1024);
+    expect(validateSkillDescription(desc1024)).toEqual([]);
+  });
+});
+
+describe('validateSkillNameMatchesDir', () => {
+  it('should pass when name matches directory', () => {
+    expect(validateSkillNameMatchesDir('code-review', 'code-review')).toEqual([]);
+  });
+
+  it('should fail when name does not match directory', () => {
+    const errors = validateSkillNameMatchesDir('code-review', 'my-skill');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('must match parent directory name');
+  });
+});
+
+describe('parseSkillContent', () => {
+  it('should parse valid SKILL.md with required fields', () => {
+    const content = `---
+name: code-review
+description: Reviews code for quality and security
+---
+
+# Code Review Skill
+
+Follow these steps...`;
+
+    const result = parseSkillContent(content, 'code-review');
+    expect(result.success).toBe(true);
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.name).toBe('code-review');
+    expect(result.metadata!.description).toBe('Reviews code for quality and security');
+    expect(result.body).toContain('# Code Review Skill');
+  });
+
+  it('should parse all optional fields', () => {
+    const content = `---
+name: full-skill
+description: A skill with all fields
+license: MIT
+compatibility:
+  - github-copilot
+  - agentforge
+metadata:
+  author: team-x
+  version: 1.0.0
+allowed-tools:
+  - read-file
+  - grep-search
+---
+
+Content here`;
+
+    const result = parseSkillContent(content, 'full-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.license).toBe('MIT');
+    expect(result.metadata!.compatibility).toEqual(['github-copilot', 'agentforge']);
+    expect(result.metadata!.metadata).toEqual({ author: 'team-x', version: '1.0.0' });
+    expect(result.metadata!.allowedTools).toEqual(['read-file', 'grep-search']);
+  });
+
+  it('should fail when name is missing', () => {
+    const content = `---
+description: A skill without a name
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'some-dir');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+    expect(result.error).toContain('required');
+  });
+
+  it('should fail when description is missing', () => {
+    const content = `---
+name: no-desc
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'no-desc');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('description');
+    expect(result.error).toContain('required');
+  });
+
+  it('should fail when name does not match directory', () => {
+    const content = `---
+name: code-review
+description: A valid description
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'wrong-dir');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('must match parent directory name');
+  });
+
+  it('should fail on invalid name format', () => {
+    const content = `---
+name: Code-Review
+description: A valid description
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'Code-Review');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('lowercase');
+  });
+
+  it('should fail on malformed frontmatter', () => {
+    const content = `---
+name: [invalid
+  yaml: {{broken
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Failed to parse frontmatter');
+  });
+
+  it('should handle empty frontmatter', () => {
+    const content = `---
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+    expect(result.error).toContain('required');
+  });
+
+  it('should handle content with no frontmatter at all', () => {
+    const content = '# Just a markdown file\n\nNo frontmatter.';
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+  });
+
+  it('should ignore unknown frontmatter fields without error', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+custom-field: some-value
+another: 42
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.name).toBe('my-skill');
+  });
+
+  it('should handle non-array compatibility gracefully', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+compatibility: not-an-array
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    // Non-array compatibility is simply ignored
+    expect(result.metadata!.compatibility).toBeUndefined();
+  });
+
+  it('should handle non-object metadata gracefully', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+metadata: just-a-string
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.metadata).toBeUndefined();
+  });
+
+  it('should collect multiple validation errors', () => {
+    const content = `---
+name: 123
+description: ""
+---
+
+body`;
+
+    // name "123" is actually valid (numeric), but empty description should fail
+    const result = parseSkillContent(content, '123');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('description');
+  });
+});

--- a/packages/core/tests/skills/registry.test.ts
+++ b/packages/core/tests/skills/registry.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for SkillRegistry
+ *
+ * Covers: constructor auto-discovery, query API (get, getAll, has, size, getNames),
+ * duplicate handling, event system, scan errors, malformed skill recovery.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { SkillRegistryEvent } from '../../src/skills/types.js';
+
+/**
+ * Create a temp directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-registry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, content: string): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('SkillRegistry', () => {
+  let tempDir: string;
+  let tempDirs: string[] = [];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Constructor and Auto-Discovery', () => {
+    it('should discover skills on construction', () => {
+      createSkillFixture(tempDir, 'my-skill', `---
+name: my-skill
+description: A test skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('my-skill')).toBe(true);
+    });
+
+    it('should handle empty roots', () => {
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should handle non-existent roots without crashing', () => {
+      const registry = new SkillRegistry({ skillRoots: ['/does/not/exist'] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should discover skills from multiple roots', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+      createSkillFixture(root2, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      expect(registry.size()).toBe(2);
+    });
+
+    it('should skip invalid skills without aborting', () => {
+      createSkillFixture(tempDir, 'valid-skill', `---
+name: valid-skill
+description: A valid skill
+---
+body`);
+
+      // Invalid: missing required description
+      createSkillFixture(tempDir, 'invalid-skill', `---
+name: invalid-skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('valid-skill')).toBe(true);
+      expect(registry.has('invalid-skill')).toBe(false);
+    });
+  });
+
+  describe('Query API', () => {
+    let registry: SkillRegistry;
+
+    beforeEach(() => {
+      createSkillFixture(tempDir, 'alpha', `---
+name: alpha
+description: Alpha skill
+license: MIT
+---
+Alpha body`);
+      createSkillFixture(tempDir, 'beta', `---
+name: beta
+description: Beta skill for testing
+---
+Beta body`);
+
+      registry = new SkillRegistry({ skillRoots: [tempDir] });
+    });
+
+    it('should get a skill by name', () => {
+      const skill = registry.get('alpha');
+      expect(skill).toBeDefined();
+      expect(skill!.metadata.name).toBe('alpha');
+      expect(skill!.metadata.description).toBe('Alpha skill');
+    });
+
+    it('should return undefined for non-existent skill', () => {
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should return all skills', () => {
+      const all = registry.getAll();
+      expect(all).toHaveLength(2);
+      const names = all.map(s => s.metadata.name).sort();
+      expect(names).toEqual(['alpha', 'beta']);
+    });
+
+    it('should check if skill exists', () => {
+      expect(registry.has('alpha')).toBe(true);
+      expect(registry.has('gamma')).toBe(false);
+    });
+
+    it('should return correct size', () => {
+      expect(registry.size()).toBe(2);
+    });
+
+    it('should return all skill names', () => {
+      const names = registry.getNames().sort();
+      expect(names).toEqual(['alpha', 'beta']);
+    });
+
+    it('should include optional metadata fields', () => {
+      const skill = registry.get('alpha');
+      expect(skill!.metadata.license).toBe('MIT');
+    });
+
+    it('should include skill path and root path', () => {
+      const skill = registry.get('alpha');
+      expect(skill!.skillPath).toContain('alpha');
+      expect(skill!.rootPath).toBe(tempDir);
+    });
+  });
+
+  describe('Duplicate Handling', () => {
+    it('should keep first root version on duplicate name', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'shared', `---
+name: shared
+description: From root 1
+---
+body1`);
+      createSkillFixture(root2, 'shared', `---
+name: shared
+description: From root 2
+---
+body2`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      expect(registry.size()).toBe(1);
+
+      const skill = registry.get('shared')!;
+      expect(skill.metadata.description).toBe('From root 1');
+      expect(skill.rootPath).toBe(tempDir);
+    });
+
+    it('should emit warning for duplicate', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'dup', `---
+name: dup
+description: First
+---
+body`);
+      createSkillFixture(root2, 'dup', `---
+name: dup
+description: Second
+---
+body`);
+
+      const warnings: unknown[] = [];
+      // Create registry with pre-registered handler won't work since
+      // discovery happens in constructor. Use getScanErrors instead.
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      const errors = registry.getScanErrors();
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors.some(e => e.error.includes('Duplicate skill name'))).toBe(true);
+    });
+  });
+
+  describe('Name-Directory Mismatch', () => {
+    it('should reject skill where name does not match directory', () => {
+      createSkillFixture(tempDir, 'wrong-dir', `---
+name: my-skill
+description: Name does not match directory
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+      expect(registry.getScanErrors()).toHaveLength(1);
+      expect(registry.getScanErrors()[0].error).toContain('must match parent directory name');
+    });
+  });
+
+  describe('Malformed Skill Recovery', () => {
+    it('should skip skill with malformed YAML', () => {
+      createSkillFixture(tempDir, 'bad-yaml', `---
+name: [broken
+  yaml: {{invalid
+---
+body`);
+
+      createSkillFixture(tempDir, 'good-skill', `---
+name: good-skill
+description: Valid skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('good-skill')).toBe(true);
+    });
+
+    it('should skip skill with empty frontmatter', () => {
+      createSkillFixture(tempDir, 'empty-front', `---
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should skip skill with no frontmatter at all', () => {
+      createSkillFixture(tempDir, 'no-front', `# Just markdown\n\nNo frontmatter here.`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+  });
+
+  describe('Event System', () => {
+    it('should emit skill:discovered events', () => {
+      createSkillFixture(tempDir, 'event-skill', `---
+name: event-skill
+description: Triggers events
+---
+body`);
+
+      // We need to register handler before discovery runs.
+      // Since discovery runs in constructor, we use discover() re-scan.
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const discoveredSkills: unknown[] = [];
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (data) => {
+        discoveredSkills.push(data);
+      });
+
+      // Re-scan to trigger events with our handler
+      registry.discover();
+      expect(discoveredSkills).toHaveLength(1);
+    });
+
+    it('should emit skill:warning events for invalid skills', () => {
+      createSkillFixture(tempDir, 'invalid', `---
+name: invalid
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const warnings: unknown[] = [];
+      registry.on(SkillRegistryEvent.SKILL_WARNING, (data) => {
+        warnings.push(data);
+      });
+
+      registry.discover();
+      expect(warnings).toHaveLength(1);
+    });
+
+    it('should support off() to remove handlers', () => {
+      createSkillFixture(tempDir, 'off-test', `---
+name: off-test
+description: Test off
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const events: unknown[] = [];
+      const handler = (data: unknown) => events.push(data);
+
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, handler);
+      registry.discover();
+      expect(events).toHaveLength(1);
+
+      registry.off(SkillRegistryEvent.SKILL_DISCOVERED, handler);
+      registry.discover();
+      // Should still be 1, not 2 — handler was removed
+      expect(events).toHaveLength(1);
+    });
+
+    it('should not crash if event handler throws', () => {
+      createSkillFixture(tempDir, 'crash-test', `---
+name: crash-test
+description: Handler will throw
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, () => {
+        throw new Error('Handler exploded!');
+      });
+
+      // Should not throw
+      expect(() => registry.discover()).not.toThrow();
+    });
+  });
+
+  describe('Re-scan (discover)', () => {
+    it('should clear and re-populate on discover()', () => {
+      createSkillFixture(tempDir, 'initial', `---
+name: initial
+description: Initial skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+
+      // Add another skill on disk
+      createSkillFixture(tempDir, 'added', `---
+name: added
+description: Added after init
+---
+body`);
+
+      registry.discover();
+      expect(registry.size()).toBe(2);
+      expect(registry.has('added')).toBe(true);
+    });
+
+    it('should reflect removed skills after re-scan', () => {
+      createSkillFixture(tempDir, 'to-remove', `---
+name: to-remove
+description: Will be removed
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+
+      // Remove from disk
+      rmSync(join(tempDir, 'to-remove'), { recursive: true, force: true });
+
+      registry.discover();
+      expect(registry.size()).toBe(0);
+    });
+  });
+
+  describe('getScanErrors', () => {
+    it('should return empty array on clean scan', () => {
+      createSkillFixture(tempDir, 'clean', `---
+name: clean
+description: No issues
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.getScanErrors()).toEqual([]);
+    });
+
+    it('should collect parse errors', () => {
+      createSkillFixture(tempDir, 'broken', `---
+name: UPPERCASE
+description: Bad name
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      const errors = registry.getScanErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].path).toContain('broken');
+    });
+  });
+});

--- a/packages/core/tests/skills/scanner.test.ts
+++ b/packages/core/tests/skills/scanner.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for Skill Directory Scanner
+ *
+ * Covers: scanSkillRoot, scanAllSkillRoots, expandHome
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  scanSkillRoot,
+  scanAllSkillRoots,
+  expandHome,
+} from '../../src/skills/scanner.js';
+
+/**
+ * Create a temporary directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, content: string): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('expandHome', () => {
+  it('should expand ~ to home directory', () => {
+    const result = expandHome('~/some/path');
+    expect(result).not.toContain('~');
+    expect(result).toContain('some/path');
+  });
+
+  it('should leave absolute paths unchanged', () => {
+    expect(expandHome('/foo/bar')).toBe('/foo/bar');
+  });
+
+  it('should leave relative paths unchanged', () => {
+    const result = expandHome('./relative/path');
+    expect(result).toContain('relative/path');
+  });
+});
+
+describe('scanSkillRoot', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return empty array for non-existent root', () => {
+    const result = scanSkillRoot('/non/existent/path/that/does/not/exist');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for empty root', () => {
+    tempDir = createTempDir();
+    const result = scanSkillRoot(tempDir);
+    expect(result).toEqual([]);
+  });
+
+  it('should discover a valid skill directory', () => {
+    tempDir = createTempDir();
+    createSkillFixture(tempDir, 'my-skill', `---
+name: my-skill
+description: A test skill
+---
+# My Skill`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].dirName).toBe('my-skill');
+    expect(result[0].content).toContain('name: my-skill');
+    expect(result[0].rootPath).toBe(tempDir);
+  });
+
+  it('should discover multiple skills', () => {
+    tempDir = createTempDir();
+    createSkillFixture(tempDir, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+    createSkillFixture(tempDir, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(2);
+
+    const names = result.map(c => c.dirName).sort();
+    expect(names).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('should skip directories without SKILL.md', () => {
+    tempDir = createTempDir();
+    mkdirSync(join(tempDir, 'no-skill-dir'), { recursive: true });
+    writeFileSync(join(tempDir, 'no-skill-dir', 'README.md'), 'not a skill', 'utf-8');
+
+    createSkillFixture(tempDir, 'valid-skill', `---
+name: valid-skill
+description: Valid
+---
+body`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].dirName).toBe('valid-skill');
+  });
+
+  it('should skip files at root level (not directories)', () => {
+    tempDir = createTempDir();
+    writeFileSync(join(tempDir, 'README.md'), '# Not a skill', 'utf-8');
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('scanAllSkillRoots', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it('should scan multiple roots', () => {
+    const root1 = createTempDir();
+    const root2 = createTempDir();
+    tempDirs.push(root1, root2);
+
+    createSkillFixture(root1, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+    createSkillFixture(root2, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+    const result = scanAllSkillRoots([root1, root2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should handle mix of existing and non-existing roots', () => {
+    const root1 = createTempDir();
+    tempDirs.push(root1);
+
+    createSkillFixture(root1, 'my-skill', `---
+name: my-skill
+description: A skill
+---
+body`);
+
+    const result = scanAllSkillRoots([root1, '/does/not/exist']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('should return empty for all non-existing roots', () => {
+    const result = scanAllSkillRoots(['/nonexistent1', '/nonexistent2']);
+    expect(result).toEqual([]);
+  });
+});

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -5,22 +5,26 @@
 **Branch:** `feat/st-06001-skill-registry-and-discovery`
 
 ### Checklist
-- [ ] Create branch `feat/st-06001-skill-registry-and-discovery`
+- [x] Create branch `feat/st-06001-skill-registry-and-discovery`
 - [ ] Create draft PR with story ID in title
-- [ ] Implement `SkillRegistry` class accepting `skillRoots: string[]` config (parallel to ToolRegistry)
-- [ ] Implement auto-scan of configured roots at init — identify directories containing a valid `SKILL.md`
-- [ ] Implement YAML frontmatter parser for all spec fields: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
-- [ ] Implement `name` field validation per spec (1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, must match parent directory name)
-- [ ] Implement `description` field validation per spec (1-1024 chars, non-empty)
-- [ ] Add duplicate skill name handling with deterministic precedence and structured warnings
-- [ ] Expose query API: `.get(name)`, `.getAll()`, `.has(name)`, `.size()` — returning skill metadata (name, description, source path, full parsed metadata)
-- [ ] Emit events: `skill:discovered`, `skill:warning` during scan for observability
-- [ ] Add structured logs for discovery counts, parse successes, and parse failures
-- [ ] Create unit tests for SkillRegistry init, scanner, frontmatter parser, name validation, query API, duplicate handling, and malformed skill recovery
-- [ ] Add or update story documentation at docs/st06001-skill-discovery-and-frontmatter.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Implement `SkillRegistry` class accepting `skillRoots: string[]` config (parallel to ToolRegistry)
+- [x] Implement auto-scan of configured roots at init — identify directories containing a valid `SKILL.md`
+- [x] Implement YAML frontmatter parser for all spec fields: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
+- [x] Implement `name` field validation per spec (1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, must match parent directory name)
+- [x] Implement `description` field validation per spec (1-1024 chars, non-empty)
+- [x] Add duplicate skill name handling with deterministic precedence and structured warnings
+- [x] Expose query API: `.get(name)`, `.getAll()`, `.has(name)`, `.size()` — returning skill metadata (name, description, source path, full parsed metadata)
+- [x] Emit events: `skill:discovered`, `skill:warning` during scan for observability
+- [x] Add structured logs for discovery counts, parse successes, and parse failures
+- [x] Create unit tests for SkillRegistry init, scanner, frontmatter parser, name validation, query API, duplicate handling, and malformed skill recovery
+  - 71 tests across 3 files: parser (34), scanner (10), registry (27)
+- [x] Add or update story documentation at docs/st06001-skill-discovery-and-frontmatter.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - 71 new unit tests added covering all acceptance criteria
+- [x] Run full test suite before finalizing the PR and record results
+  - 148 test files passed, 7 failed (pre-existing Docker/testcontainers — MySQL/PostgreSQL integration), 2106 tests passed
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any in patterns package)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -6,7 +6,8 @@
 
 ### Checklist
 - [x] Create branch `feat/st-06001-skill-registry-and-discovery`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #46: https://github.com/TVScoundrel/agentforge/pull/46
 - [x] Implement `SkillRegistry` class accepting `skillRoots: string[]` config (parallel to ToolRegistry)
 - [x] Implement auto-scan of configured roots at init — identify directories containing a valid `SKILL.md`
 - [x] Implement YAML frontmatter parser for all spec fields: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
@@ -25,8 +26,11 @@
   - 148 test files passed, 7 failed (pre-existing Docker/testcontainers — MySQL/PostgreSQL integration), 2106 tests passed
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any in patterns package)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `05b85ca` feat(st-06001): implement SkillRegistry with folder-config auto-discovery
+  - `1844948` test(st-06001): add unit tests for SkillRegistry, parser, and scanner
+  - `7feb594` docs(st-06001): add story documentation and update trackers
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories (queued for prioritization and dependencies)
 
@@ -20,6 +20,12 @@ _No stories currently ready_
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-06001: Implement SkillRegistry with Folder-Config Auto-Discovery
 - **Epic:** EP-06
 - **Priority:** P0
@@ -28,12 +34,7 @@ _No stories currently ready_
 - **Checklist:** `planning/checklists/epic-06-story-tasks.md`
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
 - **Branch:** `feat/st-06001-skill-registry-and-discovery`
-
----
-
-## In Review
-
-_No stories currently in review_
+- **PR:** https://github.com/TVScoundrel/agentforge/pull/46
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,15 +4,21 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
-- **Backlog:** 5 stories (queued for prioritization and dependencies)
+- **Backlog:** 4 stories (queued for prioritization and dependencies)
 
 ---
 
 ## Ready
+
+_No stories currently ready_
+
+---
+
+## In Progress
 
 ### ST-06001: Implement SkillRegistry with Folder-Config Auto-Discovery
 - **Epic:** EP-06
@@ -21,12 +27,7 @@
 - **Dependencies:** None
 - **Checklist:** `planning/checklists/epic-06-story-tasks.md`
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
-
----
-
-## In Progress
-
-_No stories currently in progress_
+- **Branch:** `feat/st-06001-skill-registry-and-discovery`
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@langchain/langgraph':
         specifier: ^1.1.2
         version: 1.1.2(@langchain/core@1.1.17(openai@6.16.0(zod@3.25.76)))(zod-to-json-schema@3.25.0(zod@3.25.76))(zod@3.25.76)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -2007,6 +2010,9 @@ packages:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2648,6 +2654,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -2710,6 +2721,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2892,6 +2907,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2991,6 +3010,10 @@ packages:
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3088,6 +3111,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -3106,6 +3133,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   langsmith@0.4.2:
     resolution: {integrity: sha512-BvBeFgSmR9esl8x5wsiDlALiHKKPybw2wE2Hh6x1tgSZki46H9c9KI9/06LARbPhyyDu/TZU7exfg6fnhdj1Qg==}
@@ -3791,6 +3822,10 @@ packages:
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -3893,6 +3928,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sql-escaper@1.3.3:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
@@ -3949,6 +3987,10 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -5899,6 +5941,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   asn1@0.2.6:
@@ -6560,6 +6606,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -6657,6 +6705,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   fast-deep-equal@3.1.3: {}
 
@@ -6846,6 +6898,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -6946,6 +7005,8 @@ snapshots:
 
   is-electron@2.2.2: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -7022,6 +7083,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -7041,6 +7107,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   langsmith@0.4.2(openai@6.16.0(zod@3.25.76)):
     dependencies:
@@ -7729,6 +7797,11 @@ snapshots:
 
   search-insights@2.17.3: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@7.7.3: {}
 
   send@1.2.1:
@@ -7853,6 +7926,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   sql-escaper@1.3.3: {}
 
   ssh-remote-port-forward@1.0.4:
@@ -7923,6 +7998,8 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-final-newline@3.0.0: {}
 


### PR DESCRIPTION
## Story

**ST-06001: Implement SkillRegistry with Folder-Config Auto-Discovery**
- Epic: EP-06 (Agent Skills Compatibility Layer)
- Checklist: `planning/checklists/epic-06-story-tasks.md`

## What Changed

Adds the `SkillRegistry` class to `@agentforge/core` — a folder-config auto-discovery system for Agent Skills following the [Agent Skills Specification](https://agentskills.io/specification).

### New Files
- `packages/core/src/skills/types.ts` — Core type definitions (SkillMetadata, Skill, SkillRegistryConfig, events)
- `packages/core/src/skills/parser.ts` — YAML frontmatter parser with spec-compliant validation
- `packages/core/src/skills/scanner.ts` — Filesystem scanner for skill directories
- `packages/core/src/skills/registry.ts` — SkillRegistry class with auto-discovery and query API
- `packages/core/src/skills/index.ts` — Barrel exports
- `packages/core/tests/skills/parser.test.ts` — 34 parser/validation tests
- `packages/core/tests/skills/scanner.test.ts` — 10 scanner tests with temp fixtures
- `packages/core/tests/skills/registry.test.ts` — 27 registry integration tests
- `docs/st06001-skill-discovery-and-frontmatter.md` — Story documentation

### Dependencies Added
- `gray-matter` — YAML frontmatter parsing (MIT, 5M+ weekly npm downloads)

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| SkillRegistry accepting `skillRoots: string[]` config | ✅ Implemented |
| Auto-scan of configured roots at init | ✅ Implemented |
| YAML frontmatter parser for all spec fields | ✅ Implemented |
| Name validation per spec (1-64 chars, lowercase, hyphens, match dir) | ✅ Implemented |
| Description validation per spec (1-1024 chars) | ✅ Implemented |
| Duplicate handling with deterministic precedence | ✅ Implemented (first root wins) |
| Query API: get, getAll, has, size | ✅ Implemented (+getNames, getScanErrors) |
| Events: skill:discovered, skill:warning | ✅ Implemented |
| Structured logging | ✅ Implemented with agentforge:core:skills hierarchy |
| Unit tests for all components | ✅ 71 tests across 3 files |

## Validation Performed

- **Build**: `pnpm build` — ESM + CJS + DTS all pass
- **Skills tests**: 71 tests passed (3 files)
- **Full test suite**: 148 files passed, 7 failed (pre-existing Docker/testcontainers — MySQL/PostgreSQL integration needing Docker runtime), 2106 tests passed total
- **Lint**: `pnpm lint` — 0 errors, 109 warnings (all pre-existing `@typescript-eslint/no-explicit-any` in patterns package)

## Status

Ready for review.
