### PR TITLE
docs(st-06006): comprehensive docs-site documentation for Agent Skills

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -73,6 +73,13 @@ export default defineConfig({
           ]
         },
         {
+          text: 'Agent Skills',
+          items: [
+            { text: 'Integration Guide', link: '/guide/agent-skills' },
+            { text: 'Authoring Skills', link: '/guide/agent-skills-authoring' }
+          ]
+        },
+        {
           text: 'Advanced',
           items: [
             { text: 'Streaming', link: '/guide/advanced/streaming' },
@@ -109,6 +116,7 @@ export default defineConfig({
             { text: 'Reflection Agent', link: '/examples/reflection' },
             { text: 'Multi-Agent System', link: '/examples/multi-agent' },
             { text: 'Custom Tools', link: '/examples/custom-tools' },
+            { text: 'Agent Skills', link: '/examples/agent-skills' },
             { text: 'Middleware Stack', link: '/examples/middleware' }
           ]
         }
@@ -124,6 +132,7 @@ export default defineConfig({
             { text: 'Advanced Patterns', link: '/tutorials/advanced-patterns' },
             { text: 'Production Deployment', link: '/tutorials/production-deployment' },
             { text: 'Database Agent', link: '/tutorials/database-agent' },
+            { text: 'Skill-Powered Agent', link: '/tutorials/skill-powered-agent' },
             { text: 'Testing Strategies', link: '/tutorials/testing' }
           ]
         }

--- a/docs-site/api/core.md
+++ b/docs-site/api/core.md
@@ -949,14 +949,14 @@ interface SkillMetadata {
 | `createActivateSkillTool(registry)` | `(SkillRegistry) => Tool` | Create standalone activate-skill tool |
 | `createReadSkillResourceTool(registry)` | `(SkillRegistry) => Tool` | Create standalone read-skill-resource tool |
 | `createSkillActivationTools(registry)` | `(SkillRegistry) => [Tool, Tool]` | Create both tools as a tuple |
-| `resolveResourcePath(skillDir, resourcePath)` | `(string, string) => string` | Validate and resolve a resource path |
+| `resolveResourcePath(skillDir, resourcePath)` | `(string, string) => { success: true; resolvedPath: string } \| { success: false; error: string }` | Validate and resolve a resource path (returns discriminated union) |
 | `evaluateTrustPolicy(resourcePath, trustLevel, allowUntrustedScripts?)` | `(...) => TrustPolicyDecision` | Evaluate whether a resource access is allowed |
 | `isScriptResource(resourcePath)` | `(string) => boolean` | Check if path targets `scripts/` directory |
 | `normalizeRootConfig(root)` | `(string \| SkillRootConfig) => SkillRootConfig` | Normalize string to root config |
 | `parseSkillContent(content, dirName)` | `(string, string) => SkillParseResult` | Parse SKILL.md content and validate |
 | `validateSkillName(name)` | `(string) => SkillValidationError[]` | Validate skill name format |
 | `scanSkillRoot(rootPath)` | `(string) => SkillCandidate[]` | Scan a directory for skill candidates |
-| `scanAllSkillRoots(roots)` | `(SkillRootConfig[]) => SkillCandidate[]` | Scan multiple root directories |
+| `scanAllSkillRoots(roots)` | `(string[]) => SkillCandidate[]` | Scan multiple root directories |
 
 ## Type Definitions
 

--- a/docs-site/api/core.md
+++ b/docs-site/api/core.md
@@ -775,6 +775,189 @@ metrics.gauge('active_connections', 5);
 metrics.histogram('response_time', 150);
 ```
 
+## Agent Skills {#agent-skills}
+
+The Agent Skills system provides SKILL.md-driven capability loading for agents. Skills are discovered from configurable directories and activated at runtime through tool calls.
+
+::: tip
+For a step-by-step tutorial, see [Building a Skill-Powered Agent](/tutorials/skill-powered-agent). For usage patterns, see [Agent Skills Examples](/examples/agent-skills).
+:::
+
+### SkillRegistry {#skillregistry}
+
+Central registry that discovers, indexes, and provides access to SKILL.md-based skills.
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+
+const registry = new SkillRegistry({
+  skillRoots: [
+    { path: './.agentskills', trust: 'workspace' },
+  ],
+  enabled: true,
+});
+```
+
+#### Constructor Options — `SkillRegistryConfig`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `skillRoots` | `Array<string \| SkillRootConfig>` | *required* | Directories to scan for skills |
+| `enabled` | `boolean` | `false` | Gates `generatePrompt()` output |
+| `maxDiscoveredSkills` | `number` | `undefined` | Cap on skills included in prompt |
+| `allowUntrustedScripts` | `boolean` | `false` | Allow script access from untrusted roots |
+
+#### `SkillRootConfig`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `string` | Directory path to scan |
+| `trust` | `TrustLevel` | `'workspace' \| 'trusted' \| 'untrusted'` |
+
+Plain string roots default to `{ path: value, trust: 'untrusted' }`.
+
+#### Query Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get(name)` | `Skill \| undefined` | Get a skill by name |
+| `getAll()` | `Skill[]` | Get all discovered skills |
+| `has(name)` | `boolean` | Check if a skill exists |
+| `size()` | `number` | Number of discovered skills |
+| `getNames()` | `string[]` | Array of all skill names |
+| `getScanErrors()` | `ReadonlyArray<{ path: string; error: string }>` | Errors from last scan |
+| `getAllowedTools(name)` | `string[] \| undefined` | Get `allowed-tools` list for a skill |
+| `getAllowUntrustedScripts()` | `boolean` | Whether untrusted script override is set |
+
+#### `generatePrompt(options?)`
+
+Generates an `<available_skills>` XML block for the LLM system prompt.
+
+```typescript
+// All skills
+const prompt = registry.generatePrompt();
+
+// Filtered subset
+const prompt = registry.generatePrompt({ skills: ['code-review'] });
+```
+
+**`SkillPromptOptions`:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `skills` | `string[]` | Optional subset of skill names to include |
+
+Returns an empty string when `enabled` is `false` or no skills match.
+
+#### `toActivationTools()`
+
+Returns a tuple of two tools pre-wired to the registry instance:
+
+```typescript
+const [activateSkill, readSkillResource] = registry.toActivationTools();
+```
+
+| Tool | Schema | Description |
+|------|--------|-------------|
+| `activate-skill` | `{ name: string }` | Loads the full SKILL.md body content for a skill |
+| `read-skill-resource` | `{ name: string, path: string }` | Reads a resource file from a skill directory |
+
+Both tools are in the `ToolCategory.SKILLS` category.
+
+#### `discover()`
+
+Re-scans all configured roots and rebuilds the registry. Called automatically during construction.
+
+```typescript
+registry.discover(); // Rescan after installing new skills
+```
+
+#### Event Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `on(event, handler)` | `(SkillRegistryEvent, (data: unknown) => void) => void` | Subscribe to event |
+| `off(event, handler)` | `(SkillRegistryEvent, (data: unknown) => void) => void` | Unsubscribe |
+| `emitEvent(event, data)` | `(SkillRegistryEvent, unknown) => void` | Emit an event (used by activation tools) |
+
+### SkillRegistryEvent
+
+Enum of events emitted by the registry and activation tools.
+
+| Event | String Value | Payload Shape |
+|-------|-------------|---------------|
+| `SKILL_DISCOVERED` | `'skill:discovered'` | `Skill` object |
+| `SKILL_WARNING` | `'skill:warning'` | `{ skillPath, rootPath, error, duplicateOf? }` |
+| `SKILL_ACTIVATED` | `'skill:activated'` | `{ name, skillPath, bodyLength }` |
+| `SKILL_RESOURCE_LOADED` | `'skill:resource-loaded'` | `{ name, resourcePath, resolvedPath, contentLength }` |
+| `TRUST_POLICY_DENIED` | `'trust:policy-denied'` | `{ name, resourcePath, trustLevel, reason, message }` |
+| `TRUST_POLICY_ALLOWED` | `'trust:policy-allowed'` | `{ name, resourcePath, trustLevel, reason }` |
+
+### TrustLevel
+
+```typescript
+type TrustLevel = 'workspace' | 'trusted' | 'untrusted';
+```
+
+| Level | Reference Files | Script Files | Use Case |
+|-------|:---------------:|:------------:|----------|
+| `workspace` | ✅ | ✅ | First-party project skills |
+| `trusted` | ✅ | ✅ | Vetted community/team skills |
+| `untrusted` | ✅ | ❌ | Unknown or unreviewed sources |
+
+### TrustPolicyReason
+
+Enum returned in trust policy decisions for audit logging.
+
+| Reason | When |
+|--------|------|
+| `NOT_SCRIPT` | Resource is not in `scripts/` — always allowed |
+| `WORKSPACE_TRUST` | Root has `workspace` trust — scripts allowed |
+| `TRUSTED_ROOT` | Root has `trusted` trust — scripts allowed |
+| `UNTRUSTED_SCRIPT_DENIED` | Untrusted root, no override — scripts blocked |
+| `UNTRUSTED_SCRIPT_ALLOWED` | Untrusted root but `allowUntrustedScripts: true` |
+| `UNKNOWN_TRUST_LEVEL` | Unknown trust level — treated as denied |
+
+### Skill Type
+
+```typescript
+interface Skill {
+  metadata: SkillMetadata;
+  skillPath: string;      // Absolute path to skill directory
+  rootPath: string;       // Which configured root this was discovered from
+  trustLevel: TrustLevel;
+}
+```
+
+### SkillMetadata
+
+```typescript
+interface SkillMetadata {
+  name: string;                       // 1-64 chars, kebab-case, matches directory name
+  description: string;                // 1-1024 chars
+  license?: string;                   // SPDX identifier
+  compatibility?: string[];           // Compatible frameworks
+  metadata?: Record<string, unknown>; // Arbitrary key-value pairs
+  allowedTools?: string[];            // Tools the skill is designed to use
+}
+```
+
+### Utility Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `createActivateSkillTool(registry)` | `(SkillRegistry) => Tool` | Create standalone activate-skill tool |
+| `createReadSkillResourceTool(registry)` | `(SkillRegistry) => Tool` | Create standalone read-skill-resource tool |
+| `createSkillActivationTools(registry)` | `(SkillRegistry) => [Tool, Tool]` | Create both tools as a tuple |
+| `resolveResourcePath(skillDir, resourcePath)` | `(string, string) => string` | Validate and resolve a resource path |
+| `evaluateTrustPolicy(resourcePath, trustLevel, allowUntrustedScripts?)` | `(...) => TrustPolicyDecision` | Evaluate whether a resource access is allowed |
+| `isScriptResource(resourcePath)` | `(string) => boolean` | Check if path targets `scripts/` directory |
+| `normalizeRootConfig(root)` | `(string \| SkillRootConfig) => SkillRootConfig` | Normalize string to root config |
+| `parseSkillContent(content, dirName)` | `(string, string) => SkillParseResult` | Parse SKILL.md content and validate |
+| `validateSkillName(name)` | `(string) => SkillValidationError[]` | Validate skill name format |
+| `scanSkillRoot(rootPath)` | `(string) => SkillCandidate[]` | Scan a directory for skill candidates |
+| `scanAllSkillRoots(roots)` | `(SkillRootConfig[]) => SkillCandidate[]` | Scan multiple root directories |
+
 ## Type Definitions
 
 All exports include full TypeScript definitions. See the [source code](https://github.com/TVScoundrel/agentforge/tree/main/packages/core/src) for complete type information.

--- a/docs-site/examples/agent-skills.md
+++ b/docs-site/examples/agent-skills.md
@@ -139,7 +139,8 @@ The agent calls this tool to load resource files from a skill directory:
 // read-skill-resource({ name: "test-generator", path: "references/test-template.md" })
 //
 // Returns the file content as a string.
-// Supported resource directories: references/, scripts/, assets/
+// Common resource directories: references/, scripts/, assets/ (any file within the skill directory is allowed)
+// Note: script files are subject to trust policy checks based on the skill root's trust level.
 ```
 
 ## Multi-Root Configuration
@@ -257,7 +258,7 @@ const toolRegistry = new ToolRegistry();
 
 // Get the allowed tools for a specific skill
 const allowedTools = skillRegistry.getAllowedTools('code-review');
-// Returns: ['read-file', 'grep-search'] or undefined if not set
+// Returns: ['file-reader', 'file-search'] or undefined if not set
 
 if (allowedTools) {
   // Filter registered tools to only those the skill expects
@@ -356,14 +357,14 @@ console.log(`After rescan: ${skillRegistry.size()} skills`);
 Build agents that use both custom tools and skill-driven instructions:
 
 ```typescript
-import { SkillRegistry, createToolBuilder, ToolCategory } from '@agentforge/core';
+import { SkillRegistry, toolBuilder, ToolCategory } from '@agentforge/core';
 import { createReActAgent } from '@agentforge/patterns';
 import { ChatOpenAI } from '@langchain/openai';
 import { z } from 'zod';
 
 // Custom tool
-const readFileTool = createToolBuilder()
-  .name('read-file')
+const readFileTool = toolBuilder()
+  .name('file-reader')
   .description('Read the contents of a file')
   .category(ToolCategory.FILE_SYSTEM)
   .schema(z.object({

--- a/docs-site/examples/agent-skills.md
+++ b/docs-site/examples/agent-skills.md
@@ -1,0 +1,404 @@
+---
+outline: deep
+---
+
+# Agent Skills Examples
+
+Practical code examples for integrating Agent Skills into your AgentForge agents. Each example is self-contained and can be adapted to your use case.
+
+## Basic Registry Setup
+
+Create a `SkillRegistry` that scans a local directory for skills:
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    {
+      path: path.join(__dirname, '..', '.agentskills'),
+      trust: 'workspace',
+    },
+  ],
+  enabled: true,
+});
+
+// Query discovered skills
+console.log(`Found ${skillRegistry.size()} skills`);
+console.log('Names:', skillRegistry.getNames());
+
+// Check for a specific skill
+if (skillRegistry.has('code-review')) {
+  const skill = skillRegistry.get('code-review');
+  console.log(skill?.metadata.description);
+  console.log('Trust level:', skill?.trustLevel);
+}
+
+// Get all skills
+for (const skill of skillRegistry.getAll()) {
+  console.log(`${skill.metadata.name} — ${skill.metadata.description}`);
+}
+```
+
+## Prompt Generation
+
+Generate the `<available_skills>` XML block to include in your agent's system prompt:
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+  maxDiscoveredSkills: 10, // Limit prompt token usage
+});
+
+// Full prompt with all skills
+const fullPrompt = skillRegistry.generatePrompt();
+
+// Filtered prompt — only include specific skills
+const focusedPrompt = skillRegistry.generatePrompt({
+  skills: ['code-review', 'test-generator'],
+});
+
+// Compose with tool prompt
+import { ToolRegistry } from '@agentforge/core';
+
+const toolRegistry = new ToolRegistry();
+// ... register tools ...
+
+const systemPrompt = `You are a helpful coding assistant.
+
+${toolRegistry.generatePrompt()}
+
+${skillRegistry.generatePrompt()}
+
+When a task matches an available skill, activate it and follow its instructions.`;
+```
+
+::: tip Feature Flag
+When `enabled: false` (the default), `generatePrompt()` returns an empty string. This lets you toggle skills without changing your prompt construction logic.
+:::
+
+## Activation Tools
+
+Wire skill activation into any agent pattern using `toActivationTools()`:
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+import { createReActAgent } from '@agentforge/patterns';
+import { ChatOpenAI } from '@langchain/openai';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+});
+
+// Get the two activation tools
+const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
+
+// Use with ReAct agent
+const agent = createReActAgent({
+  llm: new ChatOpenAI({ modelName: 'gpt-4o' }),
+  tools: [activateSkill, readSkillResource],
+  systemPrompt: `You have access to skills. ${skillRegistry.generatePrompt()}`,
+});
+
+// Or use individual tool factories
+import {
+  createActivateSkillTool,
+  createReadSkillResourceTool,
+} from '@agentforge/core';
+
+const activate = createActivateSkillTool(skillRegistry);
+const readResource = createReadSkillResourceTool(skillRegistry);
+```
+
+### activate-skill
+
+The agent calls this tool to load a skill's full instructions:
+
+```typescript
+// The agent would invoke this tool like:
+// activate-skill({ name: "code-review" })
+//
+// Returns the full SKILL.md body content (below the frontmatter):
+// "# Code Review Skill\n\n## Process\n1. Read the file(s)..."
+```
+
+### read-skill-resource
+
+The agent calls this tool to load resource files from a skill directory:
+
+```typescript
+// The agent would invoke this tool like:
+// read-skill-resource({ name: "test-generator", path: "references/test-template.md" })
+//
+// Returns the file content as a string.
+// Supported resource directories: references/, scripts/, assets/
+```
+
+## Multi-Root Configuration
+
+Configure multiple skill roots with different trust levels for layered access control:
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    // First-party skills — full access including scripts
+    {
+      path: './.agentskills',
+      trust: 'workspace',
+    },
+    // Vetted team/community skills — scripts allowed
+    {
+      path: '/opt/company-skills',
+      trust: 'trusted',
+    },
+    // User-installed skills — scripts blocked
+    {
+      path: `${process.env.HOME}/.agentskills`,
+      trust: 'untrusted',
+    },
+  ],
+  enabled: true,
+});
+
+// Skills from all roots are merged
+// Duplicate names: first root wins (deterministic precedence)
+console.log(`Total skills: ${skillRegistry.size()}`);
+
+// Check a skill's trust level
+const skill = skillRegistry.get('some-community-skill');
+console.log('Trust:', skill?.trustLevel); // 'trusted' or 'untrusted'
+```
+
+::: info String Shorthand
+You can pass plain strings instead of config objects. Strings default to `untrusted` trust:
+```typescript
+const registry = new SkillRegistry({
+  skillRoots: ['/path/to/skills'], // Equivalent to { path: '...', trust: 'untrusted' }
+  enabled: true,
+});
+```
+:::
+
+## Trust Policies
+
+Control what resources agents can access based on the skill root's trust level:
+
+```typescript
+import { SkillRegistry, SkillRegistryEvent } from '@agentforge/core';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    { path: './.agentskills', trust: 'workspace' },
+    { path: './community-skills', trust: 'untrusted' },
+  ],
+  enabled: true,
+  // allowUntrustedScripts: true, // Override to allow scripts from untrusted roots (NOT recommended)
+});
+
+// Monitor trust decisions
+skillRegistry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => {
+  const event = data as {
+    name: string;
+    resourcePath: string;
+    trustLevel: string;
+    reason: string;
+    message: string;
+  };
+  console.warn(`DENIED: ${event.name}/${event.resourcePath} — ${event.message}`);
+});
+
+skillRegistry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => {
+  const event = data as {
+    name: string;
+    resourcePath: string;
+    trustLevel: string;
+    reason: string;
+  };
+  console.log(`ALLOWED: ${event.name}/${event.resourcePath} (${event.reason})`);
+});
+```
+
+**Trust policy matrix:**
+
+| Resource Type | `workspace` | `trusted` | `untrusted` |
+|--------------|:-----------:|:---------:|:-----------:|
+| `references/*` | ✅ | ✅ | ✅ |
+| `assets/*` | ✅ | ✅ | ✅ |
+| `scripts/*` | ✅ | ✅ | ❌ |
+
+::: warning Path Traversal Protection
+The `read-skill-resource` tool blocks all path traversal attempts. Absolute paths, `..` segments, and symlink escapes are rejected before any file access occurs.
+:::
+
+## Allowed-Tools Filtering
+
+Skills can declare which tools they're designed to use. Use `getAllowedTools()` to filter your agent's tool set per skill:
+
+```typescript
+import { SkillRegistry, ToolRegistry } from '@agentforge/core';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+});
+
+const toolRegistry = new ToolRegistry();
+// ... register tools ...
+
+// Get the allowed tools for a specific skill
+const allowedTools = skillRegistry.getAllowedTools('code-review');
+// Returns: ['read-file', 'grep-search'] or undefined if not set
+
+if (allowedTools) {
+  // Filter registered tools to only those the skill expects
+  const filtered = toolRegistry.getAll()
+    .filter(tool => allowedTools.includes(tool.name));
+  console.log('Filtered tools:', filtered.map(t => t.name));
+}
+```
+
+## Event Monitoring
+
+Subscribe to registry events for observability, logging, and metrics:
+
+```typescript
+import { SkillRegistry, SkillRegistryEvent } from '@agentforge/core';
+
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+});
+
+// Discovery events (emitted during construction / discover())
+skillRegistry.on(SkillRegistryEvent.SKILL_DISCOVERED, (data) => {
+  const skill = data as {
+    metadata: { name: string; description: string };
+    skillPath: string;
+    trustLevel: string;
+  };
+  console.log(`✅ Discovered: ${skill.metadata.name} (${skill.trustLevel})`);
+});
+
+skillRegistry.on(SkillRegistryEvent.SKILL_WARNING, (data) => {
+  const warning = data as {
+    skillPath: string;
+    rootPath: string;
+    error: string;
+    duplicateOf?: string;
+  };
+  console.warn(`⚠️ Warning: ${warning.error} at ${warning.skillPath}`);
+});
+
+// Runtime events (emitted by activation tools)
+skillRegistry.on(SkillRegistryEvent.SKILL_ACTIVATED, (data) => {
+  const event = data as { name: string; skillPath: string; bodyLength: number };
+  console.log(`📋 Activated: ${event.name} (${event.bodyLength} chars)`);
+});
+
+skillRegistry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, (data) => {
+  const event = data as {
+    name: string;
+    resourcePath: string;
+    resolvedPath: string;
+    contentLength: number;
+  };
+  console.log(`📄 Resource: ${event.name}/${event.resourcePath}`);
+});
+
+// Trust events
+skillRegistry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => {
+  const event = data as { name: string; resourcePath: string; message: string };
+  console.error(`🚫 Denied: ${event.message}`);
+});
+
+skillRegistry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => {
+  const event = data as { name: string; resourcePath: string; reason: string };
+  console.log(`🔓 Allowed: ${event.name}/${event.resourcePath}`);
+});
+
+// Unsubscribe when done
+const handler = (data: unknown) => { /* ... */ };
+skillRegistry.on(SkillRegistryEvent.SKILL_ACTIVATED, handler);
+skillRegistry.off(SkillRegistryEvent.SKILL_ACTIVATED, handler);
+```
+
+## Re-Discovery
+
+Rescan skill roots at runtime (e.g., after installing new skills):
+
+```typescript
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+});
+
+console.log(`Initial: ${skillRegistry.size()} skills`);
+
+// ... user installs a new skill directory ...
+
+// Rescan all roots (clears and rebuilds the registry)
+skillRegistry.discover();
+console.log(`After rescan: ${skillRegistry.size()} skills`);
+```
+
+## Combining Skills with Custom Tools
+
+Build agents that use both custom tools and skill-driven instructions:
+
+```typescript
+import { SkillRegistry, createToolBuilder, ToolCategory } from '@agentforge/core';
+import { createReActAgent } from '@agentforge/patterns';
+import { ChatOpenAI } from '@langchain/openai';
+import { z } from 'zod';
+
+// Custom tool
+const readFileTool = createToolBuilder()
+  .name('read-file')
+  .description('Read the contents of a file')
+  .category(ToolCategory.FILE_SYSTEM)
+  .schema(z.object({
+    path: z.string().describe('File path to read'),
+  }))
+  .implement(async ({ path }) => {
+    const fs = await import('fs/promises');
+    return fs.readFile(path, 'utf-8');
+  })
+  .build();
+
+// Skill registry with activation tools
+const skillRegistry = new SkillRegistry({
+  skillRoots: [{ path: './.agentskills', trust: 'workspace' }],
+  enabled: true,
+});
+
+const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
+
+// Combine custom tools + skill activation tools
+const agent = createReActAgent({
+  llm: new ChatOpenAI({ modelName: 'gpt-4o' }),
+  tools: [readFileTool, activateSkill, readSkillResource],
+  systemPrompt: `You are a coding assistant.
+
+${skillRegistry.generatePrompt()}
+
+When a task matches a skill, activate it first to get detailed instructions.
+You also have direct tools available for file operations.`,
+});
+```
+
+## What's Next?
+
+- **[Agent Skills Integration Guide](/guide/agent-skills)** — Configuration reference, runtime flow, security, and rollout checklist
+- **[Skill Authoring Guide](/guide/agent-skills-authoring)** — How to write spec-compliant SKILL.md files
+- **[Skill-Powered Agent Tutorial](/tutorials/skill-powered-agent)** — Step-by-step walkthrough building from scratch
+- **[SkillRegistry API Reference](/api/core#skillregistry)** — Full API documentation

--- a/docs-site/examples/agent-skills.md
+++ b/docs-site/examples/agent-skills.md
@@ -362,9 +362,9 @@ import { createReActAgent } from '@agentforge/patterns';
 import { ChatOpenAI } from '@langchain/openai';
 import { z } from 'zod';
 
-// Custom tool
+// Custom local file-reading tool (distinct from the built-in `file-reader` tool)
 const readFileTool = toolBuilder()
-  .name('file-reader')
+  .name('local-file-reader')
   .description('Read the contents of a file')
   .category(ToolCategory.FILE_SYSTEM)
   .schema(z.object({

--- a/docs-site/examples/agent-skills.md
+++ b/docs-site/examples/agent-skills.md
@@ -103,7 +103,7 @@ const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
 
 // Use with ReAct agent
 const agent = createReActAgent({
-  llm: new ChatOpenAI({ modelName: 'gpt-4o' }),
+  model: new ChatOpenAI({ modelName: 'gpt-4o' }),
   tools: [activateSkill, readSkillResource],
   systemPrompt: `You have access to skills. ${skillRegistry.generatePrompt()}`,
 });
@@ -263,8 +263,8 @@ const allowedTools = skillRegistry.getAllowedTools('code-review');
 if (allowedTools) {
   // Filter registered tools to only those the skill expects
   const filtered = toolRegistry.getAll()
-    .filter(tool => allowedTools.includes(tool.name));
-  console.log('Filtered tools:', filtered.map(t => t.name));
+    .filter(tool => allowedTools.includes(tool.metadata.name));
+  console.log('Filtered tools:', filtered.map(t => t.metadata.name));
 }
 ```
 
@@ -370,7 +370,7 @@ const readFileTool = toolBuilder()
   .schema(z.object({
     path: z.string().describe('File path to read'),
   }))
-  .implement(async ({ path }) => {
+  .implementSafe(async ({ path }) => {
     const fs = await import('fs/promises');
     return fs.readFile(path, 'utf-8');
   })
@@ -386,7 +386,7 @@ const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
 
 // Combine custom tools + skill activation tools
 const agent = createReActAgent({
-  llm: new ChatOpenAI({ modelName: 'gpt-4o' }),
+  model: new ChatOpenAI({ modelName: 'gpt-4o' }),
   tools: [readFileTool, activateSkill, readSkillResource],
   systemPrompt: `You are a coding assistant.
 

--- a/docs-site/guide/agent-skills-authoring.md
+++ b/docs-site/guide/agent-skills-authoring.md
@@ -280,3 +280,10 @@ describe('functionName', () => {
 
 - Ensure `enabled: true` is set in `SkillRegistryConfig`
 - Check that skills were discovered: `registry.size() > 0`
+
+## See Also
+
+- **[Agent Skills Integration Guide](/guide/agent-skills)** — Configuration reference, runtime flow, security, and rollout checklist
+- **[Skill-Powered Agent Tutorial](/tutorials/skill-powered-agent)** — Step-by-step walkthrough building a skill-powered agent from scratch
+- **[Agent Skills Examples](/examples/agent-skills)** — Common patterns and runnable code snippets
+- **[SkillRegistry API Reference](/api/core#skillregistry)** — Full API documentation for the SkillRegistry class

--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -288,3 +288,10 @@ If issues are detected after enabling Agent Skills:
 Setting `enabled: false` only suppresses `generatePrompt()`. If activation tools are registered with the agent, they remain callable. Remove them from the tool array for a complete rollback.
 :::
 
+## See Also
+
+- **[Skill Authoring Guide](/guide/agent-skills-authoring)** — How to write spec-compliant SKILL.md files with frontmatter, resources, and trust policies
+- **[Skill-Powered Agent Tutorial](/tutorials/skill-powered-agent)** — Step-by-step walkthrough building a skill-powered agent from scratch
+- **[Agent Skills Examples](/examples/agent-skills)** — Common patterns and runnable code snippets
+- **[SkillRegistry API Reference](/api/core#skillregistry)** — Full API documentation for the SkillRegistry class
+

--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -1,0 +1,442 @@
+---
+outline: deep
+---
+
+# Building a Skill-Powered Agent
+
+In this tutorial, you'll build an AI agent that discovers, activates, and follows SKILL.md-driven instructions at runtime — all in about 15 minutes. By the end, your agent will select and use skills autonomously to complete user tasks.
+
+## What You'll Build
+
+A skill-powered coding assistant that can:
+- Discover available skills from configured directories
+- Show skill summaries in its system prompt
+- Activate a skill on demand and follow its instructions
+- Load skill resources (references, templates, scripts)
+- Respect trust boundaries for script access
+
+## Prerequisites
+
+- Node.js 18+
+- An OpenAI API key (or any LangChain-compatible LLM)
+- Basic TypeScript knowledge
+- Familiarity with [AgentForge tools](/guide/concepts/tools) and [agent patterns](/guide/patterns/react)
+
+## Step 1: Set Up the Project
+
+```bash
+npx @agentforge/cli create skill-agent
+cd skill-agent
+pnpm install
+```
+
+Install the LLM provider:
+
+```bash
+pnpm add @agentforge/core @agentforge/patterns @langchain/openai
+```
+
+Create `.env`:
+
+```bash
+OPENAI_API_KEY=your-api-key-here
+```
+
+## Step 2: Create Your First Skill
+
+Skills are directories containing a `SKILL.md` file with YAML frontmatter. Create a skill root and your first skill:
+
+```bash
+mkdir -p .agentskills/code-review
+```
+
+Create `.agentskills/code-review/SKILL.md`:
+
+```markdown
+---
+name: code-review
+description: Performs thorough code reviews with focus on best practices, security, and maintainability.
+allowed-tools:
+  - read-file
+  - grep-search
+---
+
+# Code Review Skill
+
+## Process
+
+1. Read the file(s) the user wants reviewed
+2. Analyze for:
+   - Security vulnerabilities
+   - Performance issues
+   - Code style and readability
+   - Error handling gaps
+3. Provide a structured review with severity levels:
+   - 🔴 Critical — must fix before merge
+   - 🟡 Warning — should fix
+   - 🟢 Suggestion — nice to have
+
+## Output Format
+
+Use this template for each finding:
+
+**[SEVERITY] Title**
+- File: `path/to/file`
+- Line: N
+- Issue: Description of the problem
+- Fix: Suggested solution
+```
+
+::: tip Skill Name Must Match Directory
+The `name` field in the frontmatter **must** match the parent directory name. So `code-review/SKILL.md` requires `name: code-review`.
+:::
+
+## Step 3: Create a Second Skill with Resources
+
+Create a test-generator skill with a reference template:
+
+```bash
+mkdir -p .agentskills/test-generator/references
+```
+
+Create `.agentskills/test-generator/SKILL.md`:
+
+```markdown
+---
+name: test-generator
+description: Generates comprehensive test suites following project conventions and testing best practices.
+allowed-tools:
+  - read-file
+  - write-file
+---
+
+# Test Generator Skill
+
+## Process
+
+1. Read the source file to understand the API surface
+2. Load the test template from `references/test-template.md`
+3. Generate tests covering:
+   - Happy path for each public method
+   - Edge cases (null, empty, boundary values)
+   - Error handling paths
+4. Follow the project's existing test conventions
+
+## Conventions
+
+- Use `describe`/`it` blocks with clear descriptions
+- One assertion per test when possible
+- Use factory helpers for test data setup
+```
+
+Create `.agentskills/test-generator/references/test-template.md`:
+
+```markdown
+# Test Template
+
+Use this structure for generated test files:
+
+\`\`\`typescript
+import { describe, it, expect } from 'vitest';
+
+describe('<ModuleName>', () => {
+  describe('<methodName>()', () => {
+    it('should <expected behavior> when <condition>', () => {
+      // Arrange
+      // Act
+      // Assert
+    });
+  });
+});
+\`\`\`
+```
+
+## Step 4: Configure the Skill Registry
+
+Now wire the skills into your agent. Create `src/index.ts`:
+
+```typescript
+import { SkillRegistry } from '@agentforge/core';
+import { createReActAgent } from '@agentforge/patterns';
+import { ChatOpenAI } from '@langchain/openai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// 1. Create the skill registry
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    {
+      path: path.join(__dirname, '..', '.agentskills'),
+      trust: 'workspace',  // Full trust for your own skills
+    }
+  ],
+  enabled: true,           // Enable skill prompt generation
+  maxDiscoveredSkills: 20, // Cap to manage prompt token usage
+});
+
+console.log(`Discovered ${skillRegistry.size()} skills:`);
+for (const skill of skillRegistry.getAll()) {
+  console.log(`  - ${skill.metadata.name}: ${skill.metadata.description}`);
+}
+```
+
+Run it to verify discovery works:
+
+```bash
+pnpm dlx tsx src/index.ts
+```
+
+Expected output:
+
+```
+Discovered 2 skills:
+  - code-review: Performs thorough code reviews with focus on best practices, security, and maintainability.
+  - test-generator: Generates comprehensive test suites following project conventions and testing best practices.
+```
+
+## Step 5: Generate the System Prompt
+
+The `generatePrompt()` method produces an `<available_skills>` XML block that tells the LLM which skills are available:
+
+```typescript
+// 2. Generate skill-aware system prompt
+const skillPrompt = skillRegistry.generatePrompt();
+console.log(skillPrompt);
+```
+
+Output:
+
+```xml
+<available_skills>
+  <skill>
+    <name>code-review</name>
+    <description>Performs thorough code reviews with focus on best practices, security, and maintainability.</description>
+    <location>/path/to/.agentskills/code-review</location>
+  </skill>
+  <skill>
+    <name>test-generator</name>
+    <description>Generates comprehensive test suites following project conventions and testing best practices.</description>
+    <location>/path/to/.agentskills/test-generator</location>
+  </skill>
+</available_skills>
+```
+
+::: tip Subset Filtering
+You can pass a `skills` filter to only include specific skills in the prompt:
+```typescript
+const prompt = skillRegistry.generatePrompt({ skills: ['code-review'] });
+```
+This is useful when building focused agents that only need a subset of available skills.
+:::
+
+## Step 6: Wire Activation Tools into the Agent
+
+The `toActivationTools()` method returns two tools pre-wired to the registry:
+
+- **`activate-skill`** — loads the full SKILL.md instructions for a skill by name
+- **`read-skill-resource`** — reads a resource file from a skill's directory
+
+```typescript
+// 3. Get activation tools
+const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
+
+// 4. Create the LLM
+const llm = new ChatOpenAI({
+  modelName: 'gpt-4o',
+  temperature: 0,
+});
+
+// 5. Build the agent with skill tools
+const agent = createReActAgent({
+  llm,
+  tools: [activateSkill, readSkillResource],
+  systemPrompt: `You are a coding assistant with access to specialized skills.
+
+${skillPrompt}
+
+When a user asks for help, check if an available skill matches the task.
+If so, use the activate-skill tool to load the skill's full instructions,
+then follow those instructions to complete the task.
+Use read-skill-resource to load any referenced templates or files.`,
+});
+```
+
+## Step 7: Run Your Skill-Powered Agent
+
+Add the invocation and run it:
+
+```typescript
+// 6. Invoke the agent
+const result = await agent.invoke({
+  messages: [
+    {
+      role: 'user',
+      content: 'Please review the code in src/index.ts for any issues.',
+    },
+  ],
+});
+
+console.log('Agent response:');
+for (const msg of result.messages) {
+  if (msg._getType() === 'ai' && msg.content) {
+    console.log(msg.content);
+  }
+}
+```
+
+The agent will:
+1. See `code-review` in `<available_skills>` and recognize it matches the task
+2. Call `activate-skill` with `{ name: "code-review" }` to load the full instructions
+3. Follow the skill's review process (read files, analyze, structured output)
+
+```bash
+pnpm dlx tsx src/index.ts
+```
+
+## Step 8: Add Observability with Events
+
+The `SkillRegistry` emits events you can monitor for observability:
+
+```typescript
+import { SkillRegistryEvent } from '@agentforge/core';
+
+// Listen for skill activations
+skillRegistry.on(SkillRegistryEvent.SKILL_ACTIVATED, (data) => {
+  const event = data as { name: string; skillPath: string; bodyLength: number };
+  console.log(`📋 Skill activated: ${event.name} (${event.bodyLength} chars)`);
+});
+
+// Listen for resource loads
+skillRegistry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, (data) => {
+  const event = data as {
+    name: string;
+    resourcePath: string;
+    contentLength: number;
+  };
+  console.log(
+    `📄 Resource loaded: ${event.name}/${event.resourcePath} (${event.contentLength} chars)`,
+  );
+});
+
+// Listen for trust policy denials
+skillRegistry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => {
+  const event = data as { name: string; resourcePath: string; reason: string };
+  console.warn(`🚫 Trust denied: ${event.name}/${event.resourcePath} — ${event.reason}`);
+});
+```
+
+## Step 9: Add Trust Policies for External Skills
+
+When loading skills from external or community sources, use trust levels to control access:
+
+```typescript
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    {
+      path: path.join(__dirname, '..', '.agentskills'),
+      trust: 'workspace',    // Your own skills — full access
+    },
+    {
+      path: '/usr/local/share/agentskills',
+      trust: 'trusted',      // Vetted community skills — scripts allowed
+    },
+    {
+      path: path.join(process.env.HOME!, '.agentskills'),
+      trust: 'untrusted',    // Unknown skills — scripts blocked
+    },
+  ],
+  enabled: true,
+});
+```
+
+| Trust Level | Reference Files | Script Files | Use Case |
+|-------------|----------------|--------------|----------|
+| `workspace` | ✅ Allowed | ✅ Allowed | First-party skills in your project |
+| `trusted` | ✅ Allowed | ✅ Allowed | Vetted community/team skills |
+| `untrusted` | ✅ Allowed | ❌ Blocked | Unknown or unreviewed skill sources |
+
+::: warning Script Access
+Resources under `scripts/` directories are subject to trust policy enforcement. Only `workspace` and `trusted` roots allow script access. Use `allowUntrustedScripts: true` in config to override (not recommended for production).
+:::
+
+## Complete Working Example
+
+Here's the full `src/index.ts` putting it all together:
+
+```typescript
+import { SkillRegistry, SkillRegistryEvent } from '@agentforge/core';
+import { createReActAgent } from '@agentforge/patterns';
+import { ChatOpenAI } from '@langchain/openai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// 1. Create and configure skill registry
+const skillRegistry = new SkillRegistry({
+  skillRoots: [
+    {
+      path: path.join(__dirname, '..', '.agentskills'),
+      trust: 'workspace',
+    },
+  ],
+  enabled: true,
+  maxDiscoveredSkills: 20,
+});
+
+// 2. Add observability
+skillRegistry.on(SkillRegistryEvent.SKILL_ACTIVATED, (data) => {
+  const event = data as { name: string; bodyLength: number };
+  console.log(`📋 Skill activated: ${event.name} (${event.bodyLength} chars)`);
+});
+
+skillRegistry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, (data) => {
+  const event = data as { name: string; resourcePath: string };
+  console.log(`📄 Resource loaded: ${event.name}/${event.resourcePath}`);
+});
+
+// 3. Generate prompt and tools
+const skillPrompt = skillRegistry.generatePrompt();
+const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
+
+// 4. Create agent
+const llm = new ChatOpenAI({ modelName: 'gpt-4o', temperature: 0 });
+
+const agent = createReActAgent({
+  llm,
+  tools: [activateSkill, readSkillResource],
+  systemPrompt: `You are a coding assistant with access to specialized skills.
+
+${skillPrompt}
+
+When a user asks for help, check if an available skill matches the task.
+If so, use the activate-skill tool to load the skill's full instructions,
+then follow those instructions to complete the task.
+Use read-skill-resource to load any referenced templates or files.`,
+});
+
+// 5. Run the agent
+const result = await agent.invoke({
+  messages: [
+    {
+      role: 'user',
+      content: 'Generate tests for the file src/utils/helpers.ts',
+    },
+  ],
+});
+
+for (const msg of result.messages) {
+  if (msg._getType() === 'ai' && msg.content) {
+    console.log(msg.content);
+  }
+}
+```
+
+## What's Next?
+
+- **[Agent Skills Integration Guide](/guide/agent-skills)** — Configuration reference, runtime flow, security, and rollout checklist
+- **[Skill Authoring Guide](/guide/agent-skills-authoring)** — How to write spec-compliant SKILL.md files with frontmatter, resources, and trust policies
+- **[Agent Skills Examples](/examples/agent-skills)** — Common patterns and code snippets for skill integration
+- **[SkillRegistry API Reference](/api/core#skillregistry)** — Full API documentation for the SkillRegistry class

--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -250,7 +250,7 @@ const llm = new ChatOpenAI({
 
 // 5. Build the agent with skill tools
 const agent = createReActAgent({
-  llm,
+  model: llm,
   tools: [activateSkill, readSkillResource],
   systemPrompt: `You are a coding assistant with access to specialized skills.
 
@@ -405,7 +405,7 @@ const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
 const llm = new ChatOpenAI({ modelName: 'gpt-4o', temperature: 0 });
 
 const agent = createReActAgent({
-  llm,
+  model: llm,
   tools: [activateSkill, readSkillResource],
   systemPrompt: `You are a coding assistant with access to specialized skills.
 

--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -57,8 +57,8 @@ Create `.agentskills/code-review/SKILL.md`:
 name: code-review
 description: Performs thorough code reviews with focus on best practices, security, and maintainability.
 allowed-tools:
-  - read-file
-  - grep-search
+  - file-reader
+  - file-search
 ---
 
 # Code Review Skill
@@ -106,8 +106,8 @@ Create `.agentskills/test-generator/SKILL.md`:
 name: test-generator
 description: Generates comprehensive test suites following project conventions and testing best practices.
 allowed-tools:
-  - read-file
-  - write-file
+  - file-reader
+  - file-writer
 ---
 
 # Test Generator Skill

--- a/docs/st06006-agent-skills-docs-site.md
+++ b/docs/st06006-agent-skills-docs-site.md
@@ -1,0 +1,57 @@
+# ST-06006: Comprehensive Docs-Site Documentation for Agent Skills
+
+**Epic:** EP-06 — Agent Skills Compatibility Layer
+**PR:** #51 — https://github.com/TVScoundrel/agentforge/pull/51
+**Branch:** `docs/st-06006-agent-skills-docs-site`
+
+## Summary
+
+Added comprehensive docs-site documentation for the Agent Skills feature (EP-06). The existing guide pages (`agent-skills.md`, `agent-skills-authoring.md`) were created in ST-06005 as developer setup/authoring references, but they were not linked in the VitePress sidebar and no tutorials, examples, or API reference existed.
+
+## What Was Added
+
+### New Pages
+
+| Page | Path | Lines | Purpose |
+|------|------|-------|---------|
+| Tutorial | `docs-site/tutorials/skill-powered-agent.md` | ~440 | Step-by-step guide building a skill-powered agent in 9 steps |
+| Examples | `docs-site/examples/agent-skills.md` | ~400 | 10 runnable code pattern examples (registry, prompts, tools, trust, events) |
+| API reference | `docs-site/api/core.md` (new section) | ~180 | SkillRegistry API, events, types, utility functions |
+
+### VitePress Sidebar Updates
+
+- Added "Agent Skills" section to the guide sidebar with links to `agent-skills.md` and `agent-skills-authoring.md`
+- Added "Skill-Powered Agent" to the tutorials sidebar
+- Added "Agent Skills" to the examples sidebar
+
+### Cross-Links
+
+- Added "See Also" sections to both existing guide pages linking to tutorial, examples, and API reference
+- Tutorial and examples pages include "What's Next?" sections linking back to guides and API reference
+- API reference section includes tip box linking to tutorial and examples
+
+## Gap Analysis
+
+Before this story:
+- 2 guide pages existed but were **invisible** (not in VitePress sidebar)
+- 0 tutorials for Agent Skills (compare: `database-agent.md` for DB tools)
+- 0 examples for Agent Skills (compare: `custom-tools.md`)
+- 0 API reference for SkillRegistry
+
+After this story:
+- All pages are linked and discoverable in the sidebar
+- Full tutorial, examples, and API reference coverage
+- Cross-linked for discoverability
+
+## Test Assessment
+
+This story is documentation-only. No code changes to `packages/` — only `docs-site/` files. Tests are not required because:
+- No runtime code was modified
+- The VitePress build (`pnpm --filter docs-site build`) validates page rendering
+- Dead links are caught by the build with `ignoreDeadLinks: true` disabled (or manually verified)
+
+## Validation
+
+- `pnpm --filter docs-site build` — builds successfully with no errors
+- All new pages are accessible in the sidebar
+- Cross-links are consistent across all Agent Skills documentation pages

--- a/docs/st06006-agent-skills-docs-site.md
+++ b/docs/st06006-agent-skills-docs-site.md
@@ -48,7 +48,7 @@ After this story:
 This story is documentation-only. No code changes to `packages/` — only `docs-site/` files. Tests are not required because:
 - No runtime code was modified
 - The VitePress build (`pnpm --filter docs-site build`) validates page rendering
-- Dead links are caught by the build with `ignoreDeadLinks: true` disabled (or manually verified)
+- Dead links for new and updated pages were manually verified; the docs-site VitePress config currently uses `ignoreDeadLinks: true`, so builds do not fail on dead links by default
 
 ## Validation
 

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -167,17 +167,20 @@
 **Branch:** `docs/st-06006-agent-skills-docs-site`
 
 ### Checklist
-- [ ] Create branch `docs/st-06006-agent-skills-docs-site`
-- [ ] Create draft PR with story ID in title
-- [ ] Add "Agent Skills" section to VitePress guide sidebar linking `agent-skills.md` and `agent-skills-authoring.md`
-- [ ] Write tutorial page `tutorials/skill-powered-agent.md` — step-by-step guide building a skill-powered agent (prerequisites, project setup, creating skills, registry config, prompt wiring, activation, trust policies, testing)
-- [ ] Write examples page `examples/agent-skills.md` — runnable code snippets for common patterns (registry setup, prompt generation, activation tools, trust policies, events, multi-root configuration)
-- [ ] Add SkillRegistry API reference section to `api/core.md` — public methods, constructor options, event types, type signatures
-- [ ] Add tutorial and examples entries to VitePress sidebar nav sections
-- [ ] Add cross-links between guide, tutorial, examples, and API pages
-- [ ] Verify `pnpm --filter docs-site dev` builds without dead-link warnings for new/updated pages
-- [ ] Add or update story documentation at docs/st06006-agent-skills-docs-site.md
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create branch `docs/st-06006-agent-skills-docs-site`
+- [x] Create draft PR with story ID in title
+  - PR #51: https://github.com/TVScoundrel/agentforge/pull/51
+- [x] Add "Agent Skills" section to VitePress guide sidebar linking `agent-skills.md` and `agent-skills-authoring.md`
+- [x] Write tutorial page `tutorials/skill-powered-agent.md` — step-by-step guide building a skill-powered agent (prerequisites, project setup, creating skills, registry config, prompt wiring, activation, trust policies, testing)
+- [x] Write examples page `examples/agent-skills.md` — runnable code snippets for common patterns (registry setup, prompt generation, activation tools, trust policies, events, multi-root configuration)
+- [x] Add SkillRegistry API reference section to `api/core.md` — public methods, constructor options, event types, type signatures
+- [x] Add tutorial and examples entries to VitePress sidebar nav sections
+- [x] Add cross-links between guide, tutorial, examples, and API pages
+- [x] Verify `pnpm --filter docs-site dev` builds without dead-link warnings for new/updated pages
+  - `pnpm --filter docs-site build` completed successfully in 8.87s
+- [x] Add or update story documentation at docs/st06006-agent-skills-docs-site.md
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Documentation-only story — no runtime code changes, VitePress build validates pages
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-06-story-tasks.md
+++ b/planning/checklists/epic-06-story-tasks.md
@@ -181,10 +181,14 @@
 - [x] Add or update story documentation at docs/st06006-agent-skills-docs-site.md
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Documentation-only story — no runtime code changes, VitePress build validates pages
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - 152 files passed (2250 tests), 7 pre-existing Docker/testcontainers failures (unrelated)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 pre-existing warnings (all @typescript-eslint/no-explicit-any in patterns)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `8849f12` docs(st-06006): add tutorial, examples, API reference, and sidebar for Agent Skills
+  - `51b3adc` docs(st-06006): add story documentation and update trackers
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,18 +20,16 @@ _No stories currently ready_
 
 ## In Progress
 
-### ST-06006: Comprehensive Docs-Site Documentation for Agent Skills
-- **Priority:** P1 (High)
-- **Estimate:** 5 hours
-- **Dependencies:** ST-06005 (complete)
-- **PR:** #51
-- **Deliverables:** Tutorial page, examples page, API reference, VitePress sidebar updates, cross-links
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+### ST-06006: Comprehensive Docs-Site Documentation for Agent Skills
+- **Priority:** P1 (High)
+- **PR:** #51 — https://github.com/TVScoundrel/agentforge/pull/51
+- **Deliverables:** Tutorial, examples, API reference, sidebar, cross-links
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,17 +14,18 @@
 
 ## Ready
 
-### ST-06006: Comprehensive Docs-Site Documentation for Agent Skills
-- **Priority:** P1 (High)
-- **Estimate:** 5 hours
-- **Dependencies:** ST-06005 (complete)
-- **Deliverables:** Tutorial page, examples page, API reference, VitePress sidebar updates, cross-links
+_No stories currently ready_
 
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+### ST-06006: Comprehensive Docs-Site Documentation for Agent Skills
+- **Priority:** P1 (High)
+- **Estimate:** 5 hours
+- **Dependencies:** ST-06005 (complete)
+- **PR:** #51
+- **Deliverables:** Tutorial page, examples page, API reference, VitePress sidebar updates, cross-links
 
 ---
 


### PR DESCRIPTION
## Story

**ST-06006:** Comprehensive Docs-Site Documentation for Agent Skills

## What Changed

### New Pages
- **Tutorial** — `docs-site/tutorials/skill-powered-agent.md` (~440 lines): Step-by-step guide building a skill-powered agent in 9 steps (project setup → skill creation → registry config → prompt wiring → activation tools → agent integration → observability → trust policies → complete example)
- **Examples** — `docs-site/examples/agent-skills.md` (~400 lines): 10 self-contained code patterns covering registry setup, prompt generation, activation tools, multi-root config, trust policies, allowed-tools filtering, event monitoring, re-discovery, combining skills with custom tools
- **API Reference** — `docs-site/api/core.md` (new ~180-line section): SkillRegistry class API (constructor, query methods, generatePrompt, toActivationTools, discover, events), SkillRegistryEvent enum, TrustLevel, TrustPolicyReason, Skill/SkillMetadata types, all utility functions

### Sidebar & Navigation
- Added "Agent Skills" section to VitePress guide sidebar linking `agent-skills.md` and `agent-skills-authoring.md`
- Added "Skill-Powered Agent" to tutorials sidebar
- Added "Agent Skills" to examples sidebar

### Cross-Links
- Added "See Also" sections to both existing guide pages
- All new pages include "What's Next?" / "See Also" linking to guides, tutorial, examples, and API reference
- API section includes tip linking to tutorial and examples

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| VitePress sidebar: Agent Skills section in Guide | ✅ |
| Tutorial page `tutorials/skill-powered-agent.md` | ✅ |
| Examples page `examples/agent-skills.md` | ✅ |
| API reference for SkillRegistry in `api/core.md` | ✅ |
| Sidebar: tutorial and examples nav entries | ✅ |
| Cross-links between all Agent Skills pages | ✅ |
| Follow existing docs-site conventions | ✅ |
| `pnpm --filter docs-site build` succeeds | ✅ |

## Validation Performed

- **Docs build**: `pnpm --filter docs-site build` — completed in 8.87s, no errors
- **Test suite**: 152 files passed (2250 tests), 7 pre-existing Docker/testcontainers failures (unrelated)
- **Lint**: 0 errors, 109 pre-existing warnings (all `@typescript-eslint/no-explicit-any` in patterns)

## Status

✅ Ready for review
