### PR TITLE
feat(st-07001): scaffold @agentforge/skills package

### DIFF
--- a/docs/st07001-scaffold-skills-package.md
+++ b/docs/st07001-scaffold-skills-package.md
@@ -14,8 +14,8 @@ Scaffolded the `@agentforge/skills` workspace package as the future home for the
 ### Dependency Strategy
 - `@agentforge/core` as **peer dependency** (`>=0.14.0`) — consumer must install core
 - `@agentforge/core` as **dev dependency** (`workspace:*`) — for local development/testing
-- `gray-matter` added to skills' `dependencies` — will be **removed from core** in ST-07003 when the source code moves
-- Cannot remove from core yet because `packages/core/src/skills/parser.ts` still imports it
+- `gray-matter` added to skills' `dependencies` — skills source will move from core to this package in ST-07002; `gray-matter` will be **removed from core** in ST-07003 once the deprecation shim is in place
+- Cannot remove from core yet because `packages/core/src/skills/parser.ts` still imports it; that dependency will be dropped as part of ST-07003
 
 ### tsconfig Convention
 - Matches `packages/testing/tsconfig.json` pattern — standalone config with same options as `tsconfig.base.json` rather than extending it

--- a/docs/st07001-scaffold-skills-package.md
+++ b/docs/st07001-scaffold-skills-package.md
@@ -1,0 +1,36 @@
+# ST-07001: Scaffold `@agentforge/skills` Package
+
+## Summary
+
+Scaffolded the `@agentforge/skills` workspace package as the future home for the Agent Skills subsystem currently living in `@agentforge/core`.
+
+## Decisions
+
+### Package Identity
+- **Description**: "Composable skill system for building modular AI agents in TypeScript, part of the AgentForge framework"
+- **Keywords**: Targeted for discoverability (`agent-skills`, `llm-skills`, `composable-agents`, `modular-agents`, `skill-authoring`, `agent-capabilities`)
+- The description conveys what skills *does* without requiring prior AgentForge knowledge, while acknowledging it's part of the ecosystem
+
+### Dependency Strategy
+- `@agentforge/core` as **peer dependency** (`>=0.14.0`) — consumer must install core
+- `@agentforge/core` as **dev dependency** (`workspace:*`) — for local development/testing
+- `gray-matter` added to skills' `dependencies` — will be **removed from core** in ST-07003 when the source code moves
+- Cannot remove from core yet because `packages/core/src/skills/parser.ts` still imports it
+
+### tsconfig Convention
+- Matches `packages/testing/tsconfig.json` pattern — standalone config with same options as `tsconfig.base.json` rather than extending it
+- This is consistent with how other leaf packages are configured
+
+### Test Impact
+- **No tests required** — scaffold-only story with no business logic
+- Tests for the skills module will be migrated from core in ST-07004
+
+## Files Created
+- `packages/skills/package.json`
+- `packages/skills/tsconfig.json`
+- `packages/skills/tsup.config.ts`
+- `packages/skills/src/index.ts` (placeholder)
+
+## Files Modified
+- `vitest.workspace.ts` — added skills test paths
+- `pnpm-lock.yaml` — workspace linking updated

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,0 +1,29 @@
+# @agentforge/skills
+
+> Composable skill system for building modular AI agents in TypeScript, part of the AgentForge framework.
+
+[![npm version](https://img.shields.io/npm/v/@agentforge/skills)](https://www.npmjs.com/package/@agentforge/skills)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue)](https://www.typescriptlang.org/)
+[![License](https://img.shields.io/badge/license-MIT-green)](../../LICENSE)
+
+## 📦 Installation
+
+```bash
+npm install @agentforge/skills
+# or
+pnpm add @agentforge/skills
+# or
+yarn add @agentforge/skills
+```
+
+> **Note:** Requires `@agentforge/core` as a peer dependency.
+
+## Overview
+
+`@agentforge/skills` provides the skill discovery, registration, activation, and trust policy engine for AgentForge agents. It implements the [Agent Skills Specification](https://agentskills.io) for composable, modular agent capabilities.
+
+Full source code and API will be available after ST-07002 (Move Skills Source Files). See the [AgentForge docs](https://agentforge.dev) for usage guides and tutorials.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE) for details.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -22,7 +22,7 @@ yarn add @agentforge/skills
 
 `@agentforge/skills` provides the skill discovery, registration, activation, and trust policy engine for AgentForge agents. It implements the [Agent Skills Specification](https://agentskills.io) for composable, modular agent capabilities.
 
-Full source code and API will be available after ST-07002 (Move Skills Source Files). See the [AgentForge docs](https://agentforge.dev) for usage guides and tutorials.
+Full source code and API will be available after ST-07002 (Move Skills Source Files). See the [AgentForge docs](https://tvscoundrel.github.io/agentforge/) for usage guides and tutorials.
 
 ## License
 

--- a/packages/skills/eslint.config.js
+++ b/packages/skills/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist/**', 'node_modules/**', '*.config.ts', '*.config.js'],
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  }
+);

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@agentforge/skills",
+  "version": "0.14.0",
+  "description": "Composable skill system for building modular AI agents in TypeScript, part of the AgentForge framework.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3"
+  },
+  "peerDependencies": {
+    "@agentforge/core": ">=0.14.0"
+  },
+  "devDependencies": {
+    "@agentforge/core": "workspace:*",
+    "@eslint/js": "^9.17.0",
+    "@types/node": "^22.10.2",
+    "@vitest/ui": "^2.1.8",
+    "eslint": "^9.17.0",
+    "prettier": "^3.4.2",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.19.1",
+    "vitest": "^2.1.8",
+    "zod": "^3.24.1"
+  },
+  "keywords": [
+    "agent-skills",
+    "llm-skills",
+    "composable-agents",
+    "modular-agents",
+    "skill-authoring",
+    "agent-capabilities",
+    "typescript",
+    "agent-skills-specification",
+    "skill-registry",
+    "langchain-typescript"
+  ],
+  "author": "Tom Van Schoor",
+  "license": "MIT",
+  "homepage": "https://tvscoundrel.github.io/agentforge/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TVScoundrel/agentforge.git",
+    "directory": "packages/skills"
+  },
+  "bugs": {
+    "url": "https://github.com/TVScoundrel/agentforge/issues"
+  }
+}

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @agentforge/skills
+ *
+ * Composable skill system for building modular AI agents in TypeScript.
+ * Part of the AgentForge framework.
+ *
+ * This is a placeholder export — the full skills system will be moved here
+ * from @agentforge/core in ST-07002.
+ *
+ * @packageDocumentation
+ */
+
+// Placeholder: full exports will be added when source is moved in ST-07002
+export const SKILLS_PACKAGE_VERSION = '0.14.0';

--- a/packages/skills/tsconfig.json
+++ b/packages/skills/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/skills/tsup.config.ts
+++ b/packages/skills/tsup.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   minify: false,
-  external: ['@agentforge/core', '@langchain/core', 'gray-matter'],
+  external: ['@agentforge/core', 'gray-matter'],
 });

--- a/packages/skills/tsup.config.ts
+++ b/packages/skills/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  minify: false,
+  external: ['@agentforge/core', '@langchain/core', 'gray-matter'],
+});

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -5,22 +5,28 @@
 **Branch:** `feat/st-07001-scaffold-skills-package`
 
 ### Checklist
-- [ ] Create branch `feat/st-07001-scaffold-skills-package`
-- [ ] Create draft PR with story ID in title
-- [ ] Create `packages/skills/` directory with `package.json` (name: `@agentforge/skills`, version matching monorepo)
-- [ ] Set package description to be clear and discoverable while acknowledging AgentForge: e.g. "Composable skill system for building modular AI agents in TypeScript, part of the AgentForge framework"
-- [ ] Set keywords for independent discoverability: `agent-skills`, `llm-skills`, `composable-agents`, `modular-agents`, `skill-authoring`, `agent-capabilities`, `typescript`
-- [ ] Add `@agentforge/core` as peer dependency and dev dependency
-- [ ] Move `gray-matter` dependency from `packages/core/package.json` to `packages/skills/package.json`
-- [ ] Add `tsconfig.json` extending `../../tsconfig.base.json`
-- [ ] Add `tsup.config.ts` for dual ESM/CJS build output
-- [ ] Register `packages/skills` in `pnpm-workspace.yaml`
-- [ ] Update `vitest.workspace.ts` to include `packages/skills`
-- [ ] Create placeholder `src/index.ts` export
-- [ ] Verify `pnpm install` succeeds with workspace linking
-- [ ] Verify `pnpm -r build` succeeds including new package
-- [ ] Add or update story documentation at `docs/st07001-scaffold-skills-package.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create branch `feat/st-07001-scaffold-skills-package`
+- [x] Create draft PR with story ID in title
+  - PR #52: https://github.com/TVScoundrel/agentforge/pull/52
+- [x] Create `packages/skills/` directory with `package.json` (name: `@agentforge/skills`, version matching monorepo)
+- [x] Set package description to be clear and discoverable while acknowledging AgentForge: e.g. "Composable skill system for building modular AI agents in TypeScript, part of the AgentForge framework"
+- [x] Set keywords for independent discoverability: `agent-skills`, `llm-skills`, `composable-agents`, `modular-agents`, `skill-authoring`, `agent-capabilities`, `typescript`
+- [x] Add `@agentforge/core` as peer dependency and dev dependency
+- [x] Move `gray-matter` dependency from `packages/core/package.json` to `packages/skills/package.json`
+  - Added to skills; removal from core deferred to ST-07003 (code still lives in core)
+- [x] Add `tsconfig.json` extending `../../tsconfig.base.json`
+  - Uses matching conventions (ES2022, Node16) without extending base (consistent with testing package)
+- [x] Add `tsup.config.ts` for dual ESM/CJS build output
+- [x] Register `packages/skills` in `pnpm-workspace.yaml`
+  - Auto-included via `packages/*` glob
+- [x] Update `vitest.workspace.ts` to include `packages/skills`
+- [x] Create placeholder `src/index.ts` export
+- [x] Verify `pnpm install` succeeds with workspace linking
+- [x] Verify `pnpm -r build` succeeds including new package
+  - Skills outputs: dist/index.js (ESM), dist/index.cjs (CJS), dist/index.d.ts (DTS)
+- [x] Add or update story documentation at `docs/st07001-scaffold-skills-package.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - No tests required — scaffold-only, no business logic. Tests migrate in ST-07004.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -27,6 +27,8 @@
 - [x] Add or update story documentation at `docs/st07001-scaffold-skills-package.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - No tests required — scaffold-only, no business logic. Tests migrate in ST-07004.
+- [x] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
+  - Not applicable — scaffold-only, no user-facing changes
 - [x] Run full test suite before finalizing the PR and record results
   - 158 passed | 1 skipped | 1 failed (160 files); 2336 passed | 17 skipped | 1 failed (2354 tests)
   - The 1 failure is a **pre-existing flaky timer test** (`packages/tools/tests/web/web-search/utils.test.ts` line 63: expected >=100ms, got 99ms) — unrelated to this change
@@ -55,6 +57,7 @@
 - [ ] Verify TypeScript strict mode passes (`pnpm typecheck`)
 - [ ] Add or update story documentation at `docs/st07002-move-skills-source.md` (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete
@@ -80,6 +83,7 @@
 - [ ] Verify IDE shows strikethrough on deprecated imports
 - [ ] Add or update story documentation at `docs/st07003-core-deprecation-shim.md` (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete
@@ -104,6 +108,7 @@
 - [ ] Verify conformance suite runs within the skills package
 - [ ] Add or update story documentation at `docs/st07004-migrate-skills-tests.md` (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete
@@ -130,6 +135,7 @@
 - [ ] Verify `pnpm --filter docs-site dev` builds without dead-link warnings
 - [ ] Add or update story documentation at `docs/st07005-skills-package-docs-migration.md`
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete
@@ -152,6 +158,7 @@
 - [ ] Verify `./scripts/release.sh` dry-run logic still works (or manually inspect changes)
 - [ ] Add or update story documentation (or document why not required)
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -27,9 +27,12 @@
 - [x] Add or update story documentation at `docs/st07001-scaffold-skills-package.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - No tests required — scaffold-only, no business logic. Tests migrate in ST-07004.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - 158 passed | 1 skipped | 1 failed (160 files); 2336 passed | 17 skipped | 1 failed (2354 tests)
+  - The 1 failure is a **pre-existing flaky timer test** (`packages/tools/tests/web/web-search/utils.test.ts` line 63: expected >=100ms, got 99ms) — unrelated to this change
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing `@typescript-eslint/no-explicit-any`)
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -134,3 +134,25 @@
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+---
+
+## ST-07006: Update Release Scripts and Checklist for Skills Package
+
+**Branch:** `feat/st-07006-release-scripts-skills`
+
+### Checklist
+- [ ] Create branch `feat/st-07006-release-scripts-skills`
+- [ ] Create draft PR with story ID in title
+- [ ] Update `scripts/release.sh` — add `packages/skills/package.json` to `PACKAGE_FILES` array
+- [ ] Update `scripts/publish.sh` — add `packages/skills` to `PACKAGES` array (after core, before cli)
+- [ ] Update `scripts/convert-workspace-deps.mjs` — add `'skills'` to workspace package name list
+- [ ] Update `RELEASE_CHECKLIST.md` — add skills to version bump, publish, and verify sections
+- [ ] Update `.ai/RELEASE_PROCESS.md` — add skills to step 1 (version bump), step 8 (publish order), step 9 (verify), quick checklist, task template
+- [ ] Verify `./scripts/release.sh` dry-run logic still works (or manually inspect changes)
+- [ ] Add or update story documentation (or document why not required)
+- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -91,7 +91,7 @@
 2. **Clean keyword separation** — Remove skills vocabulary from core's package.json, README, and description. Core owns orchestration/runtime; skills owns agent-skills/modular-agents.
 3. **Discoverability** — Keywords and description should attract developers searching for agent capabilities to the AgentForge ecosystem.
 
-**Stories:** ST-07001 through ST-07005
+**Stories:** ST-07001 through ST-07006
 
 ---
 
@@ -685,9 +685,29 @@
 
 ---
 
+#### ST-07006: Update Release Scripts and Checklist for Skills Package
+**User story:** As a release engineer, I want the release scripts and checklists to include `@agentforge/skills` so that the package is not overlooked during version bumps, publishing, and verification.
+
+**Priority:** P1 (High)
+**Estimate:** 2 hours
+**Dependencies:** ST-07001
+
+**Acceptance criteria:**
+- [ ] `scripts/release.sh` — `PACKAGE_FILES` array includes `packages/skills/package.json`
+- [ ] `scripts/publish.sh` — `PACKAGES` array includes `packages/skills` in correct dependency order (after core, before cli)
+- [ ] `scripts/convert-workspace-deps.mjs` — workspace package list includes `'skills'`
+- [ ] `RELEASE_CHECKLIST.md` — skills added to version bump, publish, and verify sections
+- [ ] `.ai/RELEASE_PROCESS.md` — skills added to step 1 (version bump), step 8 (publish), step 9 (verify), quick checklist, and task template
+- [ ] CLI templates that reference `@agentforge/skills` (if any exist) are covered by `release.sh`
+- [ ] Add or update story documentation (or document why not required)
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+
+---
+
 ## Story Summary
 
-**Total Stories:** 30
+**Total Stories:** 31
 **By Priority:**
 - P0 (Critical): 15 stories
 - P1 (High): 12 stories
@@ -702,4 +722,4 @@
 4. Phase 4 (Advanced): ST-04001, ST-04002, ST-04003 (can be parallel)
 5. Phase 5 (Quality): ST-05001 → ST-05002 → ST-05003 → ST-05004
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
-7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005
+7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -608,6 +608,7 @@
 - [ ] Package registered in `pnpm-workspace.yaml`
 - [ ] `pnpm install` and `pnpm -r build` succeed with the new package present
 - [ ] Vitest workspace config updated to include `packages/skills`
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 
 ---
 
@@ -625,6 +626,7 @@
 - [ ] `ToolCategory.SKILLS` enum value remains in `@agentforge/core` (it's a core primitive)
 - [ ] `pnpm -r build` succeeds; `@agentforge/skills` produces valid ESM/CJS output
 - [ ] TypeScript strict mode passes with no new errors
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 
 ---
 
@@ -645,6 +647,7 @@
 - [ ] Core build and bundle size verified (smaller without skills code)
 - [ ] Skills-related keywords removed from core's `package.json` (no `agent-skills`, `skill-*` terms)
 - [ ] Core's description and README focused on orchestration/runtime primitives only
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 
 ---
 
@@ -661,6 +664,7 @@
 - [ ] Test imports updated from `@agentforge/core` skills paths to `@agentforge/skills` or relative paths
 - [ ] `pnpm test --run` passes with 0 regressions (same test count, same coverage)
 - [ ] Conformance suite runs as part of skills package test suite
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 
 ---
 
@@ -680,6 +684,7 @@
 - [ ] `docs-site/changelog.md` entry drafted for next release
 - [ ] Add or update story documentation at `docs/st07005-skills-package-docs-migration.md`
 - [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 
@@ -700,6 +705,7 @@
 - [ ] `.ai/RELEASE_PROCESS.md` — skills added to step 1 (version bump), step 8 (publish), step 9 (verify), quick checklist, and task template
 - [ ] CLI templates that reference `@agentforge/skills` (if any exist) are covered by `release.sh`
 - [ ] Add or update story documentation (or document why not required)
+- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -20,6 +20,12 @@ _No stories currently ready_
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-07001: Scaffold `@agentforge/skills` Package
 - **Epic:** EP-07 — Extract Skills into Dedicated Package
 - **Priority:** P0 (Critical)
@@ -27,12 +33,6 @@ _No stories currently ready_
 - **Dependencies:** None (EP-06 complete)
 - **Branch:** `feat/st-07001-scaffold-skills-package`
 - **PR:** #52
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -8,7 +8,7 @@
 - **In Progress:** 0 stories
 - **In Review:** 1 story
 - **Blocked:** 0 stories
-- **Backlog:** 4 stories
+- **Backlog:** 5 stories
 
 ---
 
@@ -67,6 +67,12 @@ _No stories currently blocked_
 - **Priority:** P1 (High)
 - **Estimate:** 4 hours
 - **Dependencies:** ST-07003, ST-07004
+
+### ST-07006: Update Release Scripts and Checklist
+- **Epic:** EP-07
+- **Priority:** P1 (High)
+- **Estimate:** 2 hours
+- **Dependencies:** ST-07001
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
@@ -14,18 +14,19 @@
 
 ## Ready
 
+_No stories currently ready_
+
+---
+
+## In Progress
+
 ### ST-07001: Scaffold `@agentforge/skills` Package
 - **Epic:** EP-07 — Extract Skills into Dedicated Package
 - **Priority:** P0 (Critical)
 - **Estimate:** 3 hours
 - **Dependencies:** None (EP-06 complete)
 - **Branch:** `feat/st-07001-scaffold-skills-package`
-
----
-
-## In Progress
-
-_No stories currently in progress_
+- **PR:** #52
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,46 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@22.19.3)(@vitest/ui@1.6.1)
 
+  packages/skills:
+    dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+    devDependencies:
+      '@agentforge/core':
+        specifier: workspace:*
+        version: link:../core
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.39.2
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      '@vitest/ui':
+        specifier: ^2.1.8
+        version: 2.1.9(vitest@2.1.9)
+      eslint:
+        specifier: ^9.17.0
+        version: 9.39.2
+      prettier:
+        specifier: ^3.4.2
+        version: 3.7.4
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.19.1
+        version: 8.52.0(eslint@9.39.2)(typescript@5.9.3)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.3)(@vitest/ui@2.1.9)
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+
   packages/testing:
     dependencies:
       '@agentforge/core':

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -64,5 +64,17 @@ export default defineWorkspace([
       ],
     },
   },
+
+  // Skills package
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'skills',
+      include: [
+        'packages/skills/tests/**/*.test.ts',
+        'packages/skills/src/**/__tests__/**/*.test.ts',
+      ],
+    },
+  },
 ]);
 


