### PR TITLE
feat(st-07002): move skills source files and re-wire imports

### DIFF
--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### @agentforge/skills — Skills Package Source Migration (EP-07)
+- **Skills source files** now live in `@agentforge/skills` with full public API:
+  - `SkillRegistry`, `parseSkillContent`, `scanSkillRoot`, `scanAllSkillRoots`
+  - `createActivateSkillTool`, `createReadSkillResourceTool`, `createSkillActivationTools`
+  - `evaluateTrustPolicy`, `isScriptResource`, `normalizeRootConfig`, `resolveResourcePath`
+  - All types: `Skill`, `SkillMetadata`, `SkillRegistryConfig`, `TrustLevel`, etc.
+- Imports re-wired from relative core internals to `@agentforge/core` package imports
+- Logger names updated to `agentforge:skills:*` namespace
+
+### Note
+- `@agentforge/core` still exports the same skills API (deprecation re-exports coming in next release)
+
 ## [0.14.0] - 2026-02-24
 
 ### Added

--- a/docs/st07002-move-skills-source.md
+++ b/docs/st07002-move-skills-source.md
@@ -1,0 +1,40 @@
+# ST-07002: Move Skills Source Files and Re-wire Imports
+
+## Summary
+
+Copied the 6 skills source files from `packages/core/src/skills/` to `packages/skills/src/`, establishing `@agentforge/skills` as a standalone package with its own source, re-wired to import core primitives via `@agentforge/core` package imports.
+
+## Changes
+
+### Files Copied to `packages/skills/src/`
+
+| File | Import Changes |
+|------|---------------|
+| `types.ts` | None — pure type definitions |
+| `trust.ts` | None — only internal refs to `./types.js` |
+| `parser.ts` | None — only internal refs + `gray-matter` |
+| `scanner.ts` | `createLogger`, `LogLevel` → `@agentforge/core` |
+| `registry.ts` | `createLogger`, `LogLevel` → `@agentforge/core` |
+| `activation.ts` | `ToolBuilder`, `ToolCategory`, `Tool`, `createLogger`, `LogLevel` → `@agentforge/core` |
+
+### Logger Name Updates
+
+Logger names updated from `agentforge:core:skills:*` to `agentforge:skills:*` to reflect the new package home:
+- `agentforge:skills:activation`
+- `agentforge:skills:registry`
+- `agentforge:skills:scanner`
+
+### Barrel Exports
+
+`packages/skills/src/index.ts` updated to match the previous public API from `packages/core/src/skills/index.ts` — all types, enums, functions, and classes are re-exported.
+
+### What Stays in Core
+
+- Core source files remain in place (deleted and replaced with deprecation re-exports in ST-07003)
+- `ToolCategory.SKILLS` enum value stays in `@agentforge/core` — the skills package imports it
+
+## Decisions
+
+- **Copy, not move**: Core files stay until ST-07003 replaces them with thin re-exports. This prevents breaking `@agentforge/core` exports during the transition.
+- **Logger namespace**: Changed from `agentforge:core:skills:*` to `agentforge:skills:*` to reflect the canonical package home.
+- **No `index.ts` copy**: The core barrel file (`packages/core/src/skills/index.ts`) is not copied — the skills package has its own barrel that imports from local files.

