### PR TITLE
feat(st-06004): implement skill trust policies and execution guardrails

### DIFF
--- a/docs/st06004-skill-trust-policies-and-guardrails.md
+++ b/docs/st06004-skill-trust-policies-and-guardrails.md
@@ -24,25 +24,32 @@ Implements a security layer for the Agent Skills system that restricts access to
 
 ### Skill Root Configuration
 
+**Backward compatible** — string roots default to `'untrusted'`:
+
 ```typescript
 import { SkillRegistry } from '@agentforge/core';
 
-// Backward compatible — string roots default to 'untrusted'
-const registry = new SkillRegistry({
+const registryDefault = new SkillRegistry({
   skillRoots: ['/community/skills'],
 });
+```
 
-// Explicit trust levels
-const registry = new SkillRegistry({
+**Explicit trust levels:**
+
+```typescript
+const registryMixed = new SkillRegistry({
   skillRoots: [
     { path: '.agentskills', trust: 'workspace' },   // Full trust
     { path: '/org/shared-skills', trust: 'trusted' }, // Verified
     '/community/skills',                               // Untrusted (default)
   ],
 });
+```
 
-// Override: allow scripts from untrusted roots (use with caution)
-const registry = new SkillRegistry({
+**Override** — allow scripts from untrusted roots (use with caution):
+
+```typescript
+const registryOverride = new SkillRegistry({
   skillRoots: ['/community/skills'],
   allowUntrustedScripts: true,
 });
@@ -115,10 +122,11 @@ Event payload:
 
 ```typescript
 {
-  name: string;          // Skill name
-  resourcePath: string;  // Requested resource path
+  name: string;           // Skill name
+  resourcePath: string;   // Requested resource path
   trustLevel: TrustLevel;
   reason: TrustPolicyReason;
+  message?: string;       // Present on TRUST_POLICY_DENIED events
 }
 ```
 

--- a/docs/st06004-skill-trust-policies-and-guardrails.md
+++ b/docs/st06004-skill-trust-policies-and-guardrails.md
@@ -1,0 +1,158 @@
+# ST-06004: Skill Trust Policies and Execution Guardrails
+
+## Overview
+
+Implements a security layer for the Agent Skills system that restricts access to executable script resources (`scripts/` directories) based on configurable trust levels assigned to each skill root.
+
+## Trust Model
+
+### Trust Levels
+
+| Level | Script Access | Description |
+|-------|-------------|-------------|
+| `workspace` | Allowed | Project-local skills (e.g. `.agentskills/`). Full trust — scripts can be read and executed. |
+| `trusted` | Allowed | Externally managed but verified skill roots. Scripts allowed. |
+| `untrusted` | **Denied** | Community or unknown skill sources. Scripts blocked by default for security. |
+
+### Default Behaviour
+
+- **Plain string roots** (e.g. `skillRoots: ['/path/to/skills']`) default to `untrusted` trust level for backward compatibility.
+- **Script access** from untrusted roots is denied unless `allowUntrustedScripts: true` is explicitly set.
+- **Non-script resources** (references, assets, SKILL.md) are always accessible regardless of trust level.
+
+## Configuration
+
+### Skill Root Configuration
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+
+// Backward compatible — string roots default to 'untrusted'
+const registry = new SkillRegistry({
+  skillRoots: ['/community/skills'],
+});
+
+// Explicit trust levels
+const registry = new SkillRegistry({
+  skillRoots: [
+    { path: '.agentskills', trust: 'workspace' },   // Full trust
+    { path: '/org/shared-skills', trust: 'trusted' }, // Verified
+    '/community/skills',                               // Untrusted (default)
+  ],
+});
+
+// Override: allow scripts from untrusted roots (use with caution)
+const registry = new SkillRegistry({
+  skillRoots: ['/community/skills'],
+  allowUntrustedScripts: true,
+});
+```
+
+### Trust Level Effect on `read-skill-resource`
+
+| Resource Path | workspace | trusted | untrusted |
+|--------------|-----------|---------|-----------|
+| `references/guide.md` | Read | Read | Read |
+| `assets/logo.png` | Read | Read | Read |
+| `scripts/setup.sh` | Read | Read | **DENIED** |
+| `scripts/nested/deep.sh` | Read | Read | **DENIED** |
+
+## Policy Engine
+
+### `evaluateTrustPolicy(resourcePath, trustLevel, allowUntrustedScripts?)`
+
+Returns a `TrustPolicyDecision`:
+
+```typescript
+interface TrustPolicyDecision {
+  allowed: boolean;
+  reason: TrustPolicyReason;
+  message: string;
+}
+```
+
+### Policy Reason Codes
+
+| Reason | Meaning |
+|--------|---------|
+| `NOT_SCRIPT` | Not a script resource — always allowed |
+| `WORKSPACE_TRUST` | Workspace root — scripts allowed |
+| `TRUSTED_ROOT` | Trusted root — scripts allowed |
+| `UNTRUSTED_SCRIPT_DENIED` | Untrusted root — scripts blocked |
+| `UNTRUSTED_SCRIPT_ALLOWED` | Untrusted root — scripts allowed via override |
+
+## API Reference
+
+### SkillRegistry New Methods
+
+```typescript
+// Get the allowUntrustedScripts config value
+registry.getAllowUntrustedScripts(): boolean;
+
+// Get allowed-tools list for a specific skill (from frontmatter)
+registry.getAllowedTools('my-skill'): string[] | undefined;
+```
+
+### Skill Trust Level
+
+Every discovered skill now includes a `trustLevel` property:
+
+```typescript
+const skill = registry.get('my-skill');
+console.log(skill.trustLevel); // 'workspace' | 'trusted' | 'untrusted'
+```
+
+## Events
+
+Two new events are emitted by the registry during trust enforcement:
+
+| Event | When |
+|-------|------|
+| `trust:policy-denied` | Script access blocked by trust policy |
+| `trust:policy-allowed` | Script access permitted by trust policy (scripts only) |
+
+Event payload:
+
+```typescript
+{
+  name: string;          // Skill name
+  resourcePath: string;  // Requested resource path
+  trustLevel: TrustLevel;
+  reason: TrustPolicyReason;
+}
+```
+
+## Security Considerations
+
+### Defense in Depth
+
+Trust policies operate **after** existing path security checks:
+
+1. **Absolute path rejection** — `/etc/passwd` blocked
+2. **Path traversal rejection** — `../../../etc/passwd` blocked
+3. **Trust policy enforcement** — `scripts/setup.sh` from untrusted roots blocked
+4. **Path containment** — resolved path must stay within skill directory
+
+### Secure Defaults
+
+- All string roots default to `untrusted`
+- Scripts from untrusted roots are **denied by default**
+- `allowUntrustedScripts` must be **explicitly** set to `true`
+- Non-script resources remain accessible (read-only)
+
+### Trust Escalation Workflow
+
+To allow script execution from a root:
+
+1. **Review** the skill scripts manually
+2. **Promote** the root to `trusted` or `workspace`:
+   ```typescript
+   skillRoots: [{ path: '/path', trust: 'trusted' }]
+   ```
+3. Or set `allowUntrustedScripts: true` (blanket override, not recommended for production)
+
+## Test Coverage
+
+- **41 dedicated trust policy tests** in `trust.test.ts`
+- Tests cover: normalizeRootConfig, isScriptResource, evaluateTrustPolicy, integration enforcement, event emission, security regression (path traversal, bypass attempts), getAllowedTools, backward compatibility
+- **175 total skills tests** across 6 test files, all passing

--- a/packages/core/src/skills/activation.ts
+++ b/packages/core/src/skills/activation.ts
@@ -63,7 +63,7 @@ export function resolveResourcePath(
 
   // Reject traversal via segment-based '..' detection
   // Split on both '/' and '\' to handle cross-platform separators
-  const segments = resourcePath.split(/[\/\\]/);
+  const segments = resourcePath.split(/[/\\]/);
   if (segments.some((seg) => seg === '..')) {
     return { success: false, error: 'Path traversal is not allowed — resource paths must stay within the skill directory' };
   }

--- a/packages/core/src/skills/activation.ts
+++ b/packages/core/src/skills/activation.ts
@@ -26,7 +26,7 @@ import { ToolBuilder } from '../tools/builder.js';
 import { ToolCategory } from '../tools/types.js';
 import type { Tool } from '../tools/types.js';
 import type { SkillRegistry } from './registry.js';
-import { SkillRegistryEvent } from './types.js';
+import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
 import { evaluateTrustPolicy } from './trust.js';
 import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 
@@ -243,7 +243,7 @@ export function createReadSkillResourceTool(
       }
 
       // Log allowed policy decisions for auditing (scripts only)
-      if (policyDecision.reason !== 'not-script') {
+      if (policyDecision.reason !== TrustPolicyReason.NOT_SCRIPT) {
         logger.info('Skill resource trust policy — allowed', {
           name,
           resourcePath,

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -7,13 +7,16 @@ export type {
   SkillMetadata,
   Skill,
   SkillRegistryConfig,
+  SkillRootConfig,
   SkillPromptOptions,
   SkillEventHandler,
   SkillParseResult,
   SkillValidationError,
+  TrustLevel,
+  TrustPolicyDecision,
 } from './types.js';
 
-export { SkillRegistryEvent } from './types.js';
+export { SkillRegistryEvent, TrustPolicyReason } from './types.js';
 
 // Parser
 export {
@@ -41,3 +44,10 @@ export {
   createSkillActivationTools,
   resolveResourcePath,
 } from './activation.js';
+
+// Trust Policy
+export {
+  evaluateTrustPolicy,
+  isScriptResource,
+  normalizeRootConfig,
+} from './trust.js';

--- a/packages/core/src/skills/trust.ts
+++ b/packages/core/src/skills/trust.ts
@@ -1,0 +1,130 @@
+/**
+ * Skill Trust Policy Engine
+ *
+ * Enforces trust-level-based access control for skill resources.
+ * Scripts from untrusted roots are denied by default unless explicitly allowed.
+ *
+ * Trust levels:
+ * - `workspace` — Project-local skills, highest trust. Scripts always allowed.
+ * - `trusted`   — Explicitly trusted roots. Scripts allowed.
+ * - `untrusted` — Community or third-party skills. Scripts denied by default.
+ *
+ * @see https://agentskills.io/specification
+ */
+
+import type { TrustLevel, TrustPolicyDecision, SkillRootConfig } from './types.js';
+import { TrustPolicyReason } from './types.js';
+
+// ─── Constants ───────────────────────────────────────────────────────────
+
+/**
+ * Resource path prefix that requires trust enforcement.
+ *
+ * Only resources under `scripts/` are subject to trust policy checks.
+ * Other directories (references/, assets/, etc.) are always accessible.
+ */
+const SCRIPT_PATH_PREFIX = 'scripts/';
+const SCRIPT_PATH_EXACT = 'scripts';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a skill root config entry.
+ *
+ * String entries default to `'untrusted'` trust level for safe defaults.
+ *
+ * @param root - A string path or SkillRootConfig object
+ * @returns Normalized SkillRootConfig with explicit trust level
+ */
+export function normalizeRootConfig(root: string | SkillRootConfig): SkillRootConfig {
+  if (typeof root === 'string') {
+    return { path: root, trust: 'untrusted' };
+  }
+  return root;
+}
+
+/**
+ * Check whether a resource path refers to a script.
+ *
+ * A resource is considered a script if its relative path starts with
+ * `scripts/` or is exactly `scripts`.
+ *
+ * @param resourcePath - Relative path within the skill directory
+ * @returns True if the resource is in the scripts/ directory
+ */
+export function isScriptResource(resourcePath: string): boolean {
+  // Normalize to forward slashes for consistent checking
+  const normalized = resourcePath.replace(/\\/g, '/');
+  return normalized === SCRIPT_PATH_EXACT
+    || normalized.startsWith(SCRIPT_PATH_PREFIX);
+}
+
+// ─── Policy Engine ───────────────────────────────────────────────────────
+
+/**
+ * Evaluate the trust policy for a resource access request.
+ *
+ * Non-script resources are always allowed regardless of trust level.
+ * Script resources require `workspace` or `trusted` trust, or the
+ * `allowUntrustedScripts` override to be enabled.
+ *
+ * @param resourcePath - Relative path to the resource within the skill directory
+ * @param trustLevel - Trust level of the skill's root directory
+ * @param allowUntrustedScripts - Override flag to permit untrusted scripts
+ * @returns Policy decision with allow/deny, reason code, and message
+ */
+export function evaluateTrustPolicy(
+  resourcePath: string,
+  trustLevel: TrustLevel,
+  allowUntrustedScripts: boolean = false,
+): TrustPolicyDecision {
+  // Non-script resources — no policy enforcement needed
+  if (!isScriptResource(resourcePath)) {
+    return {
+      allowed: true,
+      reason: TrustPolicyReason.NOT_SCRIPT,
+      message: 'Resource is not a script — no trust check required',
+    };
+  }
+
+  // Script resources — check trust level
+  switch (trustLevel) {
+    case 'workspace':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.WORKSPACE_TRUST,
+        message: 'Script allowed — skill root has workspace trust',
+      };
+
+    case 'trusted':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.TRUSTED_ROOT,
+        message: 'Script allowed — skill root is explicitly trusted',
+      };
+
+    case 'untrusted':
+      if (allowUntrustedScripts) {
+        return {
+          allowed: true,
+          reason: TrustPolicyReason.UNTRUSTED_SCRIPT_ALLOWED,
+          message: 'Script from untrusted root allowed via allowUntrustedScripts override',
+        };
+      }
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+        message: `Script access denied — skill root is untrusted. ` +
+          `Scripts from untrusted roots are blocked by default for security. ` +
+          `To allow, set 'allowUntrustedScripts: true' in SkillRegistryConfig or ` +
+          `promote the skill root to 'trusted' or 'workspace' trust level.`,
+      };
+
+    default:
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+        message: `Script access denied — unknown trust level "${trustLevel}"`,
+      };
+  }
+}

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -63,6 +63,8 @@ export enum TrustPolicyReason {
   UNTRUSTED_SCRIPT_DENIED = 'untrusted-script-denied',
   /** Untrusted script access was explicitly allowed via config override */
   UNTRUSTED_SCRIPT_ALLOWED = 'untrusted-script-allowed-override',
+  /** Trust level is unknown — treated as untrusted for security */
+  UNKNOWN_TRUST_LEVEL = 'unknown-trust-level',
 }
 
 /**

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -5,6 +5,66 @@
  * These types align with the Agent Skills specification (https://agentskills.io/specification).
  */
 
+// ─── Trust Policy Types ──────────────────────────────────────────────────
+
+/**
+ * Trust level for a skill root directory.
+ *
+ * - `workspace` — Skills from the project workspace (highest trust, scripts allowed)
+ * - `trusted`   — Explicitly trusted skill roots (scripts allowed)
+ * - `untrusted` — Untrusted roots like community packs (scripts blocked by default)
+ */
+export type TrustLevel = 'workspace' | 'trusted' | 'untrusted';
+
+/**
+ * Configuration for a skill root with an explicit trust level.
+ *
+ * @example
+ * ```ts
+ * const roots: SkillRootConfig[] = [
+ *   { path: '.agentskills', trust: 'workspace' },
+ *   { path: '~/.agentskills', trust: 'trusted' },
+ *   { path: '/shared/community-skills', trust: 'untrusted' },
+ * ];
+ * ```
+ */
+export interface SkillRootConfig {
+  /** Directory path to scan for skills */
+  path: string;
+  /** Trust level assigned to all skills discovered from this root */
+  trust: TrustLevel;
+}
+
+/**
+ * Policy decision returned by trust enforcement checks.
+ */
+export interface TrustPolicyDecision {
+  /** Whether the action is allowed */
+  allowed: boolean;
+  /** Machine-readable reason code for auditing */
+  reason: TrustPolicyReason;
+  /** Human-readable explanation */
+  message: string;
+}
+
+/**
+ * Reason codes for trust policy decisions.
+ *
+ * Used for structured logging and auditing of guardrail behavior.
+ */
+export enum TrustPolicyReason {
+  /** Resource is not a script — no trust check needed */
+  NOT_SCRIPT = 'not-script',
+  /** Skill root has workspace trust — scripts allowed */
+  WORKSPACE_TRUST = 'workspace-trust',
+  /** Skill root has explicit trusted status — scripts allowed */
+  TRUSTED_ROOT = 'trusted-root',
+  /** Skill root is untrusted — scripts denied by default */
+  UNTRUSTED_SCRIPT_DENIED = 'untrusted-script-denied',
+  /** Untrusted script access was explicitly allowed via config override */
+  UNTRUSTED_SCRIPT_ALLOWED = 'untrusted-script-allowed-override',
+}
+
 /**
  * Parsed metadata from a SKILL.md frontmatter block.
  *
@@ -39,6 +99,8 @@ export interface Skill {
   skillPath: string;
   /** Which configured skill root this was discovered from */
   rootPath: string;
+  /** Trust level assigned to this skill (inherited from root config) */
+  trustLevel: TrustLevel;
 }
 
 /**
@@ -48,13 +110,26 @@ export interface SkillRegistryConfig {
   /**
    * Array of directory paths to scan for skills.
    *
-   * Each root is scanned for subdirectories containing a valid `SKILL.md`.
+   * Each entry can be a plain string (defaults to `'untrusted'` trust level)
+   * or a `SkillRootConfig` object with an explicit trust level.
+   *
    * Paths may be absolute or relative (resolved against `cwd`).
    * The `~` prefix is expanded to `$HOME`.
    *
-   * @example ['.agentskills', '~/.agentskills', './project-skills']
+   * @example
+   * ```ts
+   * // Simple string roots (default to 'untrusted')
+   * skillRoots: ['.agentskills', '~/.agentskills']
+   *
+   * // Trust-aware roots
+   * skillRoots: [
+   *   { path: '.agentskills', trust: 'workspace' },
+   *   { path: '~/.agentskills', trust: 'trusted' },
+   *   { path: '/shared/community', trust: 'untrusted' },
+   * ]
+   * ```
    */
-  skillRoots: string[];
+  skillRoots: Array<string | SkillRootConfig>;
 
   /**
    * Feature flag to enable Agent Skills in system prompts.
@@ -74,6 +149,20 @@ export interface SkillRegistryConfig {
    * When undefined, all discovered skills are included.
    */
   maxDiscoveredSkills?: number;
+
+  /**
+   * Allow script resources from untrusted roots.
+   *
+   * When `true`, scripts from `scripts/` directories in untrusted
+   * skill roots are returned instead of being denied. This disables
+   * the default-deny policy for untrusted scripts.
+   *
+   * **Security warning:** Only enable when you have reviewed all
+   * skill packs from untrusted roots.
+   *
+   * @default false
+   */
+  allowUntrustedScripts?: boolean;
 }
 
 /**
@@ -106,6 +195,10 @@ export enum SkillRegistryEvent {
   SKILL_ACTIVATED = 'skill:activated',
   /** Emitted when a skill resource file is loaded */
   SKILL_RESOURCE_LOADED = 'skill:resource-loaded',
+  /** Emitted when a trust policy denies access to a resource */
+  TRUST_POLICY_DENIED = 'trust:policy-denied',
+  /** Emitted when a trust policy allows access (for auditing) */
+  TRUST_POLICY_ALLOWED = 'trust:policy-allowed',
 }
 
 /**

--- a/packages/core/tests/skills/activation.test.ts
+++ b/packages/core/tests/skills/activation.test.ts
@@ -321,7 +321,7 @@ describe('read-skill-resource tool', () => {
     const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
     createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho "Hello"');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'trusted' }] });
     const tool = createReadSkillResourceTool(registry);
 
     const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
@@ -554,7 +554,10 @@ describe('End-to-end integration', () => {
     const skillBDir = createSkillFixture(root2, 'skill-b', 'name: skill-b\ndescription: Skill B', '\n# Skill B body');
     createResourceFile(skillBDir, 'scripts/run.sh', '#!/bin/bash\necho "running"');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+    const registry = new SkillRegistry({ skillRoots: [
+      { path: tempDir, trust: 'workspace' },
+      { path: root2, trust: 'trusted' },
+    ] });
     const [activateTool, readResourceTool] = registry.toActivationTools();
 
     const bodyA = await activateTool.invoke({ name: 'skill-a' });

--- a/packages/core/tests/skills/trust.test.ts
+++ b/packages/core/tests/skills/trust.test.ts
@@ -112,6 +112,27 @@ describe('isScriptResource', () => {
   it('should handle backslash separators', () => {
     expect(isScriptResource('scripts\\setup.sh')).toBe(true);
   });
+
+  it('should detect scripts with leading ./ prefix', () => {
+    expect(isScriptResource('./scripts/setup.sh')).toBe(true);
+  });
+
+  it('should detect scripts case-insensitively', () => {
+    expect(isScriptResource('Scripts/setup.sh')).toBe(true);
+    expect(isScriptResource('SCRIPTS/SETUP.SH')).toBe(true);
+  });
+
+  it('should handle collapsed repeated separators', () => {
+    expect(isScriptResource('scripts//setup.sh')).toBe(true);
+  });
+
+  it('should handle leading whitespace', () => {
+    expect(isScriptResource('  scripts/setup.sh')).toBe(true);
+  });
+
+  it('should detect exact "Scripts" path case-insensitively', () => {
+    expect(isScriptResource('Scripts')).toBe(true);
+  });
 });
 
 // ─── evaluateTrustPolicy ─────────────────────────────────────────────────

--- a/packages/core/tests/skills/trust.test.ts
+++ b/packages/core/tests/skills/trust.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for Skill Trust Policies and Execution Guardrails
+ *
+ * Covers:
+ * - Trust policy configuration model (workspace, trusted, untrusted)
+ * - normalizeRootConfig() — string and object root normalization
+ * - isScriptResource() — script path detection
+ * - evaluateTrustPolicy() — policy engine logic for all trust levels
+ * - read-skill-resource trust enforcement (scripts blocked from untrusted roots)
+ * - allowUntrustedScripts override
+ * - Trust policy events (TRUST_POLICY_DENIED, TRUST_POLICY_ALLOWED)
+ * - getAllowedTools() API
+ * - Security regression: path traversal + untrusted script denial + policy bypass
+ * - Backward compatibility: plain string roots default to untrusted
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { SkillRegistryEvent, TrustPolicyReason } from '../../src/skills/types.js';
+import type { TrustLevel } from '../../src/skills/types.js';
+import {
+  evaluateTrustPolicy,
+  isScriptResource,
+  normalizeRootConfig,
+} from '../../src/skills/trust.js';
+import {
+  createReadSkillResourceTool,
+} from '../../src/skills/activation.js';
+
+// ─── Fixture Helpers ─────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-trust-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createSkillFixture(
+  root: string,
+  dirName: string,
+  frontmatter: string,
+  body: string,
+): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\n${frontmatter}\n---\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+function createResourceFile(skillDir: string, relativePath: string, content: string): string {
+  const fullPath = join(skillDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+// ─── normalizeRootConfig ─────────────────────────────────────────────────
+
+describe('normalizeRootConfig', () => {
+  it('should convert a plain string to untrusted SkillRootConfig', () => {
+    const result = normalizeRootConfig('/some/path');
+    expect(result).toEqual({ path: '/some/path', trust: 'untrusted' });
+  });
+
+  it('should pass through SkillRootConfig objects unchanged', () => {
+    const input = { path: '/some/path', trust: 'trusted' as TrustLevel };
+    const result = normalizeRootConfig(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should normalize workspace trust level', () => {
+    const result = normalizeRootConfig({ path: '.agentskills', trust: 'workspace' });
+    expect(result.trust).toBe('workspace');
+  });
+});
+
+// ─── isScriptResource ────────────────────────────────────────────────────
+
+describe('isScriptResource', () => {
+  it('should return true for scripts/ prefix', () => {
+    expect(isScriptResource('scripts/setup.sh')).toBe(true);
+  });
+
+  it('should return true for nested scripts/ paths', () => {
+    expect(isScriptResource('scripts/init/bootstrap.sh')).toBe(true);
+  });
+
+  it('should return true for exact "scripts" path', () => {
+    expect(isScriptResource('scripts')).toBe(true);
+  });
+
+  it('should return false for references/ prefix', () => {
+    expect(isScriptResource('references/guide.md')).toBe(false);
+  });
+
+  it('should return false for assets/ prefix', () => {
+    expect(isScriptResource('assets/logo.png')).toBe(false);
+  });
+
+  it('should return false for root-level files', () => {
+    expect(isScriptResource('README.md')).toBe(false);
+  });
+
+  it('should return false for paths containing "scripts" but not as prefix', () => {
+    expect(isScriptResource('references/scripts-guide.md')).toBe(false);
+  });
+
+  it('should handle backslash separators', () => {
+    expect(isScriptResource('scripts\\setup.sh')).toBe(true);
+  });
+});
+
+// ─── evaluateTrustPolicy ─────────────────────────────────────────────────
+
+describe('evaluateTrustPolicy', () => {
+  describe('non-script resources', () => {
+    it('should allow references/ from any trust level', () => {
+      for (const trust of ['workspace', 'trusted', 'untrusted'] as TrustLevel[]) {
+        const decision = evaluateTrustPolicy('references/guide.md', trust);
+        expect(decision.allowed).toBe(true);
+        expect(decision.reason).toBe(TrustPolicyReason.NOT_SCRIPT);
+      }
+    });
+
+    it('should allow assets/ from untrusted roots', () => {
+      const decision = evaluateTrustPolicy('assets/logo.png', 'untrusted');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.NOT_SCRIPT);
+    });
+
+    it('should allow root-level files from untrusted roots', () => {
+      const decision = evaluateTrustPolicy('README.md', 'untrusted');
+      expect(decision.allowed).toBe(true);
+    });
+  });
+
+  describe('workspace trust', () => {
+    it('should allow scripts from workspace roots', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'workspace');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.WORKSPACE_TRUST);
+    });
+
+    it('should include descriptive message', () => {
+      const decision = evaluateTrustPolicy('scripts/run.sh', 'workspace');
+      expect(decision.message).toContain('workspace trust');
+    });
+  });
+
+  describe('trusted roots', () => {
+    it('should allow scripts from trusted roots', () => {
+      const decision = evaluateTrustPolicy('scripts/deploy.sh', 'trusted');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.TRUSTED_ROOT);
+    });
+  });
+
+  describe('untrusted roots', () => {
+    it('should deny scripts from untrusted roots by default', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted');
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED);
+    });
+
+    it('should include remediation guidance in denial message', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted');
+      expect(decision.message).toContain('allowUntrustedScripts');
+      expect(decision.message).toContain('trusted');
+      expect(decision.message).toContain('workspace');
+    });
+
+    it('should allow scripts when allowUntrustedScripts override is true', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted', true);
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_ALLOWED);
+    });
+
+    it('should deny scripts when allowUntrustedScripts is false', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted', false);
+      expect(decision.allowed).toBe(false);
+    });
+  });
+});
+
+// ─── Trust enforcement integration (read-skill-resource) ─────────────────
+
+describe('read-skill-resource trust enforcement', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should allow non-script resources from untrusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Guide');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // default untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+    expect(result).toBe('# Guide');
+  });
+
+  it('should deny script resources from untrusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\nrm -rf /');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // default untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toContain('Script access denied');
+    expect(result).toContain('untrusted');
+  });
+
+  it('should allow script resources from workspace roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho hello');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho hello');
+  });
+
+  it('should allow script resources from trusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho hello');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'trusted' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho hello');
+  });
+
+  it('should allow untrusted scripts when allowUntrustedScripts is true', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho ok');
+
+    const registry = new SkillRegistry({
+      skillRoots: [tempDir], // default untrusted
+      allowUntrustedScripts: true,
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho ok');
+  });
+
+  it('should emit TRUST_POLICY_DENIED event when script is blocked', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', 'danger');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.name).toBe('my-skill');
+    expect(event.resourcePath).toBe('scripts/setup.sh');
+    expect(event.trustLevel).toBe('untrusted');
+    expect(event.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED);
+  });
+
+  it('should emit TRUST_POLICY_ALLOWED event for trusted scripts', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho ok');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.name).toBe('my-skill');
+    expect(event.reason).toBe(TrustPolicyReason.WORKSPACE_TRUST);
+  });
+
+  it('should not emit TRUST_POLICY_ALLOWED for non-script resources', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Guide');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should handle mixed trust levels across roots', async () => {
+    const trustedRoot = createTempDir();
+    const untrustedRoot = createTempDir();
+    tempDirs.push(trustedRoot, untrustedRoot);
+
+    const trustedSkillDir = createSkillFixture(trustedRoot, 'trusted-skill', 'name: trusted-skill\ndescription: Trusted', '\nbody');
+    createResourceFile(trustedSkillDir, 'scripts/deploy.sh', '#!/bin/bash\ndeploy');
+
+    const untrustedSkillDir = createSkillFixture(untrustedRoot, 'community-skill', 'name: community-skill\ndescription: Community', '\nbody');
+    createResourceFile(untrustedSkillDir, 'scripts/setup.sh', '#!/bin/bash\nsetup');
+
+    const registry = new SkillRegistry({
+      skillRoots: [
+        { path: trustedRoot, trust: 'trusted' },
+        { path: untrustedRoot, trust: 'untrusted' },
+      ],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    // Trusted skill — scripts allowed
+    const trustedResult = await tool.invoke({ name: 'trusted-skill', path: 'scripts/deploy.sh' });
+    expect(trustedResult).toContain('deploy');
+
+    // Untrusted skill — scripts denied
+    const untrustedResult = await tool.invoke({ name: 'community-skill', path: 'scripts/setup.sh' });
+    expect(untrustedResult).toContain('Script access denied');
+  });
+});
+
+// ─── Security regression tests ───────────────────────────────────────────
+
+describe('Security regression — trust policy', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should block path traversal even with trusted roots', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '../../../etc/passwd' });
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block absolute paths even with trusted roots', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '/etc/passwd' });
+    expect(result).toContain('Absolute resource paths');
+  });
+
+  it('should deny nested scripts/ path from untrusted root', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/nested/deep.sh', '#!/bin/bash\nrm -rf /');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/nested/deep.sh' });
+    expect(result).toContain('Script access denied');
+  });
+
+  it('should not bypass trust via path tricks like scripts/../scripts/file', async () => {
+    // '../' is caught by path traversal check before trust policy
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/run.sh', 'danger');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/../scripts/run.sh' });
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should deny "scripts" path (no trailing slash) from untrusted root', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts', 'file-named-scripts');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts' });
+    expect(result).toContain('Script access denied');
+  });
+});
+
+// ─── getAllowedTools ─────────────────────────────────────────────────────
+
+describe('SkillRegistry.getAllowedTools()', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return allowedTools from frontmatter', () => {
+    createSkillFixture(tempDir, 'code-review',
+      'name: code-review\ndescription: Code review\nallowed-tools:\n  - read_file\n  - grep_search',
+      '\n# Code Review');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('code-review');
+
+    expect(allowed).toEqual(['read_file', 'grep_search']);
+  });
+
+  it('should return undefined for skills without allowed-tools', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('my-skill');
+
+    expect(allowed).toBeUndefined();
+  });
+
+  it('should return undefined for non-existent skills', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('nonexistent');
+
+    expect(allowed).toBeUndefined();
+  });
+});
+
+// ─── Backward compatibility ──────────────────────────────────────────────
+
+describe('Backward compatibility', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should accept plain string roots and default to untrusted', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const skill = registry.get('my-skill');
+
+    expect(skill).toBeDefined();
+    expect(skill!.trustLevel).toBe('untrusted');
+  });
+
+  it('should accept mixed string and config objects', () => {
+    const root2 = createTempDir();
+
+    createSkillFixture(tempDir, 'skill-a', 'name: skill-a\ndescription: A', '\nbody');
+    createSkillFixture(root2, 'skill-b', 'name: skill-b\ndescription: B', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [
+        tempDir,  // plain string → untrusted
+        { path: root2, trust: 'workspace' },
+      ],
+    });
+
+    expect(registry.get('skill-a')!.trustLevel).toBe('untrusted');
+    expect(registry.get('skill-b')!.trustLevel).toBe('workspace');
+
+    rmSync(root2, { recursive: true, force: true });
+  });
+
+  it('should preserve all existing SkillRegistry query APIs', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    expect(registry.get('my-skill')).toBeDefined();
+    expect(registry.has('my-skill')).toBe(true);
+    expect(registry.size()).toBe(1);
+    expect(registry.getNames()).toEqual(['my-skill']);
+    expect(registry.getAll().length).toBe(1);
+    expect(registry.getScanErrors().length).toBe(0);
+  });
+});

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -118,20 +118,20 @@
 **Branch:** `feat/st-06004-skill-trust-policies-and-guardrails`
 
 ### Checklist
-- [ ] Create branch `feat/st-06004-skill-trust-policies-and-guardrails`
-- [ ] Create draft PR with story ID in title
-- [ ] Define trust policy configuration model for `workspace`, `trusted`, and `untrusted` roots
-- [ ] Enforce trust policy in `read-skill-resource` before returning script content from `scripts/` directories
-- [ ] Enforce default-deny for script resources from untrusted roots unless explicitly allowed
-- [ ] Parse `allowed-tools` frontmatter field and make available for agent tool filtering
-- [ ] Log guardrail decisions with policy reason codes for auditing
-- [ ] Create security regression tests for path traversal, untrusted script denial, and policy bypass attempts
-- [ ] Document secure defaults and trust escalation workflow
-- [ ] Add or update story documentation at docs/st06004-skill-trust-policies-and-guardrails.md (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Create branch `feat/st-06004-skill-trust-policies-and-guardrails`
+- [x] Create draft PR with story ID in title — PR #49
+- [x] Define trust policy configuration model for `workspace`, `trusted`, and `untrusted` roots
+- [x] Enforce trust policy in `read-skill-resource` before returning script content from `scripts/` directories
+- [x] Enforce default-deny for script resources from untrusted roots unless explicitly allowed
+- [x] Parse `allowed-tools` frontmatter field and make available for agent tool filtering
+- [x] Log guardrail decisions with policy reason codes for auditing
+- [x] Create security regression tests for path traversal, untrusted script denial, and policy bypass attempts
+- [x] Document secure defaults and trust escalation workflow
+- [x] Add or update story documentation at docs/st06004-skill-trust-policies-and-guardrails.md
+- [x] Assess test impact; add/update automated tests when needed — 41 trust tests + 175 total skills tests
+- [x] Run full test suite before finalizing the PR and record results — 175 pass, 0 fail
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results — 0 errors, 0 warnings
+- [x] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -132,7 +132,7 @@
 - [x] Run full test suite before finalizing the PR and record results — 175 pass, 0 fail
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results — 0 errors, 0 warnings
 - [x] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete — marked ready 2026-02-24
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
+- **Ready:** 0 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story (queued for prioritization and dependencies)
 
@@ -14,13 +14,7 @@
 
 ## Ready
 
-### ST-06004: Implement Skill Trust Policies and Execution Guardrails
-- **Epic:** EP-06
-- **Priority:** P1
-- **Estimate:** 6 hours
-- **Dependencies:** ST-06003 (merged)
-- **Checklist:** `planning/checklists/epic-06-story-tasks.md`
-- **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
+_No stories currently ready_
 
 ---
 
@@ -32,7 +26,15 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+### ST-06004: Implement Skill Trust Policies and Execution Guardrails
+- **Epic:** EP-06
+- **Priority:** P1
+- **Estimate:** 6 hours
+- **Dependencies:** ST-06003 (merged)
+- **Branch:** `feat/st-06004-skill-trust-policies-and-guardrails`
+- **PR:** #49 (draft)
+- **Checklist:** `planning/checklists/epic-06-story-tasks.md`
+- **Feature:** `planning/features/06-agent-skills-compatibility-feature-plan.md`
 
 ---
 


### PR DESCRIPTION
## ST-06004: Implement Skill Trust Policies and Execution Guardrails

**User story:** As a platform owner, I want explicit trust controls for skills so that agents cannot execute unsafe skill resources.

### Summary

Implements a security layer for the Agent Skills system that controls access to script resources (`scripts/` directories) based on configurable trust levels per skill root.

### Trust Levels

| Level | Script Access | Use Case |
|-------|--------------|----------|
| `workspace` | Allowed | Project-local `.agentskills/` |
| `trusted` | Allowed | Verified shared skill repositories |
| `untrusted` | Denied (default) | Community/unknown skill roots |

### Changes

#### New: `packages/core/src/skills/trust.ts`
- `normalizeRootConfig()` — converts plain string roots to `{ path, trust: 'untrusted' }` (backward compatible)
- `isScriptResource()` — detects `scripts/` prefix paths
- `evaluateTrustPolicy()` — policy engine returning `{ allowed, reason, message }`

#### Modified: `packages/core/src/skills/types.ts`
- Added `TrustLevel`, `SkillRootConfig`, `TrustPolicyDecision`, `TrustPolicyReason`
- Extended `SkillRegistryConfig` with `allowUntrustedScripts` option
- Extended `Skill` with `trustLevel` field
- Added `TRUST_POLICY_DENIED` and `TRUST_POLICY_ALLOWED` events

#### Modified: `packages/core/src/skills/registry.ts`
- Trust-aware discovery: builds `rootTrustMap`, assigns `trustLevel` to skills
- New APIs: `getAllowUntrustedScripts()`, `getAllowedTools(name)`

#### Modified: `packages/core/src/skills/activation.ts`
- `read-skill-resource` enforces trust policy before returning content
- Emits trust policy events, logs guardrail decisions with reason codes

#### New: `packages/core/tests/skills/trust.test.ts`
- 41 tests covering normalizeRootConfig, isScriptResource, evaluateTrustPolicy, integration enforcement, security regression (path traversal + untrusted denial + bypass), getAllowedTools, backward compatibility

### Test Results

- **175 skills tests pass** (6 test files)
- **Lint clean** (0 errors, 0 warnings)
- No regressions in existing test suites

### Acceptance Criteria

- [x] Trust policy levels configurable per skill root
- [x] `read-skill-resource` enforces trust before returning scripts
- [x] Untrusted scripts denied by default
- [x] `allowed-tools` parsed and available for filtering
- [x] Guardrail decisions logged with reason codes
- [x] Security tests: path traversal, untrusted denial, policy bypass
- [ ] Operational docs (planned — story docs commit)

### Backward Compatibility

Plain string skill roots default to `untrusted` trust level via `normalizeRootConfig()`. Existing configurations continue to work — only script access from untrusted roots is newly restricted.
