### PR TITLE
feat(st-06003): implement skill activation and resource tools

### DIFF
--- a/docs/st06003-skill-activation-and-resource-tools.md
+++ b/docs/st06003-skill-activation-and-resource-tools.md
@@ -1,0 +1,108 @@
+# ST-06003: Skill Activation and Resource Tools
+
+**Story:** As an agent at runtime, I want to activate a skill by name and optionally load its referenced resources so that I can follow skill instructions to complete user tasks.
+
+**Epic:** EP-06 (Agent Skills Compatibility Layer)
+**Branch:** `feat/st-06003-skill-activation-and-resource-tools`
+**PR:** https://github.com/TVScoundrel/agentforge/pull/48
+
+---
+
+## Summary
+
+This story implements the runtime activation layer for the Agent Skills system. Two tools —  `activate-skill` and `read-skill-resource` — are built using the AgentForge tool builder API and pre-wired to a `SkillRegistry` instance via the `toActivationTools()` convenience method.
+
+These tools follow the Agent Skills specification's **progressive disclosure** pattern:
+1. **Discovery** (ST-06002): skill name + description in `<available_skills>` XML
+2. **Activation** (this story): full SKILL.md body loaded on demand via tool call
+3. **Resources** (this story): referenced files (scripts/, references/, assets/) loaded on demand
+
+## Architecture
+
+### Tool Design
+
+Both tools are first-class AgentForge tools created with `ToolBuilder`:
+
+| Tool | Input | Output | Purpose |
+|------|-------|--------|---------|
+| `activate-skill` | `{ name: string }` | Full SKILL.md body (string) | Load skill instructions |
+| `read-skill-resource` | `{ name: string, path: string }` | File content (string) | Load referenced resource |
+
+### Integration Pattern
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+import { createReActAgent } from '@agentforge/patterns';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: ['.agentskills', '~/.agentskills'],
+  enabled: true,
+});
+
+const agent = createReActAgent({
+  model: llm,
+  tools: [
+    ...toolRegistry.toLangChainTools(),
+    ...skillRegistry.toActivationTools(),  // [activate-skill, read-skill-resource]
+  ],
+  systemPrompt: [
+    'You are a helpful assistant.',
+    toolRegistry.generatePrompt(),
+    skillRegistry.generatePrompt(),
+  ].filter(Boolean).join('\n\n'),
+});
+```
+
+### Path Traversal Protection
+
+`read-skill-resource` implements strict path containment:
+- Rejects absolute paths (starting with `/` or `\`)
+- Rejects `..` traversal patterns (both direct and nested)
+- Resolves paths relative to the skill root directory
+- Verifies the resolved path remains within the skill root using `path.relative()` comparison
+
+### Event System Extension
+
+Two new events added to `SkillRegistryEvent`:
+- `skill:activated` — emitted when `activate-skill` successfully loads a skill body
+- `skill:resource-loaded` — emitted when `read-skill-resource` successfully reads a file
+
+Events are emitted through the registry's event system via the new `emitEvent()` public method.
+
+### SKILLS Tool Category
+
+A new `ToolCategory.SKILLS` enum value (`'skills'`) was added to organize skill-related tools alongside existing categories (FILE_SYSTEM, WEB, CODE, DATABASE, API, UTILITY, CUSTOM).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/skills/activation.ts` | **NEW** — Tool factories, path resolver, body extractor |
+| `packages/core/src/skills/registry.ts` | Added `toActivationTools()`, `emitEvent()`, activation import |
+| `packages/core/src/skills/types.ts` | Added `SKILL_ACTIVATED`, `SKILL_RESOURCE_LOADED` events |
+| `packages/core/src/skills/index.ts` | Added activation tool exports |
+| `packages/core/src/tools/types.ts` | Added `SKILLS` to `ToolCategory` enum |
+| `packages/core/tests/skills/activation.test.ts` | **NEW** — 38 tests |
+
+## Test Coverage
+
+38 tests across 6 describe blocks:
+
+| Block | Tests | Coverage |
+|-------|-------|----------|
+| `resolveResourcePath` | 8 | Path security: absolute, traversal, valid paths |
+| `activate-skill tool` | 8 | Metadata, success, errors, events, edge cases |
+| `read-skill-resource tool` | 11 | All resource dirs, traversal blocking, errors, events |
+| `createSkillActivationTools` | 2 | Factory output shape and categories |
+| `SkillRegistry.toActivationTools()` | 2 | Convenience method binding |
+| `End-to-end integration` | 5+2 | Full workflows, multi-root, event lifecycle, compose |
+
+## Design Decisions
+
+1. **Lazy body loading**: SKILL.md body is read from disk at activation time rather than cached in the registry. This aligns with the spec's progressive disclosure principle and avoids storing potentially large instruction sets in memory for all discovered skills.
+
+2. **String return type**: Both tools return strings (not parsed objects). This matches the spec's intent that skill content is instruction text for the LLM to follow, not structured data for programmatic consumption.
+
+3. **Error messages as return values**: Tools return descriptive error strings rather than throwing exceptions. This prevents agent crashes and gives the LLM context to recover gracefully.
+
+4. **Public `emitEvent()`**: Rather than tightly coupling the activation tools into the registry class, tools call `registry.emitEvent()` to emit events through the existing event system. This keeps the activation module independent while maintaining unified observability.

