### PR TITLE
ST-06002: Implement SkillRegistry.generatePrompt() and System Prompt Integration

### DIFF
--- a/docs/st06002-system-prompt-skills-injection.md
+++ b/docs/st06002-system-prompt-skills-injection.md
@@ -1,0 +1,69 @@
+# ST-06002: SkillRegistry.generatePrompt() and System Prompt Integration
+
+## Summary
+
+Implements `SkillRegistry.generatePrompt()` — produces an `<available_skills>` XML block for system prompt injection, following the Agent Skills integration guide format. Mirrors the role of `ToolRegistry.generatePrompt()` for tools.
+
+## Design Decisions
+
+### XML Output Format (vs Plain Text)
+
+The Agent Skills spec recommends XML for structured skill metadata in prompts. This differs from `ToolRegistry.generatePrompt()` which uses plain text. The XML format provides:
+- Clear structure for LLM parsing (`<name>`, `<description>`, `<location>`)
+- Composability — concatenating XML and plain text sections in system prompts works naturally
+
+### Feature Flag (Default Off)
+
+`config.enabled` defaults to `false`. When disabled, `generatePrompt()` returns an empty string, ensuring agents without skills operate with completely unmodified system prompts. This makes the feature opt-in and safe for existing deployments.
+
+### Subset Filtering
+
+`generatePrompt({ skills: ['code-review', 'testing'] })` enables creating focused agents with different skill sets from the same registry. When the `skills` array is omitted or empty, all discovered skills are included.
+
+### maxDiscoveredSkills Cap
+
+Applied after subset filtering. Limits prompt token usage when many skills are discovered. Skills are included in discovery order (first root first).
+
+## API Surface
+
+```typescript
+const registry = new SkillRegistry({
+  skillRoots: ['~/.copilot/skills'],
+  enabled: true,            // Feature flag (default: false)
+  maxDiscoveredSkills: 10,  // Optional cap
+});
+
+// All skills
+const xml = registry.generatePrompt();
+
+// Subset for focused agent
+const xml = registry.generatePrompt({ skills: ['code-review'] });
+
+// Compose with tool prompt
+const systemPrompt = [
+  toolRegistry.generatePrompt(),
+  skillRegistry.generatePrompt(),
+].filter(Boolean).join('\n\n');
+```
+
+### Example XML Output
+
+```xml
+<available_skills>
+  <skill>
+    <name>code-review</name>
+    <description>Review code for quality and correctness</description>
+    <location>/home/user/.copilot/skills/code-review</location>
+  </skill>
+</available_skills>
+```
+
+## Test Coverage
+
+- **23 tests** in `packages/core/tests/skills/prompt.test.ts`
+- Feature Flag Gating (4 tests): default off, explicit off, enabled, enabled but empty
+- XML Generation (3 tests): structure, multiple skills, XML escaping
+- Subset Filtering (5 tests): filter, nonexistent, empty array, no options, mixed
+- maxDiscoveredSkills Cap (5 tests): limit, zero, exceeds, after filter, undefined
+- Prompt Composition (2 tests): composable with tool prompt, empty when disabled
+- Edge Cases (4 tests): undefined options, empty registry, re-scan, consistency

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -7,6 +7,7 @@ export type {
   SkillMetadata,
   Skill,
   SkillRegistryConfig,
+  SkillPromptOptions,
   SkillEventHandler,
   SkillParseResult,
   SkillValidationError,

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -55,6 +55,43 @@ export interface SkillRegistryConfig {
    * @example ['.agentskills', '~/.agentskills', './project-skills']
    */
   skillRoots: string[];
+
+  /**
+   * Feature flag to enable Agent Skills in system prompts.
+   *
+   * When `false` (default), `generatePrompt()` returns an empty string
+   * so agents operate with unmodified system prompts.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
+   * Maximum number of skills to include in generated prompts.
+   *
+   * Caps prompt token usage when many skills are discovered.
+   * Skills are included in discovery order (first root first).
+   * When undefined, all discovered skills are included.
+   */
+  maxDiscoveredSkills?: number;
+}
+
+/**
+ * Options for `SkillRegistry.generatePrompt()`.
+ */
+export interface SkillPromptOptions {
+  /**
+   * Subset of skill names to include in the generated prompt.
+   *
+   * When provided, only skills matching these names appear in the
+   * `<available_skills>` XML block. This enables creating focused
+   * agents with different skill sets from the same registry.
+   *
+   * When omitted or empty, all discovered skills are included.
+   *
+   * @example ['code-review', 'testing-strategy']
+   */
+  skills?: string[];
 }
 
 /**

--- a/packages/core/tests/skills/prompt.test.ts
+++ b/packages/core/tests/skills/prompt.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for SkillRegistry.generatePrompt()
+ *
+ * Covers: XML generation, subset filtering, feature flag gating,
+ * maxDiscoveredSkills cap, prompt composition, XML escaping, token estimation,
+ * and edge cases.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../../src/skills/registry.js';
+
+/**
+ * Create a temp directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-prompt-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, frontmatter: { name: string; description: string }): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\nname: ${frontmatter.name}\ndescription: "${frontmatter.description}"\n---\n\n# ${frontmatter.name}\n\nSkill body content.`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('SkillRegistry.generatePrompt()', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function makeTempDir(): string {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  // ─── Feature Flag Gating ───────────────────────────────────────────────
+
+  describe('Feature Flag Gating', () => {
+    it('should return empty string when enabled is not set (default off)', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root] });
+      expect(registry.size()).toBe(1);
+      expect(registry.generatePrompt()).toBe('');
+    });
+
+    it('should return empty string when enabled is false', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: false });
+      expect(registry.generatePrompt()).toBe('');
+    });
+
+    it('should generate XML when enabled is true', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+      expect(xml).toContain('<available_skills>');
+      expect(xml).toContain('</available_skills>');
+      expect(xml).toContain('<name>my-skill</name>');
+    });
+
+    it('should return empty string when enabled but no skills discovered', () => {
+      const root = makeTempDir();
+      // Empty root — no skills
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      expect(registry.generatePrompt()).toBe('');
+    });
+  });
+
+  // ─── XML Generation ────────────────────────────────────────────────────
+
+  describe('XML Generation', () => {
+    it('should produce valid XML structure with name, description, location', () => {
+      const root = makeTempDir();
+      const skillDir = createSkillFixture(root, 'code-review', {
+        name: 'code-review',
+        description: 'Review code for quality and correctness',
+      });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toMatch(/^<available_skills>\n/);
+      expect(xml).toMatch(/\n<\/available_skills>$/);
+      expect(xml).toContain('  <skill>');
+      expect(xml).toContain('  </skill>');
+      expect(xml).toContain('    <name>code-review</name>');
+      expect(xml).toContain('    <description>Review code for quality and correctness</description>');
+      expect(xml).toContain(`    <location>${skillDir}</location>`);
+    });
+
+    it('should include multiple skills', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+
+      // Count skill blocks
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should escape XML special characters in skill fields', () => {
+      const root = makeTempDir();
+      const skillDir = join(root, 'html-tools');
+      mkdirSync(skillDir, { recursive: true });
+      // Description with XML-unsafe characters
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: html-tools',
+        'description: "Tools for <html> & \'CSS\\" parsing"',
+        '---',
+        '',
+        '# HTML Tools',
+      ].join('\n'), 'utf-8');
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>html-tools</name>');
+      // Should escape < > & ' "
+      expect(xml).toContain('&lt;html&gt;');
+      expect(xml).toContain('&amp;');
+    });
+  });
+
+  // ─── Subset Filtering ─────────────────────────────────────────────────
+
+  describe('Subset Filtering', () => {
+    it('should filter to requested skill names', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+      createSkillFixture(root, 'deployment', { name: 'deployment', description: 'Deploy apps' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['code-review', 'testing'] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+      expect(xml).not.toContain('<name>deployment</name>');
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should return empty string when no requested skills exist', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['nonexistent'] });
+
+      expect(xml).toBe('');
+    });
+
+    it('should return all skills when skills array is empty', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: [] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+    });
+
+    it('should return all skills when no options provided', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+    });
+
+    it('should gracefully handle mix of existing and non-existing names', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['code-review', 'nonexistent'] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).not.toContain('nonexistent');
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(1);
+    });
+  });
+
+  // ─── maxDiscoveredSkills Cap ───────────────────────────────────────────
+
+  describe('maxDiscoveredSkills Cap', () => {
+    it('should limit skills to maxDiscoveredSkills', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 2,
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should return empty string when maxDiscoveredSkills is 0', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 0,
+      });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toBe('');
+    });
+
+    it('should return all skills when maxDiscoveredSkills exceeds count', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 100,
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should apply maxDiscoveredSkills after subset filter', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 1,
+      });
+
+      // Request 2 skills but cap at 1
+      const xml = registry.generatePrompt({ skills: ['skill-a', 'skill-b'] });
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(1);
+    });
+
+    it('should not apply cap when maxDiscoveredSkills is undefined', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        // maxDiscoveredSkills not set
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(3);
+    });
+  });
+
+  // ─── Prompt Composition ────────────────────────────────────────────────
+
+  describe('Prompt Composition', () => {
+    it('should compose naturally with other prompt sections', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+
+      // Simulate composing with tool prompt
+      const toolPrompt = 'Available Tools:\n\n- my-tool: Does things';
+      const skillPrompt = registry.generatePrompt();
+
+      const systemPrompt = [toolPrompt, skillPrompt].filter(Boolean).join('\n\n');
+
+      expect(systemPrompt).toContain('Available Tools:');
+      expect(systemPrompt).toContain('<available_skills>');
+      expect(systemPrompt).toContain('code-review');
+    });
+
+    it('should not add extra content when disabled (composable as empty)', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: false });
+
+      const toolPrompt = 'Available Tools:\n\n- my-tool: Does things';
+      const skillPrompt = registry.generatePrompt();
+
+      const systemPrompt = [toolPrompt, skillPrompt].filter(Boolean).join('\n\n');
+
+      // Should only contain tool prompt, no skills XML
+      expect(systemPrompt).toBe(toolPrompt);
+      expect(systemPrompt).not.toContain('<available_skills>');
+    });
+  });
+
+  // ─── Edge Cases ────────────────────────────────────────────────────────
+
+  describe('Edge Cases', () => {
+    it('should handle undefined options gracefully', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt(undefined);
+
+      expect(xml).toContain('<name>my-skill</name>');
+    });
+
+    it('should handle empty registry with enabled flag', () => {
+      const root = makeTempDir();
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+
+      expect(registry.generatePrompt()).toBe('');
+      expect(registry.generatePrompt({ skills: ['anything'] })).toBe('');
+    });
+
+    it('should reflect registry changes after re-scan', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      expect(registry.generatePrompt()).toContain('<name>skill-a</name>');
+
+      // Add another skill and re-scan
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      registry.discover();
+
+      const xml = registry.generatePrompt();
+      expect(xml).toContain('<name>skill-a</name>');
+      expect(xml).toContain('<name>skill-b</name>');
+    });
+
+    it('should produce consistent XML across multiple calls', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml1 = registry.generatePrompt();
+      const xml2 = registry.generatePrompt();
+
+      expect(xml1).toBe(xml2);
+    });
+  });
+});

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -42,7 +42,8 @@
 
 ### Checklist
 - [x] Create branch `feat/st-06002-skill-registry-prompt-generation`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #47: https://github.com/TVScoundrel/agentforge/pull/47
 - [x] Implement `SkillRegistry.generatePrompt()` returning `<available_skills>` XML block (name + description per skill)
 - [x] Implement `generatePrompt({ skills?: string[] })` subset filter — only named skills appear in XML, enabling focused agents with different skill sets
 - [x] Follow Agent Skills integration guide XML format (name, description, location elements per skill)

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -41,21 +41,30 @@
 **Branch:** `feat/st-06002-skill-registry-prompt-generation`
 
 ### Checklist
-- [ ] Create branch `feat/st-06002-skill-registry-prompt-generation`
+- [x] Create branch `feat/st-06002-skill-registry-prompt-generation`
 - [ ] Create draft PR with story ID in title
-- [ ] Implement `SkillRegistry.generatePrompt()` returning `<available_skills>` XML block (name + description per skill)
-- [ ] Implement `generatePrompt({ skills?: string[] })` subset filter — only named skills appear in XML, enabling focused agents with different skill sets
-- [ ] Follow Agent Skills integration guide XML format (name, description, location elements per skill)
-- [ ] Ensure prompt output composes naturally with `toolRegistry.generatePrompt()` in system prompt construction
-- [ ] Add `agentSkills.enabled` feature flag (default: off) — `generatePrompt()` returns empty string when disabled
-- [ ] Add configurable `maxDiscoveredSkills` cap to limit prompt token usage
-- [ ] Verify agents without skills enabled operate with unmodified system prompts
-- [ ] Add structured logs for prompt generation events (skill count, token estimate)
-- [ ] Create unit tests for XML generation, subset filtering, feature flag gating, prompt composition, and token budget limits
-- [ ] Add or update story documentation at docs/st06002-system-prompt-skills-injection.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Implement `SkillRegistry.generatePrompt()` returning `<available_skills>` XML block (name + description per skill)
+- [x] Implement `generatePrompt({ skills?: string[] })` subset filter — only named skills appear in XML, enabling focused agents with different skill sets
+- [x] Follow Agent Skills integration guide XML format (name, description, location elements per skill)
+- [x] Ensure prompt output composes naturally with `toolRegistry.generatePrompt()` in system prompt construction
+  - Tested: concatenating skill XML with tool plain text via `filter(Boolean).join('\n\n')`
+- [x] Add `agentSkills.enabled` feature flag (default: off) — `generatePrompt()` returns empty string when disabled
+  - Added `enabled?: boolean` to `SkillRegistryConfig` (default: `false`)
+- [x] Add configurable `maxDiscoveredSkills` cap to limit prompt token usage
+  - Added `maxDiscoveredSkills?: number` to `SkillRegistryConfig`, applied after subset filter
+- [x] Verify agents without skills enabled operate with unmodified system prompts
+  - Tested: disabled flag returns empty string, `filter(Boolean)` removes it from composed prompt
+- [x] Add structured logs for prompt generation events (skill count, token estimate)
+  - Logs: `skillCount`, `totalDiscovered`, `filterApplied`, `maxCap`, `estimatedTokens`, `xmlLength`
+- [x] Create unit tests for XML generation, subset filtering, feature flag gating, prompt composition, and token budget limits
+  - 23 tests in `packages/core/tests/skills/prompt.test.ts`
+- [x] Add or update story documentation at docs/st06002-system-prompt-skills-injection.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - 23 new unit tests covering all acceptance criteria
+- [x] Run full test suite before finalizing the PR and record results
+  - 149 test files passed, 7 failed (pre-existing Docker/testcontainers), 2129 tests passed
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any in patterns package)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories (queued for prioritization and dependencies)
@@ -14,6 +14,12 @@
 
 ## Ready
 
+_No stories currently ready_
+
+---
+
+## In Progress
+
 ### ST-06002: Implement SkillRegistry.generatePrompt() and System Prompt Integration
 - **Epic:** EP-06
 - **Priority:** P0
@@ -21,12 +27,7 @@
 - **Dependencies:** ST-06001 (merged)
 - **Checklist:** `planning/checklists/epic-06-story-tasks.md`
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
-
----
-
-## In Progress
-
-_No stories currently in progress_
+- **Branch:** `feat/st-06002-skill-registry-prompt-generation`
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories (queued for prioritization and dependencies)
 
@@ -20,6 +20,12 @@ _No stories currently ready_
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-06002: Implement SkillRegistry.generatePrompt() and System Prompt Integration
 - **Epic:** EP-06
 - **Priority:** P0
@@ -28,12 +34,7 @@ _No stories currently ready_
 - **Checklist:** `planning/checklists/epic-06-story-tasks.md`
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
 - **Branch:** `feat/st-06002-skill-registry-prompt-generation`
-
----
-
-## In Review
-
-_No stories currently in review_
+- **PR:** https://github.com/TVScoundrel/agentforge/pull/47
 
 ---
 


### PR DESCRIPTION
## Story

**ST-06002: Implement SkillRegistry.generatePrompt() and System Prompt Integration**
- Epic: EP-06 (Agent Skills Compatibility Layer)
- Checklist: `planning/checklists/epic-06-story-tasks.md`

## What Changed

Adds `SkillRegistry.generatePrompt()` — produces an `<available_skills>` XML block for system prompt injection, following the Agent Skills integration guide format.

### Modified Files
- `packages/core/src/skills/types.ts` — Added `SkillPromptOptions` type, extended `SkillRegistryConfig` with `enabled` flag and `maxDiscoveredSkills` cap
- `packages/core/src/skills/registry.ts` — Implemented `generatePrompt()` method with feature flag gating, subset filtering, max cap, XML escaping, and structured logging
- `packages/core/src/skills/index.ts` — Added `SkillPromptOptions` to barrel exports

### New Files
- `packages/core/tests/skills/prompt.test.ts` — 23 unit tests for prompt generation
- `docs/st06002-system-prompt-skills-injection.md` — Story documentation

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| `generatePrompt()` returns `<available_skills>` XML | ✅ Implemented |
| `generatePrompt({ skills?: string[] })` subset filter | ✅ Implemented |
| Agent Skills integration guide XML format (name, description, location) | ✅ Implemented |
| Composable with `toolRegistry.generatePrompt()` | ✅ Tested |
| `enabled` feature flag (default: off) | ✅ Implemented on `SkillRegistryConfig` |
| `maxDiscoveredSkills` cap | ✅ Implemented, applied after subset filter |
| Agents without skills enabled get unmodified prompts | ✅ Tested |
| Structured logs (skill count, token estimate) | ✅ Implemented |
| Unit tests | ✅ 23 tests across 6 test groups |

## Validation Performed

- **Build**: `pnpm build` — ESM + CJS + DTS all pass
- **Skills tests**: 94 tests passed (4 files — 71 existing + 23 new)
- **Full test suite**: 149 files passed, 7 failed (pre-existing Docker/testcontainers), 2129 tests passed total
- **Lint**: `pnpm lint` — 0 errors, 109 warnings (all pre-existing)

## Status

Ready for review.