### PR DESCRIPTION
## ST-07001: Scaffold `@agentforge/skills` Package

**Epic:** EP-07 — Extract Skills into Dedicated Package
**Story:** [ST-07001](planning/checklists/epic-07-story-tasks.md) | [Story Docs](docs/st07001-scaffold-skills-package.md)

### Summary

Creates the empty `@agentforge/skills` package with first-class identity, ready to receive source files (ST-07002) and deprecation shim (ST-07003).

### What changed

| File | Change |
|------|--------|
| `packages/skills/package.json` | New package — v0.14.0, peer dep `@agentforge/core >=0.14.0`, `gray-matter` dependency |
| `packages/skills/tsconfig.json` | ES2022, Node16, strict — matches testing package convention |
| `packages/skills/tsup.config.ts` | Dual ESM/CJS build with external packages |
| `packages/skills/src/index.ts` | Placeholder export (`SKILLS_PACKAGE_VERSION`) |
| `vitest.workspace.ts` | Added skills test path entries |
| `pnpm-lock.yaml` | Workspace linking for new package |
| `planning/`, `docs/` | Story docs, checklists, kanban |

### Key decisions

1. **First-class identity** — Package has its own description and keywords for independent discoverability while acknowledging AgentForge
2. **gray-matter** — Added to skills; removal from core deferred to ST-07003 (core still imports it)
3. **tsconfig convention** — Standalone config (matching testing package) rather than extending `tsconfig.base.json`
4. **No tests** — Scaffold-only, no business logic. Tests migrate in ST-07004

### Build verification

- `pnpm install` — workspace linking confirmed
- `pnpm -r build` — ESM (`dist/index.js`), CJS (`dist/index.cjs`), DTS (`dist/index.d.ts`)

### Test results

```
Test Files  158 passed | 1 skipped | 1 failed (160)
     Tests  2336 passed | 17 skipped | 1 failed (2354)
```

The 1 failure is a **pre-existing flaky timer test** (`packages/tools/tests/web/web-search/utils.test.ts:63` — `measureTime()` expected >=100ms, got 99ms). Unrelated to this change.

### Lint results

```
0 errors, 109 warnings (all pre-existing @typescript-eslint/no-explicit-any)
```

### What's next

ST-07002 moves the source files from `packages/core/src/skills/` into this package.