--- a/packages/core/src/skills/activation.ts
+++ b/packages/core/src/skills/activation.ts
@@ -1,0 +1,278 @@
+/**
+ * Skill Activation Tools
+ *
+ * Provides `activate-skill` and `read-skill-resource` tools built with
+ * the AgentForge tool builder API. These tools enable agents to load
+ * skill instructions on demand and access skill resources at runtime.
+ *
+ * @see https://agentskills.io/specification
+ *
+ * @example
+ * ```ts
+ * const tools = createSkillActivationTools(registry);
+ * // tools.activateSkill  — load full SKILL.md body
+ * // tools.readSkillResource — load a resource file from a skill
+ *
+ * // Or use the convenience method:
+ * const tools = registry.toActivationTools();
+ * ```
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, normalize, relative } from 'node:path';
+import { z } from 'zod';
+import { ToolBuilder } from '../tools/builder.js';
+import { ToolCategory } from '../tools/types.js';
+import type { Tool } from '../tools/types.js';
+import type { SkillRegistry } from './registry.js';
+import { SkillRegistryEvent } from './types.js';
+import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
+
+const logger = createLogger('agentforge:core:skills:activation', { level: LogLevel.INFO });
+
+// ─── Schemas ─────────────────────────────────────────────────────────────
+
+const activateSkillSchema = z.object({
+  name: z.string().describe('The name of the skill to activate (e.g., "code-review")'),
+});
+
+const readSkillResourceSchema = z.object({
+  name: z.string().describe('The name of the skill that owns the resource'),
+  path: z.string().describe('Relative path to the resource file within the skill directory (e.g., "references/GUIDE.md", "scripts/setup.sh")'),
+});
+
+// ─── Path Security ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a resource path within a skill root, blocking path traversal.
+ *
+ * @param skillPath - Absolute path to the skill directory
+ * @param resourcePath - Relative path to the resource file
+ * @returns Absolute path to the resource, or an error string
+ */
+export function resolveResourcePath(
+  skillPath: string,
+  resourcePath: string,
+): { success: true; resolvedPath: string } | { success: false; error: string } {
+  // Reject absolute paths
+  if (resourcePath.startsWith('/') || resourcePath.startsWith('\\')) {
+    return { success: false, error: 'Absolute resource paths are not allowed' };
+  }
+
+  // Reject obvious traversal patterns before resolution
+  const normalized = normalize(resourcePath);
+  if (normalized.startsWith('..') || normalized.includes('..')) {
+    return { success: false, error: 'Path traversal is not allowed — resource paths must stay within the skill directory' };
+  }
+
+  // Resolve and verify containment
+  const resolvedPath = resolve(skillPath, resourcePath);
+  const resolvedSkillPath = resolve(skillPath);
+
+  // Ensure the resolved path is within the skill directory
+  const rel = relative(resolvedSkillPath, resolvedPath);
+  if (rel.startsWith('..') || resolve(resolvedSkillPath, rel) !== resolvedPath) {
+    return { success: false, error: 'Path traversal is not allowed — resource paths must stay within the skill directory' };
+  }
+
+  return { success: true, resolvedPath };
+}
+
+// ─── Tool Factories ──────────────────────────────────────────────────────
+
+/**
+ * Create the `activate-skill` tool bound to a registry instance.
+ *
+ * Resolves the skill by name, reads the full SKILL.md file, and returns
+ * the body content (below frontmatter).
+ *
+ * @param registry - The SkillRegistry to resolve skills from
+ * @returns An AgentForge Tool
+ */
+export function createActivateSkillTool(
+  registry: SkillRegistry,
+): Tool<z.infer<typeof activateSkillSchema>, string> {
+  return new ToolBuilder<z.infer<typeof activateSkillSchema>, string>()
+    .name('activate-skill')
+    .description(
+      'Activate an Agent Skill by name, loading its full instructions. ' +
+      'Returns the complete SKILL.md body content for the named skill. ' +
+      'Use this when you see a relevant skill in <available_skills> and want to follow its instructions.',
+    )
+    .category(ToolCategory.SKILLS)
+    .tags(['skill', 'activation', 'agent-skills'])
+    .schema(activateSkillSchema)
+    .implement(async ({ name }) => {
+      const skill = registry.get(name);
+
+      if (!skill) {
+        const availableNames = registry.getNames();
+        const suggestion = availableNames.length > 0
+          ? ` Available skills: ${availableNames.join(', ')}`
+          : ' No skills are currently registered.';
+        const errorMsg = `Skill "${name}" not found.${suggestion}`;
+
+        logger.warn('Skill activation failed — not found', { name, availableCount: availableNames.length });
+        return errorMsg;
+      }
+
+      // Read the full SKILL.md body from disk (progressive disclosure)
+      const skillMdPath = resolve(skill.skillPath, 'SKILL.md');
+      try {
+        const content = readFileSync(skillMdPath, 'utf-8');
+
+        // Extract body below frontmatter
+        const body = extractBody(content);
+
+        logger.info('Skill activated', {
+          name: skill.metadata.name,
+          skillPath: skill.skillPath,
+          bodyLength: body.length,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.SKILL_ACTIVATED, {
+          name: skill.metadata.name,
+          skillPath: skill.skillPath,
+          bodyLength: body.length,
+        });
+
+        return body;
+      } catch (error) {
+        const errorMsg = `Failed to read skill "${name}" instructions: ${error instanceof Error ? error.message : String(error)}`;
+        logger.error('Skill activation failed — read error', {
+          name,
+          skillPath: skill.skillPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorMsg;
+      }
+    })
+    .build();
+}
+
+/**
+ * Create the `read-skill-resource` tool bound to a registry instance.
+ *
+ * Resolves the skill by name, validates the resource path (blocking
+ * traversal), and returns the file content.
+ *
+ * @param registry - The SkillRegistry to resolve skills from
+ * @returns An AgentForge Tool
+ */
+export function createReadSkillResourceTool(
+  registry: SkillRegistry,
+): Tool<z.infer<typeof readSkillResourceSchema>, string> {
+  return new ToolBuilder<z.infer<typeof readSkillResourceSchema>, string>()
+    .name('read-skill-resource')
+    .description(
+      'Read a resource file from an activated Agent Skill. ' +
+      'Returns the content of a file within the skill directory (e.g., references/, scripts/, assets/). ' +
+      'The path must be relative to the skill root and cannot traverse outside it.',
+    )
+    .category(ToolCategory.SKILLS)
+    .tags(['skill', 'resource', 'agent-skills'])
+    .schema(readSkillResourceSchema)
+    .implement(async ({ name, path: resourcePath }) => {
+      const skill = registry.get(name);
+
+      if (!skill) {
+        const availableNames = registry.getNames();
+        const suggestion = availableNames.length > 0
+          ? ` Available skills: ${availableNames.join(', ')}`
+          : ' No skills are currently registered.';
+        const errorMsg = `Skill "${name}" not found.${suggestion}`;
+
+        logger.warn('Skill resource load failed — skill not found', { name, resourcePath });
+        return errorMsg;
+      }
+
+      // Resolve and validate the resource path
+      const pathResult = resolveResourcePath(skill.skillPath, resourcePath);
+      if (!pathResult.success) {
+        logger.warn('Skill resource load blocked — path traversal', {
+          name,
+          resourcePath,
+          error: pathResult.error,
+        });
+        return pathResult.error;
+      }
+
+      try {
+        const content = readFileSync(pathResult.resolvedPath, 'utf-8');
+
+        logger.info('Skill resource loaded', {
+          name: skill.metadata.name,
+          resourcePath,
+          resolvedPath: pathResult.resolvedPath,
+          contentLength: content.length,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.SKILL_RESOURCE_LOADED, {
+          name: skill.metadata.name,
+          resourcePath,
+          resolvedPath: pathResult.resolvedPath,
+          contentLength: content.length,
+        });
+
+        return content;
+      } catch (error) {
+        const errorMsg = `Failed to read resource "${resourcePath}" from skill "${name}": ${error instanceof Error ? error.message : String(error)}`;
+        logger.warn('Skill resource load failed — file not found or unreadable', {
+          name,
+          resourcePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorMsg;
+      }
+    })
+    .build();
+}
+
+/**
+ * Create both skill activation tools bound to a registry instance.
+ *
+ * @param registry - The SkillRegistry to bind tools to
+ * @returns Array of both tools [activate-skill, read-skill-resource]
+ */
+export function createSkillActivationTools(
+  registry: SkillRegistry,
+): [Tool<z.infer<typeof activateSkillSchema>, string>, Tool<z.infer<typeof readSkillResourceSchema>, string>] {
+  return [
+    createActivateSkillTool(registry),
+    createReadSkillResourceTool(registry),
+  ];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract the body content below YAML frontmatter from a SKILL.md file.
+ *
+ * Frontmatter is delimited by `---` on lines by themselves.
+ * If no frontmatter is found, returns the full content.
+ *
+ * @param content - The full SKILL.md file content
+ * @returns The body content below the frontmatter
+ */
+function extractBody(content: string): string {
+  const trimmed = content.trimStart();
+
+  // Check for frontmatter opening
+  if (!trimmed.startsWith('---')) {
+    return content.trim();
+  }
+
+  // Find the closing ---
+  const endIndex = trimmed.indexOf('---', 3);
+  if (endIndex === -1) {
+    return content.trim();
+  }
+
+  // Find the newline after the closing ---
+  const afterFrontmatter = trimmed.indexOf('\n', endIndex);
+  if (afterFrontmatter === -1) {
+    return '';
+  }
+
+  return trimmed.slice(afterFrontmatter + 1).trim();
+}

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -33,3 +33,11 @@ export {
 
 // Registry
 export { SkillRegistry } from './registry.js';
+
+// Activation Tools
+export {
+  createActivateSkillTool,
+  createReadSkillResourceTool,
+  createSkillActivationTools,
+  resolveResourcePath,
+} from './activation.js';

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -33,6 +33,7 @@ import type {
 import { SkillRegistryEvent } from './types.js';
 import { scanAllSkillRoots } from './scanner.js';
 import { parseSkillContent } from './parser.js';
+import { createSkillActivationTools } from './activation.js';
 import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 
 const logger = createLogger('agentforge:core:skills:registry', { level: LogLevel.INFO });
@@ -49,6 +50,7 @@ const logger = createLogger('agentforge:core:skills:registry', { level: LogLevel
  * | registry.has('name')     | skillRegistry.has('name')                |
  * | registry.size()          | skillRegistry.size()                     |
  * | registry.generatePrompt()| skillRegistry.generatePrompt()           |
+ * | registry.toLangChainTools()| skillRegistry.toActivationTools()       |
  */
 export class SkillRegistry {
   private skills: Map<string, Skill> = new Map();
@@ -393,6 +395,44 @@ export class SkillRegistry {
         }
       });
     }
+  }
+
+  /**
+   * Emit an event (public API for activation tools).
+   *
+   * Used by skill activation tools to emit `skill:activated` and
+   * `skill:resource-loaded` events through the registry's event system.
+   *
+   * @param event - The event to emit
+   * @param data - The event data
+   */
+  emitEvent(event: SkillRegistryEvent, data: unknown): void {
+    this.emit(event, data);
+  }
+
+  // ─── Tool Integration ────────────────────────────────────────────────
+
+  /**
+   * Create activation tools pre-wired to this registry instance.
+   *
+   * Returns `activate-skill` and `read-skill-resource` tools that
+   * agents can use to load skill instructions and resources on demand.
+   *
+   * @returns Array of [activate-skill, read-skill-resource] tools
+   *
+   * @example
+   * ```ts
+   * const agent = createReActAgent({
+   *   model: llm,
+   *   tools: [
+   *     ...toolRegistry.toLangChainTools(),
+   *     ...skillRegistry.toActivationTools(),
+   *   ],
+   * });
+   * ```
+   */
+  toActivationTools() {
+    return createSkillActivationTools(this);
   }
 }
 

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -431,7 +431,7 @@ export class SkillRegistry {
    * });
    * ```
    */
-  toActivationTools() {
+  toActivationTools(): ReturnType<typeof createSkillActivationTools> {
     return createSkillActivationTools(this);
   }
 }

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -102,6 +102,10 @@ export enum SkillRegistryEvent {
   SKILL_DISCOVERED = 'skill:discovered',
   /** Emitted when a skill parse or validation issue is encountered */
   SKILL_WARNING = 'skill:warning',
+  /** Emitted when a skill is activated (full body loaded) */
+  SKILL_ACTIVATED = 'skill:activated',
+  /** Emitted when a skill resource file is loaded */
+  SKILL_RESOURCE_LOADED = 'skill:resource-loaded',
 }
 
 /**

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -62,6 +62,12 @@ export enum ToolCategory {
    * Use this for tools that don't fit other categories
    */
   CUSTOM = 'custom',
+
+  /**
+   * Tools for Agent Skills activation and resource loading
+   * Examples: activate-skill, read-skill-resource
+   */
+  SKILLS = 'skills',
 }
 
 /**

--- a/packages/core/tests/skills/activation.test.ts
+++ b/packages/core/tests/skills/activation.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Tests for Skill Activation Tools
+ *
+ * Covers:
+ * - activate-skill tool: resolves via SkillRegistry, returns SKILL.md body
+ * - read-skill-resource tool: resolves resource files with path traversal protection
+ * - toActivationTools() convenience method
+ * - resolveResourcePath security function
+ * - Event emission (skill:activated, skill:resource-loaded)
+ * - Error handling for missing skills and resources
+ * - Integration with SkillRegistry lifecycle
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { SkillRegistryEvent } from '../../src/skills/types.js';
+import {
+  createActivateSkillTool,
+  createReadSkillResourceTool,
+  createSkillActivationTools,
+  resolveResourcePath,
+} from '../../src/skills/activation.js';
+import { ToolCategory } from '../../src/tools/types.js';
+
+// ─── Fixture Helpers ─────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-activation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createSkillFixture(
+  root: string,
+  dirName: string,
+  frontmatter: string,
+  body: string,
+): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\n${frontmatter}\n---\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+function createResourceFile(skillDir: string, relativePath: string, content: string): string {
+  const fullPath = join(skillDir, relativePath);
+  const dir = fullPath.substring(0, fullPath.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('resolveResourcePath', () => {
+  it('should resolve a valid relative path within the skill root', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'references/guide.md');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(join('/skills/my-skill', 'references/guide.md'));
+    }
+  });
+
+  it('should block absolute paths', () => {
+    const result = resolveResourcePath('/skills/my-skill', '/etc/passwd');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Absolute resource paths');
+    }
+  });
+
+  it('should block backslash absolute paths', () => {
+    const result = resolveResourcePath('/skills/my-skill', '\\etc\\passwd');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Absolute resource paths');
+    }
+  });
+
+  it('should block simple .. traversal', () => {
+    const result = resolveResourcePath('/skills/my-skill', '../secrets/key');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Path traversal');
+    }
+  });
+
+  it('should block nested .. traversal', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'references/../../secrets/key');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Path traversal');
+    }
+  });
+
+  it('should allow simple filename', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'README.md');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(join('/skills/my-skill', 'README.md'));
+    }
+  });
+
+  it('should allow nested subdirectory paths', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'scripts/setup/install.sh');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(join('/skills/my-skill', 'scripts/setup/install.sh'));
+    }
+  });
+
+  it('should allow assets/ directory', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'assets/logo.png');
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('activate-skill tool', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should have correct tool metadata', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    expect(tool.metadata.name).toBe('activate-skill');
+    expect(tool.metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tool.metadata.tags).toContain('skill');
+    expect(tool.metadata.tags).toContain('activation');
+    expect(tool.metadata.description).toContain('Activate an Agent Skill');
+  });
+
+  it('should return skill body when skill exists', async () => {
+    createSkillFixture(tempDir, 'code-review', 'name: code-review\ndescription: Code review skill', '\n# Code Review\n\nReview code for quality.');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'code-review' });
+
+    expect(result).toContain('# Code Review');
+    expect(result).toContain('Review code for quality.');
+  });
+
+  it('should strip frontmatter from returned body', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill', '\nBody content only');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill' });
+
+    expect(result).not.toContain('name: my-skill');
+    expect(result).toBe('Body content only');
+  });
+
+  it('should return error message for non-existent skill', async () => {
+    createSkillFixture(tempDir, 'code-review', 'name: code-review\ndescription: CR', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'non-existent' });
+
+    expect(result).toContain('Skill "non-existent" not found');
+    expect(result).toContain('code-review');
+  });
+
+  it('should return error message when no skills are registered', async () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'anything' });
+
+    expect(result).toContain('not found');
+    expect(result).toContain('No skills are currently registered');
+  });
+
+  it('should emit skill:activated event', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_ACTIVATED, handler);
+
+    await tool.invoke({ name: 'my-skill' });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-skill',
+        bodyLength: expect.any(Number),
+      }),
+    );
+  });
+
+  it('should handle skill with no SKILL.md gracefully', async () => {
+    // Create a registry with a skill, then delete the SKILL.md
+    const skillDir = createSkillFixture(tempDir, 'broken-skill', 'name: broken-skill\ndescription: Broken', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    // Remove SKILL.md after discovery
+    rmSync(join(skillDir, 'SKILL.md'));
+
+    const tool = createActivateSkillTool(registry);
+    const result = await tool.invoke({ name: 'broken-skill' });
+
+    expect(result).toContain('Failed to read skill');
+  });
+
+  it('should handle skill with only frontmatter (empty body)', async () => {
+    const skillDir = join(tempDir, 'empty-body');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: empty-body\ndescription: Empty\n---', 'utf-8');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'empty-body' });
+    expect(result).toBe('');
+  });
+
+  it('should handle skill with no frontmatter', async () => {
+    const skillDir = join(tempDir, 'no-frontmatter');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Just content\n\nNo frontmatter here.', 'utf-8');
+
+    // This skill will fail parsing (no frontmatter = no name), so it won't be in the registry
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    expect(registry.has('no-frontmatter')).toBe(false);
+  });
+});
+
+describe('read-skill-resource tool', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should have correct tool metadata', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    expect(tool.metadata.name).toBe('read-skill-resource');
+    expect(tool.metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tool.metadata.tags).toContain('resource');
+    expect(tool.metadata.description).toContain('resource file');
+  });
+
+  it('should read a resource file from references/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Reference Guide\n\nSome content.');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(result).toBe('# Reference Guide\n\nSome content.');
+  });
+
+  it('should read a resource file from scripts/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho "Hello"');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(result).toBe('#!/bin/bash\necho "Hello"');
+  });
+
+  it('should read a resource from assets/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'assets/config.json', '{"key": "value"}');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'assets/config.json' });
+
+    expect(result).toBe('{"key": "value"}');
+  });
+
+  it('should read a resource from nested subdirectories', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/api/endpoints.md', '# Endpoints');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/api/endpoints.md' });
+
+    expect(result).toBe('# Endpoints');
+  });
+
+  it('should block path traversal via ../', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '../SKILL.md' });
+
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block path traversal via nested ../../../', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/../../../etc/passwd' });
+
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block absolute paths', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '/etc/passwd' });
+
+    expect(result).toContain('Absolute resource paths');
+  });
+
+  it('should return error for non-existent skill', async () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'ghost', path: 'file.txt' });
+
+    expect(result).toContain('Skill "ghost" not found');
+  });
+
+  it('should return error for missing resource file', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/nonexistent.md' });
+
+    expect(result).toContain('Failed to read resource');
+    expect(result).toContain('nonexistent.md');
+  });
+
+  it('should emit skill:resource-loaded event on success', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', 'Guide content');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, handler);
+
+    await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-skill',
+        resourcePath: 'references/guide.md',
+        contentLength: expect.any(Number),
+      }),
+    );
+  });
+
+  it('should not emit event on failure', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, handler);
+
+    await tool.invoke({ name: 'my-skill', path: '../etc/passwd' });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSkillActivationTools', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return an array of two tools', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = createSkillActivationTools(registry);
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].metadata.name).toBe('activate-skill');
+    expect(tools[1].metadata.name).toBe('read-skill-resource');
+  });
+
+  it('should return tools in SKILLS category', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = createSkillActivationTools(registry);
+
+    expect(tools[0].metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tools[1].metadata.category).toBe(ToolCategory.SKILLS);
+  });
+});
+
+describe('SkillRegistry.toActivationTools()', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return activation tools bound to the registry', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = registry.toActivationTools();
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].metadata.name).toBe('activate-skill');
+    expect(tools[1].metadata.name).toBe('read-skill-resource');
+  });
+
+  it('should return tools that work with the registry state', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: A test skill', '\n# Test Skill\n\nInstructions here.');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool] = registry.toActivationTools();
+
+    const result = await activateTool.invoke({ name: 'my-skill' });
+
+    expect(result).toContain('# Test Skill');
+    expect(result).toContain('Instructions here.');
+  });
+});
+
+describe('End-to-end integration', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should activate a skill and then read its resources', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review best practices',
+      '\n# Code Review Skill\n\nFollow the guidelines in references/checklist.md',
+    );
+    createResourceFile(skillDir, 'references/checklist.md', '# Checklist\n\n- [ ] Check naming\n- [ ] Check tests');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    // Step 1: Activate the skill
+    const skillBody = await activateTool.invoke({ name: 'code-review' });
+    expect(skillBody).toContain('# Code Review Skill');
+    expect(skillBody).toContain('references/checklist.md');
+
+    // Step 2: Read the referenced resource
+    const resource = await readResourceTool.invoke({
+      name: 'code-review',
+      path: 'references/checklist.md',
+    });
+    expect(resource).toContain('# Checklist');
+    expect(resource).toContain('Check naming');
+  });
+
+  it('should work with multiple skills from multiple roots', async () => {
+    const root2 = createTempDir();
+    tempDirs.push(root2);
+
+    createSkillFixture(tempDir, 'skill-a', 'name: skill-a\ndescription: Skill A', '\n# Skill A body');
+    const skillBDir = createSkillFixture(root2, 'skill-b', 'name: skill-b\ndescription: Skill B', '\n# Skill B body');
+    createResourceFile(skillBDir, 'scripts/run.sh', '#!/bin/bash\necho "running"');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    const bodyA = await activateTool.invoke({ name: 'skill-a' });
+    expect(bodyA).toContain('# Skill A body');
+
+    const bodyB = await activateTool.invoke({ name: 'skill-b' });
+    expect(bodyB).toContain('# Skill B body');
+
+    const script = await readResourceTool.invoke({ name: 'skill-b', path: 'scripts/run.sh' });
+    expect(script).toContain('echo "running"');
+  });
+
+  it('should emit both event types in a full workflow', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/ref.md', 'reference content');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    const activatedHandler = vi.fn();
+    const resourceHandler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_ACTIVATED, activatedHandler);
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, resourceHandler);
+
+    await activateTool.invoke({ name: 'my-skill' });
+    await readResourceTool.invoke({ name: 'my-skill', path: 'references/ref.md' });
+
+    expect(activatedHandler).toHaveBeenCalledOnce();
+    expect(resourceHandler).toHaveBeenCalledOnce();
+  });
+
+  it('should work alongside SkillRegistry.generatePrompt()', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill for compose', '\n# Skill Body');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir], enabled: true });
+    const [activateTool] = registry.toActivationTools();
+
+    // generatePrompt() should list the skill
+    const prompt = registry.generatePrompt();
+    expect(prompt).toContain('my-skill');
+    expect(prompt).toContain('Test skill for compose');
+
+    // activate-skill should return the body
+    const body = await activateTool.invoke({ name: 'my-skill' });
+    expect(body).toContain('# Skill Body');
+  });
+
+  it('tools can be spread into any agent tool array', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const skillTools = registry.toActivationTools();
+
+    // Simulating adding to an agent's tool array
+    const allTools = [...skillTools];
+    expect(allTools).toHaveLength(2);
+    expect(allTools[0].metadata.name).toBe('activate-skill');
+    expect(allTools[1].metadata.name).toBe('read-skill-resource');
+  });
+});

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -81,23 +81,29 @@
 **Branch:** `feat/st-06003-skill-activation-and-resource-tools`
 
 ### Checklist
-- [ ] Create branch `feat/st-06003-skill-activation-and-resource-tools`
-- [ ] Create draft PR with story ID in title
-- [ ] Implement `activate-skill` tool using AgentForge tool builder API — resolves skill via SkillRegistry, returns full SKILL.md body content
-- [ ] Implement `read-skill-resource` tool using AgentForge tool builder API — resolves skill + relative path via SkillRegistry, returns file content
-- [ ] Implement `SkillRegistry.toActivationTools()` convenience method returning both tools pre-wired to the registry instance
-- [ ] Resolve resource paths relative to skill root directory (scripts/, references/, assets/)
-- [ ] Block path traversal — resource resolution must stay within the skill root
-- [ ] Return clear error messages for non-existent skills and missing resource files
-- [ ] Emit structured logs and events (`skill:activated`, `skill:resource-loaded`) for activation and resource loads
-- [ ] Register both tools in a `SKILLS` tool category
-- [ ] Ensure tools can be added to any agent pattern (ReAct, Plan-Execute, Multi-Agent)
-- [ ] Create fixture skill packs for testing (valid, missing SKILL.md, traversal attempts)
-- [ ] Create integration tests for end-to-end activation and resource loading flows
-- [ ] Add or update story documentation at docs/st06003-skill-activation-and-resource-tools.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `feat/st-06003-skill-activation-and-resource-tools`
+- [x] Create draft PR with story ID in title
+  - PR #48: https://github.com/TVScoundrel/agentforge/pull/48
+- [x] Implement `activate-skill` tool using AgentForge tool builder API — resolves skill via SkillRegistry, returns full SKILL.md body content
+- [x] Implement `read-skill-resource` tool using AgentForge tool builder API — resolves skill + relative path via SkillRegistry, returns file content
+- [x] Implement `SkillRegistry.toActivationTools()` convenience method returning both tools pre-wired to the registry instance
+- [x] Resolve resource paths relative to skill root directory (scripts/, references/, assets/)
+- [x] Block path traversal — resource resolution must stay within the skill root
+- [x] Return clear error messages for non-existent skills and missing resource files
+- [x] Emit structured logs and events (`skill:activated`, `skill:resource-loaded`) for activation and resource loads
+- [x] Register both tools in a `SKILLS` tool category
+- [x] Ensure tools can be added to any agent pattern (ReAct, Plan-Execute, Multi-Agent)
+  - Tools use standard AgentForge Tool type, compatible with any agent pattern's tool array
+- [x] Create fixture skill packs for testing (valid, missing SKILL.md, traversal attempts)
+- [x] Create integration tests for end-to-end activation and resource loading flows
+  - 38 tests in `packages/core/tests/skills/activation.test.ts`
+- [x] Add or update story documentation at docs/st06003-skill-activation-and-resource-tools.md (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - 38 new unit tests covering all acceptance criteria
+- [x] Run full test suite before finalizing the PR and record results
+  - 150 test files passed, 7 failed (pre-existing Docker/testcontainers), 2167 tests passed
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any in patterns package)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -104,8 +104,10 @@
   - 150 test files passed, 7 failed (pre-existing Docker/testcontainers), 2167 tests passed
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any in patterns package)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `16cfceb` feat(st-06003): implement skill activation tools and resource loading
+  - `71a0679` docs(st-06003): add story documentation and update trackers
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories (queued for prioritization and dependencies)
@@ -14,6 +14,12 @@
 
 ## Ready
 
+_No stories currently ready_
+
+---
+
+## In Progress
+
 ### ST-06003: Implement Skill Activation and Resource Tools
 - **Epic:** EP-06
 - **Priority:** P0
@@ -21,12 +27,8 @@
 - **Dependencies:** ST-06002 (merged)
 - **Checklist:** `planning/checklists/epic-06-story-tasks.md`
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
-
----
-
-## In Progress
-
-_No stories currently in progress_
+- **Branch:** `feat/st-06003-skill-activation-and-resource-tools`
+- **PR:** https://github.com/TVScoundrel/agentforge/pull/48
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories (queued for prioritization and dependencies)
 
@@ -20,6 +20,12 @@ _No stories currently ready_
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-06003: Implement Skill Activation and Resource Tools
 - **Epic:** EP-06
 - **Priority:** P0
@@ -29,12 +35,6 @@ _No stories currently ready_
 - **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
 - **Branch:** `feat/st-06003-skill-activation-and-resource-tools`
 - **PR:** https://github.com/TVScoundrel/agentforge/pull/48
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 


### PR DESCRIPTION
## ST-06003: Implement Skill Activation and Resource Tools

### Story
As an agent at runtime, I want to activate a skill by name and optionally load its referenced resources so that I can follow skill instructions to complete user tasks.

### What Changed
- Added `SKILLS` tool category to `ToolCategory` enum
- Implemented `activate-skill` tool using AgentForge tool builder API — resolves skill via SkillRegistry, returns full SKILL.md body content
- Implemented `read-skill-resource` tool using AgentForge tool builder API — resolves skill + relative path via SkillRegistry, returns file content with path traversal protection
- Added `SkillRegistry.toActivationTools()` convenience method returning both tools pre-wired to the registry instance
- Added `SkillRegistry.emitEvent()` for tool-to-registry event integration
- Added `SKILL_ACTIVATED` and `SKILL_RESOURCE_LOADED` events to `SkillRegistryEvent`
- Added `resolveResourcePath()` security function with path containment checks
- Exported all new symbols from `@agentforge/core` barrel

### Acceptance Criteria Coverage
- [x] `activate-skill` tool: resolves skill via SkillRegistry, returns full SKILL.md body
- [x] `read-skill-resource` tool: resolves skill + relative path, returns file content
- [x] `toActivationTools()` convenience method returns both tools pre-wired
- [x] Resource paths resolved relative to skill root (scripts/, references/, assets/)
- [x] Path traversal blocked — stays within skill root
- [x] Clear error messages for non-existent skills and missing resources
- [x] Structured logs and events (skill:activated, skill:resource-loaded)
- [x] Tools registered in SKILLS tool category
- [x] Tools can be added to any agent pattern (standard Tool type)
- [x] Fixture skill packs for testing (valid, missing SKILL.md, traversal attempts)
- [x] Integration tests for end-to-end activation and resource loading flows

### Validation Performed

**Test Suite:**
- 150 test files passed, 7 failed (pre-existing Docker/testcontainers)
- 2167 tests passed (38 new in this PR)
- All 132 skills tests pass (71 registry/parser/scanner + 23 prompt + 38 activation)

**Lint:**
- 0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any)

**Build:**
- `pnpm build` succeeds — ESM, CJS, and DTS all clean

### Commits
- `16cfceb` feat(st-06003): implement skill activation tools and resource loading
- `71a0679` docs(st-06003): add story documentation and update trackers

### Status
Ready for review