--- a/packages/core/src/langgraph/middleware/__tests__/logging.test.ts
+++ b/packages/core/src/langgraph/middleware/__tests__/logging.test.ts
@@ -23,6 +23,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -51,6 +53,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -80,6 +84,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: errorSpy,
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -106,6 +112,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -130,6 +138,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -157,6 +167,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const extractData = <State,>(state: State) => ({ value: (state as TestState).value });
@@ -187,6 +199,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -212,6 +226,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({
@@ -241,6 +257,8 @@ describe('Logging Middleware', () => {
         warn: vi.fn(),
         error: vi.fn(),
         withContext: vi.fn(),
+        isDebugEnabled: vi.fn().mockReturnValue(false),
+        isLevelEnabled: vi.fn().mockReturnValue(false),
       };
 
       const loggedNode = withLogging({

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -30,7 +30,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "zod": "^3.24.1"
   },
   "peerDependencies": {
     "@agentforge/core": ">=0.14.0"
@@ -45,8 +46,7 @@
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.19.1",
-    "vitest": "^2.1.8",
-    "zod": "^3.24.1"
+    "vitest": "^2.1.8"
   },
   "keywords": [
     "agent-skills",

--- a/packages/skills/src/activation.ts
+++ b/packages/skills/src/activation.ts
@@ -1,0 +1,319 @@
+/**
+ * Skill Activation Tools
+ *
+ * Provides `activate-skill` and `read-skill-resource` tools built with
+ * the AgentForge tool builder API. These tools enable agents to load
+ * skill instructions on demand and access skill resources at runtime.
+ *
+ * @see https://agentskills.io/specification
+ *
+ * @example
+ * ```ts
+ * const [activateSkill, readSkillResource] = createSkillActivationTools(registry);
+ * // activateSkill       — load full SKILL.md body
+ * // readSkillResource   — load a resource file from a skill
+ *
+ * // Or use the convenience method:
+ * const [activateSkill, readSkillResource] = registry.toActivationTools();
+ * ```
+ */
+
+import { readFileSync, realpathSync } from 'node:fs';
+import { resolve, relative, isAbsolute } from 'node:path';
+import matter from 'gray-matter';
+import { z } from 'zod';
+import { ToolBuilder, ToolCategory, createLogger, LogLevel } from '@agentforge/core';
+import type { Tool } from '@agentforge/core';
+import type { SkillRegistry } from './registry.js';
+import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
+import { evaluateTrustPolicy } from './trust.js';
+
+const logger = createLogger('agentforge:skills:activation', { level: LogLevel.INFO });
+
+// ─── Schemas ─────────────────────────────────────────────────────────────
+
+const activateSkillSchema = z.object({
+  name: z.string().describe('The name of the skill to activate (e.g., "code-review")'),
+});
+
+const readSkillResourceSchema = z.object({
+  name: z.string().describe('The name of the skill that owns the resource'),
+  path: z.string().describe('Relative path to the resource file within the skill directory (e.g., "references/GUIDE.md", "scripts/setup.sh")'),
+});
+
+// ─── Path Security ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a resource path within a skill root, blocking path traversal.
+ *
+ * @param skillPath - Absolute path to the skill directory
+ * @param resourcePath - Relative path to the resource file
+ * @returns Absolute path to the resource, or an error string
+ */
+export function resolveResourcePath(
+  skillPath: string,
+  resourcePath: string,
+): { success: true; resolvedPath: string } | { success: false; error: string } {
+  // Reject absolute paths using platform-aware check
+  if (isAbsolute(resourcePath)) {
+    return { success: false, error: 'Absolute resource paths are not allowed' };
+  }
+
+  // Reject traversal via segment-based '..' detection
+  // Split on both '/' and '\' to handle cross-platform separators
+  const segments = resourcePath.split(/[/\\]/);
+  if (segments.some((seg) => seg === '..')) {
+    return { success: false, error: 'Path traversal is not allowed — resource paths must stay within the skill directory' };
+  }
+
+  // Resolve and verify containment (final guard)
+  const resolvedPath = resolve(skillPath, resourcePath);
+  const resolvedSkillPath = resolve(skillPath);
+
+  // Ensure the resolved path is within the skill directory
+  const rel = relative(resolvedSkillPath, resolvedPath);
+  if (rel.startsWith('..') || resolve(resolvedSkillPath, rel) !== resolvedPath) {
+    return { success: false, error: 'Path traversal is not allowed — resource paths must stay within the skill directory' };
+  }
+
+  // Guard against symlink escapes: resolve real filesystem paths and
+  // verify that the real target still sits under the real skill root.
+  // This prevents a symlink inside the skill dir from pointing outside.
+  try {
+    const realSkillRoot = realpathSync(resolvedSkillPath);
+    const realTarget = realpathSync(resolvedPath);
+    const realRel = relative(realSkillRoot, realTarget);
+    if (realRel.startsWith('..') || isAbsolute(realRel)) {
+      return { success: false, error: 'Symlink target escapes the skill directory — access denied' };
+    }
+  } catch {
+    // File doesn't exist yet (or can't be stat'd) — skip symlink check.
+    // The caller (readFileSync) will produce a clear error if missing.
+  }
+
+  return { success: true, resolvedPath };
+}
+
+// ─── Tool Factories ──────────────────────────────────────────────────────
+
+/**
+ * Create the `activate-skill` tool bound to a registry instance.
+ *
+ * Resolves the skill by name, reads the full SKILL.md file, and returns
+ * the body content (below frontmatter).
+ *
+ * @param registry - The SkillRegistry to resolve skills from
+ * @returns An AgentForge Tool
+ */
+export function createActivateSkillTool(
+  registry: SkillRegistry,
+): Tool<z.infer<typeof activateSkillSchema>, string> {
+  return new ToolBuilder<z.infer<typeof activateSkillSchema>, string>()
+    .name('activate-skill')
+    .description(
+      'Activate an Agent Skill by name, loading its full instructions. ' +
+      'Returns the complete SKILL.md body content for the named skill. ' +
+      'Use this when you see a relevant skill in <available_skills> and want to follow its instructions.',
+    )
+    .category(ToolCategory.SKILLS)
+    .tags(['skill', 'activation', 'agent-skills'])
+    .schema(activateSkillSchema)
+    .implement(async ({ name }) => {
+      const skill = registry.get(name);
+
+      if (!skill) {
+        const availableNames = registry.getNames();
+        const suggestion = availableNames.length > 0
+          ? ` Available skills: ${availableNames.join(', ')}`
+          : ' No skills are currently registered.';
+        const errorMsg = `Skill "${name}" not found.${suggestion}`;
+
+        logger.warn('Skill activation failed — not found', { name, availableCount: availableNames.length });
+        return errorMsg;
+      }
+
+      // Read the full SKILL.md body from disk (progressive disclosure)
+      const skillMdPath = resolve(skill.skillPath, 'SKILL.md');
+      try {
+        const content = readFileSync(skillMdPath, 'utf-8');
+
+        // Extract body below frontmatter
+        const body = extractBody(content);
+
+        logger.info('Skill activated', {
+          name: skill.metadata.name,
+          skillPath: skill.skillPath,
+          bodyLength: body.length,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.SKILL_ACTIVATED, {
+          name: skill.metadata.name,
+          skillPath: skill.skillPath,
+          bodyLength: body.length,
+        });
+
+        return body;
+      } catch (error) {
+        const errorMsg = `Failed to read skill "${name}" instructions: ${error instanceof Error ? error.message : String(error)}`;
+        logger.error('Skill activation failed — read error', {
+          name,
+          skillPath: skill.skillPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorMsg;
+      }
+    })
+    .build();
+}
+
+/**
+ * Create the `read-skill-resource` tool bound to a registry instance.
+ *
+ * Resolves the skill by name, validates the resource path (blocking
+ * traversal), and returns the file content.
+ *
+ * @param registry - The SkillRegistry to resolve skills from
+ * @returns An AgentForge Tool
+ */
+export function createReadSkillResourceTool(
+  registry: SkillRegistry,
+): Tool<z.infer<typeof readSkillResourceSchema>, string> {
+  return new ToolBuilder<z.infer<typeof readSkillResourceSchema>, string>()
+    .name('read-skill-resource')
+    .description(
+      'Read a resource file from an activated Agent Skill. ' +
+      'Returns the content of a file within the skill directory (e.g., references/, scripts/, assets/). ' +
+      'The path must be relative to the skill root and cannot traverse outside it.',
+    )
+    .category(ToolCategory.SKILLS)
+    .tags(['skill', 'resource', 'agent-skills'])
+    .schema(readSkillResourceSchema)
+    .implement(async ({ name, path: resourcePath }) => {
+      const skill = registry.get(name);
+
+      if (!skill) {
+        const availableNames = registry.getNames();
+        const suggestion = availableNames.length > 0
+          ? ` Available skills: ${availableNames.join(', ')}`
+          : ' No skills are currently registered.';
+        const errorMsg = `Skill "${name}" not found.${suggestion}`;
+
+        logger.warn('Skill resource load failed — skill not found', { name, resourcePath });
+        return errorMsg;
+      }
+
+      // Resolve and validate the resource path
+      const pathResult = resolveResourcePath(skill.skillPath, resourcePath);
+      if (!pathResult.success) {
+        logger.warn('Skill resource load blocked — path traversal', {
+          name,
+          resourcePath,
+          error: pathResult.error,
+        });
+        return pathResult.error;
+      }
+
+      // Enforce trust policy for script resources
+      const policyDecision = evaluateTrustPolicy(
+        resourcePath,
+        skill.trustLevel,
+        registry.getAllowUntrustedScripts(),
+      );
+
+      if (!policyDecision.allowed) {
+        logger.warn('Skill resource load blocked — trust policy', {
+          name,
+          resourcePath,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+          message: policyDecision.message,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+          name: skill.metadata.name,
+          resourcePath,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+          message: policyDecision.message,
+        });
+
+        return policyDecision.message;
+      }
+
+      // Log allowed policy decisions for auditing (scripts only)
+      if (policyDecision.reason !== TrustPolicyReason.NOT_SCRIPT) {
+        logger.info('Skill resource trust policy — allowed', {
+          name,
+          resourcePath,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_ALLOWED, {
+          name: skill.metadata.name,
+          resourcePath,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+        });
+      }
+
+      try {
+        const content = readFileSync(pathResult.resolvedPath, 'utf-8');
+
+        logger.info('Skill resource loaded', {
+          name: skill.metadata.name,
+          resourcePath,
+          resolvedPath: pathResult.resolvedPath,
+          contentLength: content.length,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.SKILL_RESOURCE_LOADED, {
+          name: skill.metadata.name,
+          resourcePath,
+          resolvedPath: pathResult.resolvedPath,
+          contentLength: content.length,
+        });
+
+        return content;
+      } catch (error) {
+        const errorMsg = `Failed to read resource "${resourcePath}" from skill "${name}": ${error instanceof Error ? error.message : String(error)}`;
+        logger.warn('Skill resource load failed — file not found or unreadable', {
+          name,
+          resourcePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorMsg;
+      }
+    })
+    .build();
+}
+
+/**
+ * Create both skill activation tools bound to a registry instance.
+ *
+ * @param registry - The SkillRegistry to bind tools to
+ * @returns Array of both tools [activate-skill, read-skill-resource]
+ */
+export function createSkillActivationTools(
+  registry: SkillRegistry,
+): [Tool<z.infer<typeof activateSkillSchema>, string>, Tool<z.infer<typeof readSkillResourceSchema>, string>] {
+  return [
+    createActivateSkillTool(registry),
+    createReadSkillResourceTool(registry),
+  ];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract the body content below YAML frontmatter from a SKILL.md file.
+ *
+ * Delegates to `gray-matter` for consistent frontmatter handling across
+ * the codebase (matches `parseSkillContent()` in parser.ts).
+ *
+ * @param content - The full SKILL.md file content
+ * @returns The body content below the frontmatter
+ */
+function extractBody(content: string): string {
+  return matter(content).content.trim();
+}

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -4,11 +4,55 @@
  * Composable skill system for building modular AI agents in TypeScript.
  * Part of the AgentForge framework.
  *
- * This is a placeholder export — the full skills system will be moved here
- * from @agentforge/core in ST-07002.
- *
  * @packageDocumentation
  */
 
-// Placeholder: full exports will be added when source is moved in ST-07002
-export const SKILLS_PACKAGE_VERSION = '0.14.0';
+// Type definitions
+export type {
+  SkillMetadata,
+  Skill,
+  SkillRegistryConfig,
+  SkillRootConfig,
+  SkillPromptOptions,
+  SkillEventHandler,
+  SkillParseResult,
+  SkillValidationError,
+  TrustLevel,
+  TrustPolicyDecision,
+} from './types.js';
+
+export { SkillRegistryEvent, TrustPolicyReason } from './types.js';
+
+// Parser
+export {
+  parseSkillContent,
+  validateSkillName,
+  validateSkillDescription,
+  validateSkillNameMatchesDir,
+} from './parser.js';
+
+// Scanner
+export {
+  scanSkillRoot,
+  scanAllSkillRoots,
+  expandHome,
+  type SkillCandidate,
+} from './scanner.js';
+
+// Registry
+export { SkillRegistry } from './registry.js';
+
+// Activation Tools
+export {
+  createActivateSkillTool,
+  createReadSkillResourceTool,
+  createSkillActivationTools,
+  resolveResourcePath,
+} from './activation.js';
+
+// Trust Policy
+export {
+  evaluateTrustPolicy,
+  isScriptResource,
+  normalizeRootConfig,
+} from './trust.js';

--- a/packages/skills/src/parser.ts
+++ b/packages/skills/src/parser.ts
@@ -1,0 +1,194 @@
+/**
+ * SKILL.md Frontmatter Parser
+ *
+ * Parses YAML frontmatter from SKILL.md files and validates
+ * against the Agent Skills specification constraints.
+ *
+ * @see https://agentskills.io/specification
+ */
+
+import matter from 'gray-matter';
+import type { SkillMetadata, SkillParseResult, SkillValidationError } from './types.js';
+
+/**
+ * Skill name validation constraints (per spec).
+ *
+ * - 1-64 characters
+ * - Lowercase alphanumeric and hyphens only
+ * - No leading, trailing, or consecutive hyphens
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const SKILL_NAME_MAX_LENGTH = 64;
+const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+
+/**
+ * Validate the `name` field per the Agent Skills spec.
+ *
+ * @param name - The name value from frontmatter
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillName(name: unknown): SkillValidationError[] {
+  const errors: SkillValidationError[] = [];
+
+  if (name === undefined || name === null) {
+    errors.push({ field: 'name', message: 'name is required' });
+    return errors;
+  }
+
+  if (typeof name !== 'string') {
+    errors.push({ field: 'name', message: 'name must be a string' });
+    return errors;
+  }
+
+  if (name.length === 0) {
+    errors.push({ field: 'name', message: 'name must not be empty' });
+    return errors;
+  }
+
+  if (name.length > SKILL_NAME_MAX_LENGTH) {
+    errors.push({
+      field: 'name',
+      message: `name must be at most ${SKILL_NAME_MAX_LENGTH} characters (got ${name.length})`,
+    });
+    return errors;
+  }
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    errors.push({
+      field: 'name',
+      message: 'name must be lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens',
+    });
+  }
+
+  if (name.includes('--')) {
+    errors.push({
+      field: 'name',
+      message: 'name must not contain consecutive hyphens',
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the `description` field per the Agent Skills spec.
+ *
+ * @param description - The description value from frontmatter
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillDescription(description: unknown): SkillValidationError[] {
+  const errors: SkillValidationError[] = [];
+
+  if (description === undefined || description === null) {
+    errors.push({ field: 'description', message: 'description is required' });
+    return errors;
+  }
+
+  if (typeof description !== 'string') {
+    errors.push({ field: 'description', message: 'description must be a string' });
+    return errors;
+  }
+
+  if (description.trim().length === 0) {
+    errors.push({ field: 'description', message: 'description must not be empty' });
+    return errors;
+  }
+
+  if (description.length > SKILL_DESCRIPTION_MAX_LENGTH) {
+    errors.push({
+      field: 'description',
+      message: `description must be at most ${SKILL_DESCRIPTION_MAX_LENGTH} characters (got ${description.length})`,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate that the skill name matches its parent directory name (per spec).
+ *
+ * @param name - The name from frontmatter
+ * @param dirName - The parent directory name
+ * @returns Array of validation errors (empty = valid)
+ */
+export function validateSkillNameMatchesDir(name: string, dirName: string): SkillValidationError[] {
+  if (name !== dirName) {
+    return [{
+      field: 'name',
+      message: `name "${name}" must match parent directory name "${dirName}"`,
+    }];
+  }
+  return [];
+}
+
+/**
+ * Parse and validate a SKILL.md file's raw content.
+ *
+ * Extracts YAML frontmatter using gray-matter, then validates
+ * required and optional fields against spec constraints.
+ *
+ * @param content - Raw file content of the SKILL.md
+ * @param dirName - Parent directory name for name-match validation
+ * @returns Parse result with metadata or error
+ */
+export function parseSkillContent(content: string, dirName: string): SkillParseResult {
+  let parsed: matter.GrayMatterFile<string>;
+
+  try {
+    parsed = matter(content);
+  } catch (err) {
+    return {
+      success: false,
+      error: `Failed to parse frontmatter: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const data = parsed.data;
+
+  // Validate required fields
+  const errors: SkillValidationError[] = [
+    ...validateSkillName(data.name),
+    ...validateSkillDescription(data.description),
+  ];
+
+  // If name is valid, validate it matches directory name
+  if (typeof data.name === 'string' && data.name.length > 0 && SKILL_NAME_PATTERN.test(data.name)) {
+    errors.push(...validateSkillNameMatchesDir(data.name, dirName));
+  }
+
+  if (errors.length > 0) {
+    return {
+      success: false,
+      error: errors.map((e) => `${e.field}: ${e.message}`).join('; '),
+    };
+  }
+
+  // Build metadata from validated fields
+  const metadata: SkillMetadata = {
+    name: data.name as string,
+    description: data.description as string,
+  };
+
+  // Optional fields
+  if (data.license !== undefined) {
+    metadata.license = String(data.license);
+  }
+
+  if (Array.isArray(data.compatibility)) {
+    metadata.compatibility = data.compatibility.map(String);
+  }
+
+  if (data.metadata !== undefined && typeof data.metadata === 'object' && data.metadata !== null) {
+    metadata.metadata = data.metadata as Record<string, unknown>;
+  }
+
+  if (Array.isArray(data['allowed-tools'])) {
+    metadata.allowedTools = data['allowed-tools'].map(String);
+  }
+
+  return {
+    success: true,
+    metadata,
+    body: parsed.content,
+  };
+}

--- a/packages/skills/src/registry.ts
+++ b/packages/skills/src/registry.ts
@@ -1,0 +1,502 @@
+/**
+ * Skill Registry
+ *
+ * Central registry for discovering, storing, and querying Agent Skills.
+ * Mirrors ToolRegistry but uses folder-based auto-discovery instead
+ * of programmatic registration.
+ *
+ * @see https://agentskills.io/specification
+ *
+ * @example
+ * ```ts
+ * const registry = new SkillRegistry({
+ *   skillRoots: ['.agentskills', '~/.agentskills'],
+ * });
+ *
+ * // Query discovered skills
+ * const skill = registry.get('code-review');
+ * const allSkills = registry.getAll();
+ *
+ * // Listen for events
+ * registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (skill) => {
+ *   console.log('Found skill:', skill.metadata.name);
+ * });
+ * ```
+ */
+
+import type {
+  Skill,
+  SkillRegistryConfig,
+  SkillPromptOptions,
+  SkillEventHandler,
+  TrustLevel,
+} from './types.js';
+import { SkillRegistryEvent } from './types.js';
+import { scanAllSkillRoots, expandHome } from './scanner.js';
+import { parseSkillContent } from './parser.js';
+import { createSkillActivationTools } from './activation.js';
+import { normalizeRootConfig } from './trust.js';
+import { resolve as resolvePath } from 'node:path';
+import { createLogger, LogLevel } from '@agentforge/core';
+
+const logger = createLogger('agentforge:skills:registry', { level: LogLevel.INFO });
+
+/**
+ * Skill Registry — auto-discovers skills from configured folder paths.
+ *
+ * Parallel to ToolRegistry:
+ * | ToolRegistry             | SkillRegistry                            |
+ * |--------------------------|------------------------------------------|
+ * | registry.register(tool)  | new SkillRegistry({ skillRoots })        |
+ * | registry.get('name')     | skillRegistry.get('name')                |
+ * | registry.getAll()        | skillRegistry.getAll()                   |
+ * | registry.has('name')     | skillRegistry.has('name')                |
+ * | registry.size()          | skillRegistry.size()                     |
+ * | registry.generatePrompt()| skillRegistry.generatePrompt()           |
+ * | registry.toLangChainTools()| skillRegistry.toActivationTools()       |
+ */
+export class SkillRegistry {
+  private skills: Map<string, Skill> = new Map();
+  private eventHandlers: Map<SkillRegistryEvent, Set<SkillEventHandler>> = new Map();
+  private readonly config: SkillRegistryConfig;
+  private scanErrors: Array<{ path: string; error: string }> = [];
+  /** Maps resolved root paths → trust levels for skill trust assignment */
+  private rootTrustMap: Map<string, TrustLevel> = new Map();
+
+  /**
+   * Create a SkillRegistry and immediately scan configured roots for skills.
+   *
+   * @param config - Registry configuration with skill root paths
+   *
+   * @example
+   * ```ts
+   * const registry = new SkillRegistry({
+   *   skillRoots: ['.agentskills', '~/.agentskills', './project-skills'],
+   * });
+   * console.log(`Discovered ${registry.size()} skills`);
+   * ```
+   */
+  constructor(config: SkillRegistryConfig) {
+    this.config = config;
+    this.discover();
+  }
+
+  /**
+   * Scan all configured roots and populate the registry.
+   *
+   * Called automatically during construction. Can be called again
+   * to re-scan (clears existing skills first).
+   */
+  discover(): void {
+    this.skills.clear();
+    this.scanErrors = [];
+    this.rootTrustMap.clear();
+
+    // Normalize roots: extract plain paths for the scanner and build trust map
+    const normalizedRoots = this.config.skillRoots.map(normalizeRootConfig);
+    const plainPaths = normalizedRoots.map((r) => r.path);
+
+    // Build trust map (resolve paths to match scanner output)
+    for (const root of normalizedRoots) {
+      const resolvedPath = resolvePath(expandHome(root.path));
+      this.rootTrustMap.set(resolvedPath, root.trust);
+    }
+
+    const candidates = scanAllSkillRoots(plainPaths);
+
+    let successCount = 0;
+    let warningCount = 0;
+
+    for (const candidate of candidates) {
+      const result = parseSkillContent(candidate.content, candidate.dirName);
+
+      if (!result.success) {
+        warningCount++;
+        this.scanErrors.push({
+          path: candidate.skillPath,
+          error: result.error || 'Unknown parse error',
+        });
+        this.emit(SkillRegistryEvent.SKILL_WARNING, {
+          skillPath: candidate.skillPath,
+          rootPath: candidate.rootPath,
+          error: result.error,
+        });
+        logger.warn('Skipping invalid skill', {
+          skillPath: candidate.skillPath,
+          error: result.error,
+        });
+        continue;
+      }
+
+      const skill: Skill = {
+        metadata: result.metadata!,
+        skillPath: candidate.skillPath,
+        rootPath: candidate.rootPath,
+        trustLevel: this.rootTrustMap.get(candidate.rootPath) ?? 'untrusted',
+      };
+
+      // Handle duplicate skill names — first root wins (deterministic precedence)
+      if (this.skills.has(skill.metadata.name)) {
+        const existing = this.skills.get(skill.metadata.name)!;
+        warningCount++;
+        const warningMsg = `Duplicate skill name "${skill.metadata.name}" from "${candidate.rootPath}" — ` +
+          `keeping version from "${existing.rootPath}" (first root takes precedence)`;
+        this.scanErrors.push({
+          path: candidate.skillPath,
+          error: warningMsg,
+        });
+        this.emit(SkillRegistryEvent.SKILL_WARNING, {
+          skillPath: candidate.skillPath,
+          rootPath: candidate.rootPath,
+          duplicateOf: existing.skillPath,
+          error: warningMsg,
+        });
+        logger.warn('Duplicate skill name, keeping first', {
+          name: skill.metadata.name,
+          kept: existing.skillPath,
+          skipped: candidate.skillPath,
+        });
+        continue;
+      }
+
+      this.skills.set(skill.metadata.name, skill);
+      successCount++;
+
+      this.emit(SkillRegistryEvent.SKILL_DISCOVERED, skill);
+      logger.debug('Skill discovered', {
+        name: skill.metadata.name,
+        description: skill.metadata.description.slice(0, 80),
+        skillPath: skill.skillPath,
+      });
+    }
+
+    logger.info('Skill registry populated', {
+      rootsScanned: this.config.skillRoots.length,
+      skillsDiscovered: successCount,
+      warnings: warningCount,
+    });
+  }
+
+  // ─── Query API (parallel to ToolRegistry) ──────────────────────────────
+
+  /**
+   * Get a skill by name.
+   *
+   * @param name - The skill name
+   * @returns The skill, or undefined if not found
+   *
+   * @example
+   * ```ts
+   * const skill = registry.get('code-review');
+   * if (skill) {
+   *   console.log(skill.metadata.description);
+   * }
+   * ```
+   */
+  get(name: string): Skill | undefined {
+    return this.skills.get(name);
+  }
+
+  /**
+   * Get all discovered skills.
+   *
+   * @returns Array of all skills
+   *
+   * @example
+   * ```ts
+   * const allSkills = registry.getAll();
+   * console.log(`Total skills: ${allSkills.length}`);
+   * ```
+   */
+  getAll(): Skill[] {
+    return Array.from(this.skills.values());
+  }
+
+  /**
+   * Check if a skill exists in the registry.
+   *
+   * @param name - The skill name
+   * @returns True if the skill exists
+   *
+   * @example
+   * ```ts
+   * if (registry.has('code-review')) {
+   *   console.log('Skill available!');
+   * }
+   * ```
+   */
+  has(name: string): boolean {
+    return this.skills.has(name);
+  }
+
+  /**
+   * Get the number of discovered skills.
+   *
+   * @returns Number of skills in the registry
+   *
+   * @example
+   * ```ts
+   * console.log(`Registry has ${registry.size()} skills`);
+   * ```
+   */
+  size(): number {
+    return this.skills.size;
+  }
+
+  /**
+   * Get all skill names.
+   *
+   * @returns Array of skill names
+   */
+  getNames(): string[] {
+    return Array.from(this.skills.keys());
+  }
+
+  /**
+   * Get errors/warnings from the last scan.
+   *
+   * Useful for diagnostics and observability.
+   *
+   * @returns Array of scan errors with paths
+   */
+  getScanErrors(): ReadonlyArray<{ path: string; error: string }> {
+    return this.scanErrors;
+  }
+
+  /**
+   * Check whether untrusted script access is allowed via config override.
+   *
+   * Used by activation tools to pass the override flag to trust policy checks.
+   *
+   * @returns True if `allowUntrustedScripts` is set in config
+   */
+  getAllowUntrustedScripts(): boolean {
+    return this.config.allowUntrustedScripts ?? false;
+  }
+
+  /**
+   * Get the `allowed-tools` list for a skill.
+   *
+   * Returns the `allowedTools` array from the skill's frontmatter metadata,
+   * enabling agents to filter their tool set based on what the skill expects.
+   *
+   * @param name - The skill name
+   * @returns Array of allowed tool names, or undefined if skill not found or field not set
+   *
+   * @example
+   * ```ts
+   * const allowed = registry.getAllowedTools('code-review');
+   * if (allowed) {
+   *   const filteredTools = allTools.filter(t => allowed.includes(t.name));
+   * }
+   * ```
+   */
+  getAllowedTools(name: string): string[] | undefined {
+    const skill = this.skills.get(name);
+    return skill?.metadata.allowedTools;
+  }
+
+  // ─── Prompt Generation ─────────────────────────────────────────────────
+
+  /**
+   * Generate an `<available_skills>` XML block for system prompt injection.
+   *
+   * Returns an empty string when:
+   * - `config.enabled` is `false` (default) — agents operate with unmodified prompts
+   * - No skills match the filter criteria
+   *
+   * The output composes naturally with `toolRegistry.generatePrompt()` —
+   * simply concatenate both into the system prompt.
+   *
+   * @param options - Optional filtering (subset of skill names)
+   * @returns XML string or empty string
+   *
+   * @example
+   * ```ts
+   * // All skills
+   * const xml = registry.generatePrompt();
+   *
+   * // Subset for a focused agent
+   * const xml = registry.generatePrompt({ skills: ['code-review', 'testing'] });
+   *
+   * // Compose with tool prompt
+   * const systemPrompt = [
+   *   toolRegistry.generatePrompt(),
+   *   skillRegistry.generatePrompt(),
+   * ].filter(Boolean).join('\n\n');
+   * ```
+   */
+  generatePrompt(options?: SkillPromptOptions): string {
+    // Feature flag gate — disabled by default
+    if (!this.config.enabled) {
+      logger.debug('Skill prompt generation skipped (disabled)', {
+        enabled: this.config.enabled ?? false,
+      });
+      return '';
+    }
+
+    // Resolve which skills to include
+    let skills = this.getAll();
+
+    // Apply subset filter if provided
+    if (options?.skills && options.skills.length > 0) {
+      const requested = new Set(options.skills);
+      skills = skills.filter((s) => requested.has(s.metadata.name));
+    }
+
+    // Apply maxDiscoveredSkills cap
+    if (this.config.maxDiscoveredSkills !== undefined && this.config.maxDiscoveredSkills >= 0) {
+      skills = skills.slice(0, this.config.maxDiscoveredSkills);
+    }
+
+    // No skills — return empty string
+    if (skills.length === 0) {
+      logger.debug('Skill prompt generation produced empty result', {
+        totalDiscovered: this.size(),
+        filterApplied: !!(options?.skills && options.skills.length > 0),
+        maxCap: this.config.maxDiscoveredSkills,
+      });
+      return '';
+    }
+
+    // Generate XML
+    const skillEntries = skills.map((skill) => {
+      const lines = [
+        '  <skill>',
+        `    <name>${escapeXml(skill.metadata.name)}</name>`,
+        `    <description>${escapeXml(skill.metadata.description)}</description>`,
+        `    <location>${escapeXml(skill.skillPath)}</location>`,
+        '  </skill>',
+      ];
+      return lines.join('\n');
+    });
+
+    const xml = `<available_skills>\n${skillEntries.join('\n')}\n</available_skills>`;
+
+    // Estimate token count (~4 chars per token, rough heuristic)
+    const estimatedTokens = Math.ceil(xml.length / 4);
+
+    logger.info('Skill prompt generated', {
+      skillCount: skills.length,
+      totalDiscovered: this.size(),
+      filterApplied: !!(options?.skills && options.skills.length > 0),
+      maxCap: this.config.maxDiscoveredSkills,
+      estimatedTokens,
+      xmlLength: xml.length,
+    });
+
+    return xml;
+  }
+
+  // ─── Event System ──────────────────────────────────────────────────────
+
+  /**
+   * Register an event handler.
+   *
+   * @param event - The event to listen for
+   * @param handler - The handler function
+   *
+   * @example
+   * ```ts
+   * registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (skill) => {
+   *   console.log('Found skill:', skill.metadata.name);
+   * });
+   * ```
+   */
+  on(event: SkillRegistryEvent, handler: SkillEventHandler): void {
+    if (!this.eventHandlers.has(event)) {
+      this.eventHandlers.set(event, new Set());
+    }
+    this.eventHandlers.get(event)!.add(handler);
+  }
+
+  /**
+   * Unregister an event handler.
+   *
+   * @param event - The event to stop listening for
+   * @param handler - The handler function to remove
+   */
+  off(event: SkillRegistryEvent, handler: SkillEventHandler): void {
+    const handlers = this.eventHandlers.get(event);
+    if (handlers) {
+      handlers.delete(handler);
+    }
+  }
+
+  /**
+   * Emit an event to all registered handlers.
+   *
+   * @param event - The event to emit
+   * @param data - The event data
+   * @private
+   */
+  private emit(event: SkillRegistryEvent, data: unknown): void {
+    const handlers = this.eventHandlers.get(event);
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(data);
+        } catch (error) {
+          logger.error('Skill event handler error', {
+            event,
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
+      });
+    }
+  }
+
+  /**
+   * Emit an event (public API for activation tools).
+   *
+   * Used by skill activation tools to emit `skill:activated` and
+   * `skill:resource-loaded` events through the registry's event system.
+   *
+   * @param event - The event to emit
+   * @param data - The event data
+   */
+  emitEvent(event: SkillRegistryEvent, data: unknown): void {
+    this.emit(event, data);
+  }
+
+  // ─── Tool Integration ────────────────────────────────────────────────
+
+  /**
+   * Create activation tools pre-wired to this registry instance.
+   *
+   * Returns `activate-skill` and `read-skill-resource` tools that
+   * agents can use to load skill instructions and resources on demand.
+   *
+   * @returns Array of [activate-skill, read-skill-resource] tools
+   *
+   * @example
+   * ```ts
+   * const agent = createReActAgent({
+   *   model: llm,
+   *   tools: [
+   *     ...toolRegistry.toLangChainTools(),
+   *     ...skillRegistry.toActivationTools(),
+   *   ],
+   * });
+   * ```
+   */
+  toActivationTools(): ReturnType<typeof createSkillActivationTools> {
+    return createSkillActivationTools(this);
+  }
+}
+
+/**
+ * Escape special XML characters in a string.
+ *
+ * @param str - The string to escape
+ * @returns Escaped string safe for XML content
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/packages/skills/src/scanner.ts
+++ b/packages/skills/src/scanner.ts
@@ -1,0 +1,130 @@
+/**
+ * Skill Directory Scanner
+ *
+ * Scans configured skill roots for directories containing valid SKILL.md files.
+ * Returns a list of candidate skill paths for the parser to process.
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { createLogger, LogLevel } from '@agentforge/core';
+
+const logger = createLogger('agentforge:skills:scanner', { level: LogLevel.INFO });
+
+/**
+ * Discovered skill candidate — a directory containing a SKILL.md file.
+ */
+export interface SkillCandidate {
+  /** Absolute path to the skill directory */
+  skillPath: string;
+  /** The parent directory name (expected to match the skill name) */
+  dirName: string;
+  /** Raw content of the SKILL.md file */
+  content: string;
+  /** Which configured root this came from */
+  rootPath: string;
+}
+
+/**
+ * Expand `~` prefix to the user's home directory.
+ */
+export function expandHome(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return resolve(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Scan a single skill root for directories containing SKILL.md.
+ *
+ * @param rootPath - The root directory to scan (may not exist)
+ * @returns Array of valid skill candidates found under this root
+ */
+export function scanSkillRoot(rootPath: string): SkillCandidate[] {
+  const resolvedRoot = resolve(expandHome(rootPath));
+  const candidates: SkillCandidate[] = [];
+
+  if (!existsSync(resolvedRoot)) {
+    logger.debug('Skill root does not exist, skipping', { rootPath: resolvedRoot });
+    return candidates;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(resolvedRoot);
+  } catch (err) {
+    logger.warn('Failed to read skill root directory', {
+      rootPath: resolvedRoot,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return candidates;
+  }
+
+  for (const entry of entries) {
+    const entryPath = resolve(resolvedRoot, entry);
+
+    // Only process directories
+    let stat;
+    try {
+      stat = statSync(entryPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) {
+      continue;
+    }
+
+    // Check for SKILL.md inside the directory
+    const skillMdPath = resolve(entryPath, 'SKILL.md');
+    if (!existsSync(skillMdPath)) {
+      continue;
+    }
+
+    // Read the SKILL.md content
+    try {
+      const content = readFileSync(skillMdPath, 'utf-8');
+      candidates.push({
+        skillPath: entryPath,
+        dirName: basename(entryPath),
+        content,
+        rootPath: resolvedRoot,
+      });
+    } catch (err) {
+      logger.warn('Failed to read SKILL.md', {
+        path: skillMdPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  logger.debug('Scanned skill root', {
+    rootPath: resolvedRoot,
+    candidatesFound: candidates.length,
+  });
+
+  return candidates;
+}
+
+/**
+ * Scan multiple skill roots for directories containing SKILL.md.
+ *
+ * @param skillRoots - Array of root paths to scan
+ * @returns Array of all skill candidates found across all roots
+ */
+export function scanAllSkillRoots(skillRoots: string[]): SkillCandidate[] {
+  const allCandidates: SkillCandidate[] = [];
+
+  for (const root of skillRoots) {
+    const candidates = scanSkillRoot(root);
+    allCandidates.push(...candidates);
+  }
+
+  logger.info('Skill discovery complete', {
+    rootsScanned: skillRoots.length,
+    totalCandidates: allCandidates.length,
+  });
+
+  return allCandidates;
+}

--- a/packages/skills/src/trust.ts
+++ b/packages/skills/src/trust.ts
@@ -1,0 +1,143 @@
+/**
+ * Skill Trust Policy Engine
+ *
+ * Enforces trust-level-based access control for skill resources.
+ * Scripts from untrusted roots are denied by default unless explicitly allowed.
+ *
+ * Trust levels:
+ * - `workspace` — Project-local skills, highest trust. Scripts always allowed.
+ * - `trusted`   — Explicitly trusted roots. Scripts allowed.
+ * - `untrusted` — Community or third-party skills. Scripts denied by default.
+ *
+ * @see https://agentskills.io/specification
+ */
+
+import type { TrustLevel, TrustPolicyDecision, SkillRootConfig } from './types.js';
+import { TrustPolicyReason } from './types.js';
+
+// ─── Constants ───────────────────────────────────────────────────────────
+
+/**
+ * Resource path prefix that requires trust enforcement.
+ *
+ * Only resources under `scripts/` are subject to trust policy checks.
+ * Other directories (references/, assets/, etc.) are always accessible.
+ */
+const SCRIPT_PATH_PREFIX = 'scripts/';
+const SCRIPT_PATH_EXACT = 'scripts';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a skill root config entry.
+ *
+ * String entries default to `'untrusted'` trust level for safe defaults.
+ *
+ * @param root - A string path or SkillRootConfig object
+ * @returns Normalized SkillRootConfig with explicit trust level
+ */
+export function normalizeRootConfig(root: string | SkillRootConfig): SkillRootConfig {
+  if (typeof root === 'string') {
+    return { path: root, trust: 'untrusted' };
+  }
+  return root;
+}
+
+/**
+ * Check whether a resource path refers to a script.
+ *
+ * A resource is considered a script if its relative path starts with
+ * `scripts/` or is exactly `scripts`, after normalizing path separators,
+ * stripping leading "./" segments, and ignoring case.
+ *
+ * @param resourcePath - Relative path within the skill directory
+ * @returns True if the resource is in the scripts/ directory
+ */
+export function isScriptResource(resourcePath: string): boolean {
+  // Normalize to forward slashes and trim for consistent checking
+  let normalized = resourcePath.trim().replace(/\\/g, '/');
+
+  // Collapse repeated separators (e.g., "scripts//setup.sh" → "scripts/setup.sh")
+  normalized = normalized.replace(/\/+/g, '/');
+
+  // Strip leading "./" segments (e.g., "./scripts/setup.sh" → "scripts/setup.sh")
+  while (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+
+  // Case-insensitive comparison to handle case-insensitive file systems
+  const lower = normalized.toLowerCase();
+
+  return lower === SCRIPT_PATH_EXACT
+    || lower.startsWith(SCRIPT_PATH_PREFIX);
+}
+
+// ─── Policy Engine ───────────────────────────────────────────────────────
+
+/**
+ * Evaluate the trust policy for a resource access request.
+ *
+ * Non-script resources are always allowed regardless of trust level.
+ * Script resources require `workspace` or `trusted` trust, or the
+ * `allowUntrustedScripts` override to be enabled.
+ *
+ * @param resourcePath - Relative path to the resource within the skill directory
+ * @param trustLevel - Trust level of the skill's root directory
+ * @param allowUntrustedScripts - Override flag to permit untrusted scripts
+ * @returns Policy decision with allow/deny, reason code, and message
+ */
+export function evaluateTrustPolicy(
+  resourcePath: string,
+  trustLevel: TrustLevel,
+  allowUntrustedScripts: boolean = false,
+): TrustPolicyDecision {
+  // Non-script resources — no policy enforcement needed
+  if (!isScriptResource(resourcePath)) {
+    return {
+      allowed: true,
+      reason: TrustPolicyReason.NOT_SCRIPT,
+      message: 'Resource is not a script — no trust check required',
+    };
+  }
+
+  // Script resources — check trust level
+  switch (trustLevel) {
+    case 'workspace':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.WORKSPACE_TRUST,
+        message: 'Script allowed — skill root has workspace trust',
+      };
+
+    case 'trusted':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.TRUSTED_ROOT,
+        message: 'Script allowed — skill root is explicitly trusted',
+      };
+
+    case 'untrusted':
+      if (allowUntrustedScripts) {
+        return {
+          allowed: true,
+          reason: TrustPolicyReason.UNTRUSTED_SCRIPT_ALLOWED,
+          message: 'Script from untrusted root allowed via allowUntrustedScripts override',
+        };
+      }
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+        message: `Script access denied — skill root is untrusted. ` +
+          `Scripts from untrusted roots are blocked by default for security. ` +
+          `To allow, set 'allowUntrustedScripts: true' in SkillRegistryConfig or ` +
+          `promote the skill root to 'trusted' or 'workspace' trust level.`,
+      };
+
+    default:
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNKNOWN_TRUST_LEVEL,
+        message: `Script access denied — trust level "${trustLevel}" is unknown and is treated as untrusted for security.`,
+      };
+  }
+}

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -1,0 +1,233 @@
+/**
+ * Skill System Types
+ *
+ * Core type definitions for the AgentForge Agent Skills system.
+ * These types align with the Agent Skills specification (https://agentskills.io/specification).
+ */
+
+// ─── Trust Policy Types ──────────────────────────────────────────────────
+
+/**
+ * Trust level for a skill root directory.
+ *
+ * - `workspace` — Skills from the project workspace (highest trust, scripts allowed)
+ * - `trusted`   — Explicitly trusted skill roots (scripts allowed)
+ * - `untrusted` — Untrusted roots like community packs (scripts blocked by default)
+ */
+export type TrustLevel = 'workspace' | 'trusted' | 'untrusted';
+
+/**
+ * Configuration for a skill root with an explicit trust level.
+ *
+ * @example
+ * ```ts
+ * const roots: SkillRootConfig[] = [
+ *   { path: '.agentskills', trust: 'workspace' },
+ *   { path: '~/.agentskills', trust: 'trusted' },
+ *   { path: '/shared/community-skills', trust: 'untrusted' },
+ * ];
+ * ```
+ */
+export interface SkillRootConfig {
+  /** Directory path to scan for skills */
+  path: string;
+  /** Trust level assigned to all skills discovered from this root */
+  trust: TrustLevel;
+}
+
+/**
+ * Policy decision returned by trust enforcement checks.
+ */
+export interface TrustPolicyDecision {
+  /** Whether the action is allowed */
+  allowed: boolean;
+  /** Machine-readable reason code for auditing */
+  reason: TrustPolicyReason;
+  /** Human-readable explanation */
+  message: string;
+}
+
+/**
+ * Reason codes for trust policy decisions.
+ *
+ * Used for structured logging and auditing of guardrail behavior.
+ */
+export enum TrustPolicyReason {
+  /** Resource is not a script — no trust check needed */
+  NOT_SCRIPT = 'not-script',
+  /** Skill root has workspace trust — scripts allowed */
+  WORKSPACE_TRUST = 'workspace-trust',
+  /** Skill root has explicit trusted status — scripts allowed */
+  TRUSTED_ROOT = 'trusted-root',
+  /** Skill root is untrusted — scripts denied by default */
+  UNTRUSTED_SCRIPT_DENIED = 'untrusted-script-denied',
+  /** Untrusted script access was explicitly allowed via config override */
+  UNTRUSTED_SCRIPT_ALLOWED = 'untrusted-script-allowed-override',
+  /** Trust level is unknown — treated as untrusted for security */
+  UNKNOWN_TRUST_LEVEL = 'unknown-trust-level',
+}
+
+/**
+ * Parsed metadata from a SKILL.md frontmatter block.
+ *
+ * Required fields: `name`, `description`.
+ * All other fields are optional per the Agent Skills spec.
+ */
+export interface SkillMetadata {
+  /** Skill name (1-64 chars, lowercase alphanumeric + hyphens, must match parent dir name) */
+  name: string;
+  /** Human-readable description (1-1024 chars) */
+  description: string;
+  /** SPDX license identifier */
+  license?: string;
+  /** List of compatible agent frameworks / tool hosts */
+  compatibility?: string[];
+  /** Arbitrary key-value metadata (author, version, etc.) */
+  metadata?: Record<string, unknown>;
+  /** Tools that this skill is allowed to use */
+  allowedTools?: string[];
+}
+
+/**
+ * A fully resolved skill entry in the registry.
+ *
+ * Contains parsed metadata plus internal tracking fields
+ * that are not part of the SKILL.md frontmatter.
+ */
+export interface Skill {
+  /** Parsed frontmatter metadata */
+  metadata: SkillMetadata;
+  /** Absolute path to the skill directory */
+  skillPath: string;
+  /** Which configured skill root this was discovered from */
+  rootPath: string;
+  /** Trust level assigned to this skill (inherited from root config) */
+  trustLevel: TrustLevel;
+}
+
+/**
+ * Configuration for the SkillRegistry.
+ */
+export interface SkillRegistryConfig {
+  /**
+   * Array of directory paths to scan for skills.
+   *
+   * Each entry can be a plain string (defaults to `'untrusted'` trust level)
+   * or a `SkillRootConfig` object with an explicit trust level.
+   *
+   * Paths may be absolute or relative (resolved against `cwd`).
+   * The `~` prefix is expanded to `$HOME`.
+   *
+   * @example
+   * ```ts
+   * // Simple string roots (default to 'untrusted')
+   * skillRoots: ['.agentskills', '~/.agentskills']
+   *
+   * // Trust-aware roots
+   * skillRoots: [
+   *   { path: '.agentskills', trust: 'workspace' },
+   *   { path: '~/.agentskills', trust: 'trusted' },
+   *   { path: '/shared/community', trust: 'untrusted' },
+   * ]
+   * ```
+   */
+  skillRoots: Array<string | SkillRootConfig>;
+
+  /**
+   * Feature flag to enable Agent Skills in system prompts.
+   *
+   * When `false` (default), `generatePrompt()` returns an empty string
+   * so agents operate with unmodified system prompts.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
+   * Maximum number of skills to include in generated prompts.
+   *
+   * Caps prompt token usage when many skills are discovered.
+   * Skills are included in discovery order (first root first).
+   * When undefined, all discovered skills are included.
+   */
+  maxDiscoveredSkills?: number;
+
+  /**
+   * Allow script resources from untrusted roots.
+   *
+   * When `true`, scripts from `scripts/` directories in untrusted
+   * skill roots are returned instead of being denied. This disables
+   * the default-deny policy for untrusted scripts.
+   *
+   * **Security warning:** Only enable when you have reviewed all
+   * skill packs from untrusted roots.
+   *
+   * @default false
+   */
+  allowUntrustedScripts?: boolean;
+}
+
+/**
+ * Options for `SkillRegistry.generatePrompt()`.
+ */
+export interface SkillPromptOptions {
+  /**
+   * Subset of skill names to include in the generated prompt.
+   *
+   * When provided, only skills matching these names appear in the
+   * `<available_skills>` XML block. This enables creating focused
+   * agents with different skill sets from the same registry.
+   *
+   * When omitted or empty, all discovered skills are included.
+   *
+   * @example ['code-review', 'testing-strategy']
+   */
+  skills?: string[];
+}
+
+/**
+ * Events emitted by the SkillRegistry during discovery and usage.
+ */
+export enum SkillRegistryEvent {
+  /** Emitted when a valid skill is discovered during scanning */
+  SKILL_DISCOVERED = 'skill:discovered',
+  /** Emitted when a skill parse or validation issue is encountered */
+  SKILL_WARNING = 'skill:warning',
+  /** Emitted when a skill is activated (full body loaded) */
+  SKILL_ACTIVATED = 'skill:activated',
+  /** Emitted when a skill resource file is loaded */
+  SKILL_RESOURCE_LOADED = 'skill:resource-loaded',
+  /** Emitted when a trust policy denies access to a resource */
+  TRUST_POLICY_DENIED = 'trust:policy-denied',
+  /** Emitted when a trust policy allows access (for auditing) */
+  TRUST_POLICY_ALLOWED = 'trust:policy-allowed',
+}
+
+/**
+ * Event handler type for skill registry events.
+ */
+export type SkillEventHandler = (data: unknown) => void;
+
+/**
+ * Result of parsing a single SKILL.md file.
+ */
+export interface SkillParseResult {
+  /** Whether parsing and validation succeeded */
+  success: boolean;
+  /** Parsed metadata (present when success is true) */
+  metadata?: SkillMetadata;
+  /** The raw markdown body below the frontmatter (present when success is true) */
+  body?: string;
+  /** Error description (present when success is false) */
+  error?: string;
+}
+
+/**
+ * Validation error detail.
+ */
+export interface SkillValidationError {
+  /** Which field failed validation */
+  field: string;
+  /** Human-readable error message */
+  message: string;
+}

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -45,20 +45,26 @@
 **Branch:** `feat/st-07002-move-skills-source`
 
 ### Checklist
-- [ ] Create branch `feat/st-07002-move-skills-source`
-- [ ] Create draft PR with story ID in title
-- [ ] Move `packages/core/src/skills/*.ts` to `packages/skills/src/` (activation.ts, index.ts, parser.ts, registry.ts, scanner.ts, trust.ts, types.ts)
-- [ ] Replace relative imports to core internals with `@agentforge/core` package imports:
+- [x] Create branch `feat/st-07002-move-skills-source`
+- [x] Create draft PR with story ID in title
+  - PR #53: https://github.com/TVScoundrel/agentforge/pull/53
+- [x] Move `packages/core/src/skills/*.ts` to `packages/skills/src/` (activation.ts, parser.ts, registry.ts, scanner.ts, trust.ts, types.ts)
+  - Core files remain in place; deleted in ST-07003 when deprecation re-exports replace them
+- [x] Replace relative imports to core internals with `@agentforge/core` package imports:
   - `../tools/builder.js` → `@agentforge/core` (ToolBuilder)
   - `../tools/types.js` → `@agentforge/core` (ToolCategory, Tool)
   - `../langgraph/observability/logger.js` → `@agentforge/core` (createLogger, LogLevel)
-- [ ] Verify `ToolCategory.SKILLS` enum value stays in `@agentforge/core` (no move needed)
-- [ ] Update `packages/skills/src/index.ts` barrel exports to match previous public API
-- [ ] Verify `pnpm -r build` succeeds with clean output
-- [ ] Verify TypeScript strict mode passes (`pnpm typecheck`)
-- [ ] Add or update story documentation at `docs/st07002-move-skills-source.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
+- [x] Verify `ToolCategory.SKILLS` enum value stays in `@agentforge/core` (no move needed)
+  - Confirmed — ToolCategory enum stays in core; skills package imports it via `@agentforge/core`
+- [x] Update `packages/skills/src/index.ts` barrel exports to match previous public API
+- [x] Verify `pnpm -r build` succeeds with clean output
+  - All 7 packages build: skills ESM/CJS/DTS all succeed
+- [x] Verify TypeScript strict mode passes (`pnpm typecheck`)
+  - Skills passes with zero errors; core has 9 pre-existing errors in logging.test.ts (unrelated)
+- [x] Add or update story documentation at `docs/st07002-move-skills-source.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - No new tests required — source is copied (not changed), existing tests in core still pass against core's files. Tests migrate to skills package in ST-07004.
+- [x] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Mark PR Ready only after all story tasks are complete

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -65,9 +65,11 @@
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - No new tests required — source is copied (not changed), existing tests in core still pass against core's files. Tests migrate to skills package in ST-07004.
 - [x] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - 159 passed | 1 skipped (160 files); 2337 passed | 17 skipped (2354 tests); 0 failures
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing `@typescript-eslint/no-explicit-any`)
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 stories
+- **In Progress:** 1 stories
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
@@ -13,12 +13,6 @@
 ---
 
 ## Ready
-
-### ST-07002: Move Skills Source Files and Re-wire Imports
-- **Epic:** EP-07 — Extract Skills into Dedicated Package
-- **Priority:** P0 (Critical)
-- **Estimate:** 5 hours
-- **Dependencies:** ST-07001 (merged)
 
 ### ST-07006: Update Release Scripts and Checklist
 - **Epic:** EP-07 — Extract Skills into Dedicated Package
@@ -30,7 +24,12 @@
 
 ## In Progress
 
-_No stories currently in progress_
+### ST-07002: Move Skills Source Files and Re-wire Imports
+- **Epic:** EP-07 — Extract Skills into Dedicated Package
+- **Priority:** P0 (Critical)
+- **Estimate:** 5 hours
+- **Dependencies:** ST-07001 (merged)
+- **PR:** #53
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 stories
-- **In Progress:** 1 stories
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
 
@@ -24,18 +24,18 @@
 
 ## In Progress
 
+_No stories currently in progress_
+
+---
+
+## In Review
+
 ### ST-07002: Move Skills Source Files and Re-wire Imports
 - **Epic:** EP-07 — Extract Skills into Dedicated Package
 - **Priority:** P0 (Critical)
 - **Estimate:** 5 hours
 - **Dependencies:** ST-07001 (merged)
 - **PR:** #53
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
       '@agentforge/core':
         specifier: workspace:*
@@ -237,9 +240,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.3)(@vitest/ui@2.1.9)
-      zod:
-        specifier: ^3.24.1
-        version: 3.25.76
 
   packages/testing:
     dependencies:


### PR DESCRIPTION
## ST-07002: Move Skills Source Files and Re-wire Imports

### Story
Move the 6 skills source files from `packages/core/src/skills/` to `packages/skills/src/` and replace relative imports to core internals with `@agentforge/core` package imports.

### What Changed

**Source files copied to `packages/skills/src/`:**
| File | Import Changes |
|------|---------------|
| `types.ts` | None — pure type definitions |
| `trust.ts` | None — only internal refs to `./types.js` |
| `parser.ts` | None — only internal refs + `gray-matter` |
| `scanner.ts` | `createLogger`, `LogLevel` → `@agentforge/core` |
| `registry.ts` | `createLogger`, `LogLevel` → `@agentforge/core` |
| `activation.ts` | `ToolBuilder`, `ToolCategory`, `Tool`, `createLogger`, `LogLevel` → `@agentforge/core` |

**Additional changes:**
- Barrel exports in `index.ts` match previous public API from core
- Logger names updated: `agentforge:core:skills:*` → `agentforge:skills:*`
- Story doc: `docs/st07002-move-skills-source.md`
- Changelog: `[Unreleased]` section updated

**What stays in core:**
- Core source files remain in place (replaced by deprecation re-exports in ST-07003)
- `ToolCategory.SKILLS` stays in `@agentforge/core` — skills imports it

### Acceptance Criteria Coverage
- [x] Skills source files present in `packages/skills/src/`
- [x] Imports re-wired from relative to `@agentforge/core`
- [x] `ToolCategory.SKILLS` stays in core (verified)
- [x] Barrel exports match previous public API
- [x] `pnpm build` succeeds cleanly (all 7 packages)
- [x] TypeScript strict mode passes (skills: 0 errors)
- [x] Test suite passes (2337/2337, 0 failures)
- [x] Lint passes (0 errors, 109 pre-existing warnings)

### Bonus: Pre-existing Typecheck Fix
Fixed 9 pre-existing TS2739 errors in `packages/core/src/langgraph/middleware/__tests__/logging.test.ts` (these exist on `main` too — not introduced by this branch). All 9 mock `Logger` objects were missing `isDebugEnabled` and `isLevelEnabled` properties required by the `Logger` interface. Added `isDebugEnabled: vi.fn().mockReturnValue(false)` and `isLevelEnabled: vi.fn().mockReturnValue(false)` to each mock. Core typecheck now passes cleanly.

### Validation Performed
- `pnpm build` — all 7 packages build (ESM+CJS+DTS)
- `npx tsc --noEmit` in skills package — 0 errors
- `npx tsc --noEmit` in core package — 0 errors (9 pre-existing errors fixed)
- `pnpm test --run` — 159 passed | 1 skipped (160 files); 2337 passed | 17 skipped; 0 failures
- `pnpm lint` — 0 errors, 109 warnings (all pre-existing `@typescript-eslint/no-explicit-any`)

### Status
Ready for review

