### PR TITLE
feat(st-07004): migrate skills tests and fixtures

### DIFF
--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All types: `Skill`, `SkillMetadata`, `SkillRegistryConfig`, `TrustLevel`, etc.
 - Imports re-wired from relative core internals to `@agentforge/core` package imports
 - Logger names updated to `agentforge:skills:*` namespace
+- **Skills test suite** (215 tests) migrated from `packages/core/tests/skills/` to `packages/skills/tests/`
+  - 7 test files: activation, conformance, parser, prompt, registry, scanner, trust
+  - Fixture skill packs (valid, malformed, untrusted) moved to `packages/skills/tests/fixtures/`
 
 ### Removed
 

--- a/packages/skills/tests/activation.test.ts
+++ b/packages/skills/tests/activation.test.ts
@@ -1,0 +1,618 @@
+/**
+ * Tests for Skill Activation Tools
+ *
+ * Covers:
+ * - activate-skill tool: resolves via SkillRegistry, returns SKILL.md body
+ * - read-skill-resource tool: resolves resource files with path traversal protection
+ * - toActivationTools() convenience method
+ * - resolveResourcePath security function
+ * - Event emission (skill:activated, skill:resource-loaded)
+ * - Error handling for missing skills and resources
+ * - Integration with SkillRegistry lifecycle
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../src/registry.js';
+import { SkillRegistryEvent } from '../src/types.js';
+import {
+  createActivateSkillTool,
+  createReadSkillResourceTool,
+  createSkillActivationTools,
+  resolveResourcePath,
+} from '../src/activation.js';
+import { ToolCategory } from '@agentforge/core';
+
+// ─── Fixture Helpers ─────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-activation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createSkillFixture(
+  root: string,
+  dirName: string,
+  frontmatter: string,
+  body: string,
+): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\n${frontmatter}\n---\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+function createResourceFile(skillDir: string, relativePath: string, content: string): string {
+  const fullPath = join(skillDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('resolveResourcePath', () => {
+  it('should resolve a valid relative path within the skill root', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'references/guide.md');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(resolve('/skills/my-skill', 'references/guide.md'));
+    }
+  });
+
+  it('should block absolute paths', () => {
+    const result = resolveResourcePath('/skills/my-skill', '/etc/passwd');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Absolute resource paths');
+    }
+  });
+
+  it('should block backslash absolute paths on Windows or treat as relative on POSIX', () => {
+    const result = resolveResourcePath('/skills/my-skill', '\\etc\\passwd');
+    if (process.platform === 'win32') {
+      // On Windows, backslash paths are absolute
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('Absolute resource paths');
+      }
+    } else {
+      // On POSIX, backslashes are valid filename chars — path stays within root
+      // The relative() containment guard handles this correctly
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('should block simple .. traversal', () => {
+    const result = resolveResourcePath('/skills/my-skill', '../secrets/key');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Path traversal');
+    }
+  });
+
+  it('should block nested .. traversal', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'references/../../secrets/key');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Path traversal');
+    }
+  });
+
+  it('should allow simple filename', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'README.md');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(resolve('/skills/my-skill', 'README.md'));
+    }
+  });
+
+  it('should allow nested subdirectory paths', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'scripts/setup/install.sh');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(resolve('/skills/my-skill', 'scripts/setup/install.sh'));
+    }
+  });
+
+  it('should allow assets/ directory', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'assets/logo.png');
+    expect(result.success).toBe(true);
+  });
+
+  it('should allow filenames containing double dots (e.g., foo..bar)', () => {
+    const result = resolveResourcePath('/skills/my-skill', 'references/foo..bar.md');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.resolvedPath).toBe(resolve('/skills/my-skill', 'references/foo..bar.md'));
+    }
+  });
+
+  it('should block symlinks that escape the skill directory', () => {
+    // Create a real temp skill directory and a target outside it
+    const skillRoot = createTempDir();
+    const outsideDir = createTempDir();
+    const outsideFile = join(outsideDir, 'secret.txt');
+    writeFileSync(outsideFile, 'secret-data', 'utf-8');
+
+    // Create a symlink inside the skill root that points outside
+    const symlinkPath = join(skillRoot, 'escape-link.txt');
+    symlinkSync(outsideFile, symlinkPath);
+
+    const result = resolveResourcePath(skillRoot, 'escape-link.txt');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Symlink target escapes the skill directory');
+    }
+
+    // Cleanup
+    rmSync(skillRoot, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+});
+
+describe('activate-skill tool', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should have correct tool metadata', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    expect(tool.metadata.name).toBe('activate-skill');
+    expect(tool.metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tool.metadata.tags).toContain('skill');
+    expect(tool.metadata.tags).toContain('activation');
+    expect(tool.metadata.description).toContain('Activate an Agent Skill');
+  });
+
+  it('should return skill body when skill exists', async () => {
+    createSkillFixture(tempDir, 'code-review', 'name: code-review\ndescription: Code review skill', '\n# Code Review\n\nReview code for quality.');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'code-review' });
+
+    expect(result).toContain('# Code Review');
+    expect(result).toContain('Review code for quality.');
+  });
+
+  it('should strip frontmatter from returned body', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill', '\nBody content only');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill' });
+
+    expect(result).not.toContain('name: my-skill');
+    expect(result).toBe('Body content only');
+  });
+
+  it('should return error message for non-existent skill', async () => {
+    createSkillFixture(tempDir, 'code-review', 'name: code-review\ndescription: CR', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'non-existent' });
+
+    expect(result).toContain('Skill "non-existent" not found');
+    expect(result).toContain('code-review');
+  });
+
+  it('should return error message when no skills are registered', async () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'anything' });
+
+    expect(result).toContain('not found');
+    expect(result).toContain('No skills are currently registered');
+  });
+
+  it('should emit skill:activated event', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_ACTIVATED, handler);
+
+    await tool.invoke({ name: 'my-skill' });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-skill',
+        bodyLength: expect.any(Number),
+      }),
+    );
+  });
+
+  it('should handle skill with no SKILL.md gracefully', async () => {
+    // Create a registry with a skill, then delete the SKILL.md
+    const skillDir = createSkillFixture(tempDir, 'broken-skill', 'name: broken-skill\ndescription: Broken', '\nbody');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    // Remove SKILL.md after discovery
+    rmSync(join(skillDir, 'SKILL.md'));
+
+    const tool = createActivateSkillTool(registry);
+    const result = await tool.invoke({ name: 'broken-skill' });
+
+    expect(result).toContain('Failed to read skill');
+  });
+
+  it('should handle skill with only frontmatter (empty body)', async () => {
+    const skillDir = join(tempDir, 'empty-body');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: empty-body\ndescription: Empty\n---', 'utf-8');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createActivateSkillTool(registry);
+
+    const result = await tool.invoke({ name: 'empty-body' });
+    expect(result).toBe('');
+  });
+
+  it('should handle skill with no frontmatter', async () => {
+    const skillDir = join(tempDir, 'no-frontmatter');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Just content\n\nNo frontmatter here.', 'utf-8');
+
+    // This skill will fail parsing (no frontmatter = no name), so it won't be in the registry
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    expect(registry.has('no-frontmatter')).toBe(false);
+  });
+});
+
+describe('read-skill-resource tool', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should have correct tool metadata', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    expect(tool.metadata.name).toBe('read-skill-resource');
+    expect(tool.metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tool.metadata.tags).toContain('resource');
+    expect(tool.metadata.description).toContain('resource file');
+  });
+
+  it('should read a resource file from references/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Reference Guide\n\nSome content.');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(result).toBe('# Reference Guide\n\nSome content.');
+  });
+
+  it('should read a resource file from scripts/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho "Hello"');
+
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'trusted' }] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(result).toBe('#!/bin/bash\necho "Hello"');
+  });
+
+  it('should read a resource from assets/', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'assets/config.json', '{"key": "value"}');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'assets/config.json' });
+
+    expect(result).toBe('{"key": "value"}');
+  });
+
+  it('should read a resource from nested subdirectories', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/api/endpoints.md', '# Endpoints');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/api/endpoints.md' });
+
+    expect(result).toBe('# Endpoints');
+  });
+
+  it('should block path traversal via ../', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '../SKILL.md' });
+
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block path traversal via nested ../../../', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/../../../etc/passwd' });
+
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block absolute paths', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '/etc/passwd' });
+
+    expect(result).toContain('Absolute resource paths');
+  });
+
+  it('should return error for non-existent skill', async () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'ghost', path: 'file.txt' });
+
+    expect(result).toContain('Skill "ghost" not found');
+  });
+
+  it('should return error for missing resource file', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/nonexistent.md' });
+
+    expect(result).toContain('Failed to read resource');
+    expect(result).toContain('nonexistent.md');
+  });
+
+  it('should emit skill:resource-loaded event on success', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', 'Guide content');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, handler);
+
+    await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'my-skill',
+        resourcePath: 'references/guide.md',
+        contentLength: expect.any(Number),
+      }),
+    );
+  });
+
+  it('should not emit event on failure', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const handler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, handler);
+
+    await tool.invoke({ name: 'my-skill', path: '../etc/passwd' });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSkillActivationTools', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return an array of two tools', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = createSkillActivationTools(registry);
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].metadata.name).toBe('activate-skill');
+    expect(tools[1].metadata.name).toBe('read-skill-resource');
+  });
+
+  it('should return tools in SKILLS category', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = createSkillActivationTools(registry);
+
+    expect(tools[0].metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tools[1].metadata.category).toBe(ToolCategory.SKILLS);
+  });
+});
+
+describe('SkillRegistry.toActivationTools()', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return activation tools bound to the registry', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tools = registry.toActivationTools();
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].metadata.name).toBe('activate-skill');
+    expect(tools[1].metadata.name).toBe('read-skill-resource');
+  });
+
+  it('should return tools that work with the registry state', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: A test skill', '\n# Test Skill\n\nInstructions here.');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool] = registry.toActivationTools();
+
+    const result = await activateTool.invoke({ name: 'my-skill' });
+
+    expect(result).toContain('# Test Skill');
+    expect(result).toContain('Instructions here.');
+  });
+});
+
+describe('End-to-end integration', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should activate a skill and then read its resources', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review best practices',
+      '\n# Code Review Skill\n\nFollow the guidelines in references/checklist.md',
+    );
+    createResourceFile(skillDir, 'references/checklist.md', '# Checklist\n\n- [ ] Check naming\n- [ ] Check tests');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    // Step 1: Activate the skill
+    const skillBody = await activateTool.invoke({ name: 'code-review' });
+    expect(skillBody).toContain('# Code Review Skill');
+    expect(skillBody).toContain('references/checklist.md');
+
+    // Step 2: Read the referenced resource
+    const resource = await readResourceTool.invoke({
+      name: 'code-review',
+      path: 'references/checklist.md',
+    });
+    expect(resource).toContain('# Checklist');
+    expect(resource).toContain('Check naming');
+  });
+
+  it('should work with multiple skills from multiple roots', async () => {
+    const root2 = createTempDir();
+    tempDirs.push(root2);
+
+    createSkillFixture(tempDir, 'skill-a', 'name: skill-a\ndescription: Skill A', '\n# Skill A body');
+    const skillBDir = createSkillFixture(root2, 'skill-b', 'name: skill-b\ndescription: Skill B', '\n# Skill B body');
+    createResourceFile(skillBDir, 'scripts/run.sh', '#!/bin/bash\necho "running"');
+
+    const registry = new SkillRegistry({ skillRoots: [
+      { path: tempDir, trust: 'workspace' },
+      { path: root2, trust: 'trusted' },
+    ] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    const bodyA = await activateTool.invoke({ name: 'skill-a' });
+    expect(bodyA).toContain('# Skill A body');
+
+    const bodyB = await activateTool.invoke({ name: 'skill-b' });
+    expect(bodyB).toContain('# Skill B body');
+
+    const script = await readResourceTool.invoke({ name: 'skill-b', path: 'scripts/run.sh' });
+    expect(script).toContain('echo "running"');
+  });
+
+  it('should emit both event types in a full workflow', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/ref.md', 'reference content');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const [activateTool, readResourceTool] = registry.toActivationTools();
+
+    const activatedHandler = vi.fn();
+    const resourceHandler = vi.fn();
+    registry.on(SkillRegistryEvent.SKILL_ACTIVATED, activatedHandler);
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, resourceHandler);
+
+    await activateTool.invoke({ name: 'my-skill' });
+    await readResourceTool.invoke({ name: 'my-skill', path: 'references/ref.md' });
+
+    expect(activatedHandler).toHaveBeenCalledOnce();
+    expect(resourceHandler).toHaveBeenCalledOnce();
+  });
+
+  it('should work alongside SkillRegistry.generatePrompt()', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill for compose', '\n# Skill Body');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir], enabled: true });
+    const [activateTool] = registry.toActivationTools();
+
+    // generatePrompt() should list the skill
+    const prompt = registry.generatePrompt();
+    expect(prompt).toContain('my-skill');
+    expect(prompt).toContain('Test skill for compose');
+
+    // activate-skill should return the body
+    const body = await activateTool.invoke({ name: 'my-skill' });
+    expect(body).toContain('# Skill Body');
+  });
+
+  it('tools can be spread into any agent tool array', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const skillTools = registry.toActivationTools();
+
+    // Simulating adding to an agent's tool array
+    const allTools = [...skillTools];
+    expect(allTools).toHaveLength(2);
+    expect(allTools[0].metadata.name).toBe('activate-skill');
+    expect(allTools[1].metadata.name).toBe('read-skill-resource');
+  });
+});

--- a/packages/skills/tests/conformance.test.ts
+++ b/packages/skills/tests/conformance.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Conformance Test Suite — Agent Skills Integration
+ *
+ * Validates the full Agent Skills pipeline end-to-end using the static
+ * fixture skill packs committed alongside this test. Unlike the unit
+ * tests (which create ephemeral temp fixtures), these tests run against
+ * the committed fixtures to catch regressions in fixture quality and to
+ * ensure the framework handles real-world skill structures correctly.
+ *
+ * Pipeline stages covered:
+ *   scan → parse → register → prompt → activate → read-resource → trust
+ *
+ * Fixture layout:
+ *   tests/skills/fixtures/
+ *   ├── valid/           (code-review, test-generator)
+ *   ├── malformed/       (bad-frontmatter, name-mismatch, no-frontmatter)
+ *   └── untrusted/       (community-tool with scripts)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SkillRegistry } from '../src/registry.js';
+import { SkillRegistryEvent, type SkillRegistryConfig } from '../src/types.js';
+import { ToolCategory } from '@agentforge/core';
+
+// ─── Fixture Roots ──────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURES = resolve(__dirname, 'fixtures');
+const VALID_ROOT = resolve(FIXTURES, 'valid');
+const MALFORMED_ROOT = resolve(FIXTURES, 'malformed');
+const UNTRUSTED_ROOT = resolve(FIXTURES, 'untrusted');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function createRegistry(config: Partial<SkillRegistryConfig> = {}): SkillRegistry {
+  return new SkillRegistry({
+    enabled: true,
+    skillRoots: [
+      { path: VALID_ROOT, trust: 'workspace' },
+    ],
+    ...config,
+  });
+}
+
+function collectEvents(
+  registry: SkillRegistry,
+  event: SkillRegistryEvent,
+): unknown[] {
+  const captured: unknown[] = [];
+  registry.on(event, (data) => captured.push(data));
+  return captured;
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// 1. Discovery — scanning static fixture packs
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Discovery', () => {
+  it('should discover valid fixture skills (code-review, test-generator)', () => {
+    const registry = createRegistry();
+    expect(registry.size()).toBe(2);
+    expect(registry.getNames().sort()).toEqual(['code-review', 'test-generator']);
+  });
+
+  it('should populate metadata from frontmatter', () => {
+    const registry = createRegistry();
+    const skill = registry.get('code-review');
+    expect(skill).toBeDefined();
+    expect(skill!.metadata.name).toBe('code-review');
+    expect(skill!.metadata.description).toContain('code reviews');
+    expect(skill!.metadata.license).toBe('MIT');
+    expect(skill!.metadata.compatibility).toEqual(['agentforge', 'copilot']);
+    expect(skill!.metadata.metadata).toEqual({ category: 'development', difficulty: 'intermediate' });
+    expect(skill!.metadata.allowedTools).toEqual(['read-file', 'grep-search']);
+  });
+
+  it('should set correct trust level from root config', () => {
+    const registry = createRegistry();
+    const skill = registry.get('code-review');
+    expect(skill!.trustLevel).toBe('workspace');
+  });
+
+  it('should skip all malformed fixtures without crashing', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: MALFORMED_ROOT, trust: 'workspace' }],
+    });
+    // All 3 malformed fixtures should be rejected
+    expect(registry.size()).toBe(0);
+    expect(registry.getScanErrors().length).toBeGreaterThan(0);
+  });
+
+  it('should emit warnings for malformed fixtures', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: MALFORMED_ROOT, trust: 'workspace' }],
+    });
+    const errors = registry.getScanErrors();
+    // Should have errors for bad-frontmatter, name-mismatch, no-frontmatter
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should discover untrusted skills with correct trust level', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: UNTRUSTED_ROOT, trust: 'untrusted' }],
+    });
+    expect(registry.size()).toBe(1);
+    const skill = registry.get('community-tool');
+    expect(skill).toBeDefined();
+    expect(skill!.trustLevel).toBe('untrusted');
+  });
+
+  it('should discover skills from mixed roots', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+    });
+    expect(registry.size()).toBe(3);
+    expect(registry.getNames().sort()).toEqual([
+      'code-review',
+      'community-tool',
+      'test-generator',
+    ]);
+  });
+
+  it('should respect maxDiscoveredSkills cap in prompt generation', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+      maxDiscoveredSkills: 2,
+    });
+    // Cap applies to prompt generation, not discovery
+    expect(registry.size()).toBe(3);
+    const prompt = registry.generatePrompt();
+    // Only 2 skills should appear in the prompt
+    const skillMatches = prompt.match(/<skill>/g);
+    expect(skillMatches).toHaveLength(2);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 2. Prompt Generation — XML injection of fixture metadata
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Prompt Generation', () => {
+  let registry: SkillRegistry;
+
+  beforeEach(() => {
+    registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+    });
+  });
+
+  it('should produce <available_skills> XML for fixture skills', () => {
+    const prompt = registry.generatePrompt();
+    expect(prompt).toContain('<available_skills>');
+    expect(prompt).toContain('</available_skills>');
+    expect(prompt).toContain('code-review');
+    expect(prompt).toContain('test-generator');
+    expect(prompt).toContain('community-tool');
+  });
+
+  it('should include skill descriptions in prompt', () => {
+    const prompt = registry.generatePrompt();
+    expect(prompt).toContain('code reviews');
+    expect(prompt).toContain('test suites');
+    expect(prompt).toContain('community-contributed');
+  });
+
+  it('should return empty string when disabled', () => {
+    const disabled = new SkillRegistry({
+      enabled: false,
+      skillRoots: [{ path: VALID_ROOT, trust: 'workspace' }],
+    });
+    expect(disabled.generatePrompt()).toBe('');
+  });
+
+  it('should filter prompt to requested skills only', () => {
+    const prompt = registry.generatePrompt({ skills: ['code-review'] });
+    expect(prompt).toContain('code-review');
+    expect(prompt).not.toContain('test-generator');
+    expect(prompt).not.toContain('community-tool');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 3. Tool Activation — activate-skill with fixture skills
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Tool Activation', () => {
+  let registry: SkillRegistry;
+
+  beforeEach(() => {
+    registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+    });
+  });
+
+  it('should produce two activation tools via toActivationTools()', () => {
+    const tools = registry.toActivationTools();
+    expect(tools).toHaveLength(2);
+    expect(tools[0].metadata.name).toBe('activate-skill');
+    expect(tools[1].metadata.name).toBe('read-skill-resource');
+    expect(tools[0].metadata.category).toBe(ToolCategory.SKILLS);
+    expect(tools[1].metadata.category).toBe(ToolCategory.SKILLS);
+  });
+
+  it('should activate code-review and return body content', async () => {
+    const [activateSkill] = registry.toActivationTools();
+    const body = await activateSkill.invoke({ name: 'code-review' });
+    expect(body).toContain('Code Review Skill');
+    expect(body).toContain('Review Process');
+    // Frontmatter should be stripped from the top of the body, but content
+    // may legitimately contain '---' or frontmatter-like text later on.
+    const headerRegion = body.split('\n').slice(0, 5).join('\n');
+    expect(headerRegion.trimStart().startsWith('---')).toBe(false);
+    expect(headerRegion).not.toContain('name: code-review');
+  });
+
+  it('should activate test-generator and return body content', async () => {
+    const [activateSkill] = registry.toActivationTools();
+    const body = await activateSkill.invoke({ name: 'test-generator' });
+    expect(body).toContain('Test Generator');
+    expect(body).toContain('Test Quality Rules');
+  });
+
+  it('should activate community-tool from untrusted root', async () => {
+    const [activateSkill] = registry.toActivationTools();
+    const body = await activateSkill.invoke({ name: 'community-tool' });
+    expect(body).toContain('Community Tool');
+    // Activation always works regardless of trust — trust is enforced on resources
+    expect(body).toContain('trust policy');
+  });
+
+  it('should emit SKILL_ACTIVATED event on activation', async () => {
+    const events = collectEvents(registry, SkillRegistryEvent.SKILL_ACTIVATED);
+    const [activateSkill] = registry.toActivationTools();
+    await activateSkill.invoke({ name: 'code-review' });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ name: 'code-review' });
+  });
+
+  it('should return error for non-existent skill', async () => {
+    const [activateSkill] = registry.toActivationTools();
+    const result = await activateSkill.invoke({ name: 'does-not-exist' });
+    expect(result).toContain('not found');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 4. Resource Loading — read-skill-resource with fixture resources
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Resource Loading', () => {
+  let registry: SkillRegistry;
+
+  beforeEach(() => {
+    registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+    });
+  });
+
+  it('should read references/style-guide.md from code-review', async () => {
+    const [, readResource] = registry.toActivationTools();
+    const content = await readResource.invoke({
+      name: 'code-review',
+      path: 'references/style-guide.md',
+    });
+    expect(content).toContain('Style Guide');
+  });
+
+  it('should read references/testing-patterns.md from test-generator', async () => {
+    const [, readResource] = registry.toActivationTools();
+    const content = await readResource.invoke({
+      name: 'test-generator',
+      path: 'references/testing-patterns.md',
+    });
+    expect(content).toContain('Testing Patterns');
+  });
+
+  it('should read scripts from workspace-trusted skill', async () => {
+    const [, readResource] = registry.toActivationTools();
+    const content = await readResource.invoke({
+      name: 'code-review',
+      path: 'scripts/setup-linter.sh',
+    });
+    expect(content).toContain('Setup linter');
+  });
+
+  it('should read references from untrusted skill (non-script allowed)', async () => {
+    const [, readResource] = registry.toActivationTools();
+    const content = await readResource.invoke({
+      name: 'community-tool',
+      path: 'references/readme.md',
+    });
+    expect(content).toBeTruthy();
+  });
+
+  it('should emit SKILL_RESOURCE_LOADED event on success', async () => {
+    const events = collectEvents(registry, SkillRegistryEvent.SKILL_RESOURCE_LOADED);
+    const [, readResource] = registry.toActivationTools();
+    await readResource.invoke({
+      name: 'code-review',
+      path: 'references/style-guide.md',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      name: 'code-review',
+      resourcePath: 'references/style-guide.md',
+    });
+  });
+
+  it('should return error for missing resource file', async () => {
+    const [, readResource] = registry.toActivationTools();
+    const result = await readResource.invoke({
+      name: 'code-review',
+      path: 'references/nonexistent.md',
+    });
+    expect(result).toContain('Failed to read resource');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 5. Trust Policy Enforcement — blocking untrusted scripts
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Trust Policy', () => {
+  it('should block script access from untrusted root (default)', async () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: UNTRUSTED_ROOT, trust: 'untrusted' }],
+      allowUntrustedScripts: false,
+    });
+    const events = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_DENIED);
+    const [, readResource] = registry.toActivationTools();
+
+    const result = await readResource.invoke({
+      name: 'community-tool',
+      path: 'scripts/install.sh',
+    });
+
+    expect(result).toContain('blocked');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      name: 'community-tool',
+      resourcePath: 'scripts/install.sh',
+    });
+  });
+
+  it('should allow script access from untrusted root when override is true', async () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: UNTRUSTED_ROOT, trust: 'untrusted' }],
+      allowUntrustedScripts: true,
+    });
+    const allowed = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_ALLOWED);
+    const denied = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_DENIED);
+    const [, readResource] = registry.toActivationTools();
+
+    const result = await readResource.invoke({
+      name: 'community-tool',
+      path: 'scripts/install.sh',
+    });
+
+    // Should succeed and return file content
+    expect(result).toContain('Installing');
+    expect(denied).toHaveLength(0);
+    expect(allowed).toHaveLength(1);
+  });
+
+  it('should allow script access from workspace-trusted root', async () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: VALID_ROOT, trust: 'workspace' }],
+      allowUntrustedScripts: false,
+    });
+    const denied = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_DENIED);
+    const [, readResource] = registry.toActivationTools();
+
+    const result = await readResource.invoke({
+      name: 'code-review',
+      path: 'scripts/setup-linter.sh',
+    });
+
+    expect(result).toContain('Setup linter');
+    expect(denied).toHaveLength(0);
+  });
+
+  it('should allow non-script resources from untrusted root', async () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: UNTRUSTED_ROOT, trust: 'untrusted' }],
+      allowUntrustedScripts: false,
+    });
+    const denied = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_DENIED);
+    const [, readResource] = registry.toActivationTools();
+
+    const result = await readResource.invoke({
+      name: 'community-tool',
+      path: 'references/readme.md',
+    });
+
+    expect(result).toBeTruthy();
+    expect(denied).toHaveLength(0);
+  });
+
+  it('should block path traversal even with workspace trust', async () => {
+    const registry = createRegistry();
+    const [, readResource] = registry.toActivationTools();
+
+    const result = await readResource.invoke({
+      name: 'code-review',
+      path: '../../../etc/passwd',
+    });
+
+    expect(result).toContain('traversal');
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 6. getAllowedTools — fixture frontmatter validation
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Allowed Tools', () => {
+  it('should return allowedTools for code-review fixture', () => {
+    const registry = createRegistry();
+    expect(registry.getAllowedTools('code-review')).toEqual(['read-file', 'grep-search']);
+  });
+
+  it('should return allowedTools for test-generator fixture', () => {
+    const registry = createRegistry();
+    expect(registry.getAllowedTools('test-generator')).toEqual(['read-file', 'create-file', 'grep-search']);
+  });
+
+  it('should return allowedTools for untrusted community-tool', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: UNTRUSTED_ROOT, trust: 'untrusted' }],
+    });
+    expect(registry.getAllowedTools('community-tool')).toEqual(['run-in-terminal']);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// 7. Full Pipeline — scan → prompt → activate → read-resource → trust
+// ═════════════════════════════════════════════════════════════════════════
+
+describe('Conformance: Full Pipeline', () => {
+  it('should execute the complete pipeline from discovery to trust enforcement', async () => {
+    // 1. Scan — create registry with mixed roots
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+      allowUntrustedScripts: false,
+    });
+
+    // Collect all events
+    const activated = collectEvents(registry, SkillRegistryEvent.SKILL_ACTIVATED);
+    const loaded = collectEvents(registry, SkillRegistryEvent.SKILL_RESOURCE_LOADED);
+    const denied = collectEvents(registry, SkillRegistryEvent.TRUST_POLICY_DENIED);
+
+    expect(registry.size()).toBe(3);
+
+    // 2. Prompt — generate skill listing
+    const prompt = registry.generatePrompt();
+    expect(prompt).toContain('<available_skills>');
+    expect(prompt).toContain('code-review');
+    expect(prompt).toContain('community-tool');
+
+    // 3. Activate — load skill instructions
+    const [activateSkill, readResource] = registry.toActivationTools();
+
+    const codeReviewBody = await activateSkill.invoke({ name: 'code-review' });
+    expect(codeReviewBody).toContain('Code Review Skill');
+
+    const communityBody = await activateSkill.invoke({ name: 'community-tool' });
+    expect(communityBody).toContain('Community Tool');
+
+    expect(activated).toHaveLength(2);
+
+    // 4. Read resource — workspace reference (allowed)
+    const styleGuide = await readResource.invoke({
+      name: 'code-review',
+      path: 'references/style-guide.md',
+    });
+    expect(styleGuide).toContain('Style Guide');
+    expect(loaded).toHaveLength(1);
+
+    // 5. Read resource — workspace script (allowed, workspace trust)
+    const script = await readResource.invoke({
+      name: 'code-review',
+      path: 'scripts/setup-linter.sh',
+    });
+    expect(script).toContain('Setup linter');
+
+    // 6. Read resource — untrusted reference (allowed, non-script)
+    const communityRef = await readResource.invoke({
+      name: 'community-tool',
+      path: 'references/readme.md',
+    });
+    expect(communityRef).toBeTruthy();
+
+    // 7. Trust enforcement — untrusted script (blocked)
+    const blockedScript = await readResource.invoke({
+      name: 'community-tool',
+      path: 'scripts/install.sh',
+    });
+    expect(blockedScript).toContain('blocked');
+    expect(denied).toHaveLength(1);
+
+    // 8. Path traversal — blocked regardless of trust
+    const traversal = await readResource.invoke({
+      name: 'code-review',
+      path: '../../../etc/passwd',
+    });
+    expect(traversal).toContain('traversal');
+  });
+
+  it('should handle malformed fixtures gracefully in mixed roots', async () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [
+        { path: VALID_ROOT, trust: 'workspace' },
+        { path: MALFORMED_ROOT, trust: 'workspace' },
+        { path: UNTRUSTED_ROOT, trust: 'untrusted' },
+      ],
+    });
+
+    // Valid + untrusted skills discovered, malformed skipped
+    expect(registry.size()).toBe(3);
+    expect(registry.getScanErrors().length).toBeGreaterThan(0);
+
+    // Pipeline still works for valid skills
+    const [activateSkill] = registry.toActivationTools();
+    const body = await activateSkill.invoke({ name: 'code-review' });
+    expect(body).toContain('Code Review Skill');
+  });
+
+  it('should reflect changes after re-scan', () => {
+    const registry = new SkillRegistry({
+      enabled: true,
+      skillRoots: [{ path: VALID_ROOT, trust: 'workspace' }],
+    });
+
+    expect(registry.size()).toBe(2);
+
+    // Re-scan should produce the same result from static fixtures
+    registry.discover();
+    expect(registry.size()).toBe(2);
+    expect(registry.getNames().sort()).toEqual(['code-review', 'test-generator']);
+  });
+});

--- a/packages/skills/tests/conformance.test.ts
+++ b/packages/skills/tests/conformance.test.ts
@@ -11,7 +11,7 @@
  *   scan → parse → register → prompt → activate → read-resource → trust
  *
  * Fixture layout:
- *   tests/skills/fixtures/
+ *   fixtures/
  *   ├── valid/           (code-review, test-generator)
  *   ├── malformed/       (bad-frontmatter, name-mismatch, no-frontmatter)
  *   └── untrusted/       (community-tool with scripts)

--- a/packages/skills/tests/fixtures/malformed/bad-frontmatter/SKILL.md
+++ b/packages/skills/tests/fixtures/malformed/bad-frontmatter/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: INVALID_NAME!!!
+description:
+---
+
+This skill has invalid frontmatter:
+- Name uses uppercase and special characters (violates [a-z0-9-] rule)
+- Description is empty (violates non-empty description rule)

--- a/packages/skills/tests/fixtures/malformed/name-mismatch/SKILL.md
+++ b/packages/skills/tests/fixtures/malformed/name-mismatch/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: wrong-dir-name
+description: This skill name does not match its parent directory name
+---
+
+# Name Mismatch Skill
+
+The skill name 'wrong-dir-name' does not match the directory 'name-mismatch'.

--- a/packages/skills/tests/fixtures/malformed/no-frontmatter/SKILL.md
+++ b/packages/skills/tests/fixtures/malformed/no-frontmatter/SKILL.md
@@ -1,0 +1,6 @@
+This file has no YAML frontmatter at all — it's just plain markdown
+without the --- delimiters.
+
+# No Frontmatter
+
+This should fail parsing.

--- a/packages/skills/tests/fixtures/untrusted/community-tool/SKILL.md
+++ b/packages/skills/tests/fixtures/untrusted/community-tool/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: community-tool
+description: A community-contributed skill with executable scripts that should be trust-gated
+version: 0.1.0
+allowed-tools:
+  - run-in-terminal
+---
+
+# Community Tool
+
+This skill comes from an untrusted source and includes scripts.
+The trust policy should block script access unless explicitly allowed.
+
+## Usage
+
+1. Read setup instructions from `references/readme.md`
+2. Attempt to read `scripts/install.sh` — should be blocked from untrusted roots

--- a/packages/skills/tests/fixtures/untrusted/community-tool/references/readme.md
+++ b/packages/skills/tests/fixtures/untrusted/community-tool/references/readme.md
@@ -1,0 +1,3 @@
+# Community Tool Readme
+
+This tool helps with setup tasks.

--- a/packages/skills/tests/fixtures/untrusted/community-tool/scripts/install.sh
+++ b/packages/skills/tests/fixtures/untrusted/community-tool/scripts/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This script should NOT be accessible from untrusted roots
+echo "Installing community tool..."

--- a/packages/skills/tests/fixtures/valid/code-review/SKILL.md
+++ b/packages/skills/tests/fixtures/valid/code-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: code-review
+description: Performs thorough code reviews with style checks and improvement suggestions
+version: 1.0.0
+license: MIT
+compatibility:
+  - agentforge
+  - copilot
+metadata:
+  category: development
+  difficulty: intermediate
+allowed-tools:
+  - read-file
+  - grep-search
+---
+
+# Code Review Skill
+
+You are a code review expert. When activated, analyze code for quality, style, and potential issues.
+
+## Review Process
+
+1. Read the target file(s) using `read-file`
+2. Load the style guide from `references/style-guide.md` using `read-skill-resource`
+3. Analyze code against the style guide rules
+4. Report findings organized by severity:
+   - **Critical** — bugs, security issues
+   - **Warning** — potential problems, anti-patterns
+   - **Suggestion** — style improvements, readability
+
+## Output Format
+
+Provide a structured review with:
+- File and line references
+- Issue description
+- Suggested fix (if applicable)
+- Severity level

--- a/packages/skills/tests/fixtures/valid/code-review/references/style-guide.md
+++ b/packages/skills/tests/fixtures/valid/code-review/references/style-guide.md
@@ -1,0 +1,11 @@
+# Style Guide
+
+## Naming Conventions
+- Use camelCase for variables and functions
+- Use PascalCase for classes and interfaces
+- Use UPPER_SNAKE_CASE for constants
+
+## Code Structure
+- Keep functions under 30 lines
+- Prefer composition over inheritance
+- Use early returns to reduce nesting

--- a/packages/skills/tests/fixtures/valid/code-review/scripts/setup-linter.sh
+++ b/packages/skills/tests/fixtures/valid/code-review/scripts/setup-linter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Setup linter configuration for code review
+echo "Installing ESLint..."

--- a/packages/skills/tests/fixtures/valid/test-generator/SKILL.md
+++ b/packages/skills/tests/fixtures/valid/test-generator/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: test-generator
+description: Generates comprehensive test suites for TypeScript projects using Vitest
+version: 1.0.0
+license: MIT
+compatibility:
+  - agentforge
+metadata:
+  category: testing
+  framework: vitest
+allowed-tools:
+  - read-file
+  - create-file
+  - grep-search
+---
+
+# Test Generator
+
+You are an expert test writer. When activated, generate comprehensive test suites for the specified TypeScript code.
+
+## Process
+
+1. Read the source file using `read-file`
+2. Load testing patterns from `references/testing-patterns.md` using `read-skill-resource`
+3. Analyze exports, classes, and functions
+4. Generate tests following the patterns guide
+5. Write test files using `create-file`
+
+## Test Quality Rules
+
+- Every public function must have at least one test
+- Include edge cases and error paths
+- Use descriptive test names following "should..." convention
+- Follow the AAA pattern (Arrange, Act, Assert)
+- Mock external dependencies

--- a/packages/skills/tests/fixtures/valid/test-generator/references/testing-patterns.md
+++ b/packages/skills/tests/fixtures/valid/test-generator/references/testing-patterns.md
@@ -1,0 +1,23 @@
+# Testing Patterns
+
+## Unit Test Structure
+
+Use `describe` blocks grouped by function, with `it` blocks per case:
+
+```typescript
+describe('functionName', () => {
+  it('should handle normal input', () => {
+    // Arrange → Act → Assert
+  });
+
+  it('should throw on invalid input', () => {
+    expect(() => fn(null)).toThrow();
+  });
+});
+```
+
+## Mock Patterns
+
+- Use `vi.fn()` for function mocks
+- Use `vi.spyOn()` for method spies
+- Always restore mocks in `afterEach`

--- a/packages/skills/tests/parser.test.ts
+++ b/packages/skills/tests/parser.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for Skill Frontmatter Parser
+ *
+ * Covers: parseSkillContent, validateSkillName, validateSkillDescription,
+ * validateSkillNameMatchesDir
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSkillContent,
+  validateSkillName,
+  validateSkillDescription,
+  validateSkillNameMatchesDir,
+} from '../src/parser.js';
+
+describe('validateSkillName', () => {
+  it('should accept valid names', () => {
+    expect(validateSkillName('code-review')).toEqual([]);
+    expect(validateSkillName('a')).toEqual([]);
+    expect(validateSkillName('my-great-skill')).toEqual([]);
+    expect(validateSkillName('abc123')).toEqual([]);
+    expect(validateSkillName('a1b2c3')).toEqual([]);
+  });
+
+  it('should reject undefined/null', () => {
+    expect(validateSkillName(undefined)).toHaveLength(1);
+    expect(validateSkillName(undefined)[0].message).toContain('required');
+    expect(validateSkillName(null)).toHaveLength(1);
+  });
+
+  it('should reject non-string', () => {
+    expect(validateSkillName(42)).toHaveLength(1);
+    expect(validateSkillName(42)[0].message).toContain('must be a string');
+  });
+
+  it('should reject empty string', () => {
+    expect(validateSkillName('')).toHaveLength(1);
+    expect(validateSkillName('')[0].message).toContain('must not be empty');
+  });
+
+  it('should reject names exceeding 64 characters', () => {
+    const longName = 'a'.repeat(65);
+    const errors = validateSkillName(longName);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some(e => e.message.includes('at most 64'))).toBe(true);
+  });
+
+  it('should accept name at exactly 64 characters', () => {
+    const name64 = 'a'.repeat(64);
+    expect(validateSkillName(name64)).toEqual([]);
+  });
+
+  it('should reject uppercase letters', () => {
+    const errors = validateSkillName('Code-Review');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject leading hyphen', () => {
+    const errors = validateSkillName('-code');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject trailing hyphen', () => {
+    const errors = validateSkillName('code-');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject consecutive hyphens', () => {
+    const errors = validateSkillName('code--review');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some(e => e.message.includes('consecutive hyphens'))).toBe(true);
+  });
+
+  it('should reject special characters', () => {
+    expect(validateSkillName('code_review').length).toBeGreaterThanOrEqual(1);
+    expect(validateSkillName('code.review').length).toBeGreaterThanOrEqual(1);
+    expect(validateSkillName('code review').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('validateSkillDescription', () => {
+  it('should accept valid descriptions', () => {
+    expect(validateSkillDescription('A useful skill')).toEqual([]);
+    expect(validateSkillDescription('x')).toEqual([]);
+  });
+
+  it('should reject undefined/null', () => {
+    expect(validateSkillDescription(undefined)).toHaveLength(1);
+    expect(validateSkillDescription(undefined)[0].message).toContain('required');
+    expect(validateSkillDescription(null)).toHaveLength(1);
+  });
+
+  it('should reject non-string', () => {
+    expect(validateSkillDescription(123)).toHaveLength(1);
+    expect(validateSkillDescription(123)[0].message).toContain('must be a string');
+  });
+
+  it('should reject empty/whitespace-only', () => {
+    expect(validateSkillDescription('')).toHaveLength(1);
+    expect(validateSkillDescription('   ')).toHaveLength(1);
+    expect(validateSkillDescription('  ')[0].message).toContain('must not be empty');
+  });
+
+  it('should reject descriptions exceeding 1024 characters', () => {
+    const longDesc = 'a'.repeat(1025);
+    const errors = validateSkillDescription(longDesc);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0].message).toContain('at most 1024');
+  });
+
+  it('should accept description at exactly 1024 characters', () => {
+    const desc1024 = 'a'.repeat(1024);
+    expect(validateSkillDescription(desc1024)).toEqual([]);
+  });
+});
+
+describe('validateSkillNameMatchesDir', () => {
+  it('should pass when name matches directory', () => {
+    expect(validateSkillNameMatchesDir('code-review', 'code-review')).toEqual([]);
+  });
+
+  it('should fail when name does not match directory', () => {
+    const errors = validateSkillNameMatchesDir('code-review', 'my-skill');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('must match parent directory name');
+  });
+});
+
+describe('parseSkillContent', () => {
+  it('should parse valid SKILL.md with required fields', () => {
+    const content = `---
+name: code-review
+description: Reviews code for quality and security
+---
+
+# Code Review Skill
+
+Follow these steps...`;
+
+    const result = parseSkillContent(content, 'code-review');
+    expect(result.success).toBe(true);
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata!.name).toBe('code-review');
+    expect(result.metadata!.description).toBe('Reviews code for quality and security');
+    expect(result.body).toContain('# Code Review Skill');
+  });
+
+  it('should parse all optional fields', () => {
+    const content = `---
+name: full-skill
+description: A skill with all fields
+license: MIT
+compatibility:
+  - github-copilot
+  - agentforge
+metadata:
+  author: team-x
+  version: 1.0.0
+allowed-tools:
+  - read-file
+  - grep-search
+---
+
+Content here`;
+
+    const result = parseSkillContent(content, 'full-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.license).toBe('MIT');
+    expect(result.metadata!.compatibility).toEqual(['github-copilot', 'agentforge']);
+    expect(result.metadata!.metadata).toEqual({ author: 'team-x', version: '1.0.0' });
+    expect(result.metadata!.allowedTools).toEqual(['read-file', 'grep-search']);
+  });
+
+  it('should fail when name is missing', () => {
+    const content = `---
+description: A skill without a name
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'some-dir');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+    expect(result.error).toContain('required');
+  });
+
+  it('should fail when description is missing', () => {
+    const content = `---
+name: no-desc
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'no-desc');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('description');
+    expect(result.error).toContain('required');
+  });
+
+  it('should fail when name does not match directory', () => {
+    const content = `---
+name: code-review
+description: A valid description
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'wrong-dir');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('must match parent directory name');
+  });
+
+  it('should fail on invalid name format', () => {
+    const content = `---
+name: Code-Review
+description: A valid description
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'Code-Review');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('lowercase');
+  });
+
+  it('should fail on malformed frontmatter', () => {
+    const content = `---
+name: [invalid
+  yaml: {{broken
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Failed to parse frontmatter');
+  });
+
+  it('should handle empty frontmatter', () => {
+    const content = `---
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+    expect(result.error).toContain('required');
+  });
+
+  it('should handle content with no frontmatter at all', () => {
+    const content = '# Just a markdown file\n\nNo frontmatter.';
+
+    const result = parseSkillContent(content, 'test');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('name');
+  });
+
+  it('should ignore unknown frontmatter fields without error', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+custom-field: some-value
+another: 42
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.name).toBe('my-skill');
+  });
+
+  it('should handle non-array compatibility gracefully', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+compatibility: not-an-array
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    // Non-array compatibility is simply ignored
+    expect(result.metadata!.compatibility).toBeUndefined();
+  });
+
+  it('should handle non-object metadata gracefully', () => {
+    const content = `---
+name: my-skill
+description: A valid skill
+metadata: just-a-string
+---
+
+body`;
+
+    const result = parseSkillContent(content, 'my-skill');
+    expect(result.success).toBe(true);
+    expect(result.metadata!.metadata).toBeUndefined();
+  });
+
+  it('should collect multiple validation errors', () => {
+    const content = `---
+name: 123
+description: ""
+---
+
+body`;
+
+    // name "123" is actually valid (numeric), but empty description should fail
+    const result = parseSkillContent(content, '123');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('description');
+  });
+});

--- a/packages/skills/tests/prompt.test.ts
+++ b/packages/skills/tests/prompt.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for SkillRegistry.generatePrompt()
+ *
+ * Covers: XML generation, subset filtering, feature flag gating,
+ * maxDiscoveredSkills cap, prompt composition, XML escaping, token estimation,
+ * and edge cases.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../src/registry.js';
+
+/**
+ * Create a temp directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-prompt-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, frontmatter: { name: string; description: string }): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\nname: ${frontmatter.name}\ndescription: "${frontmatter.description}"\n---\n\n# ${frontmatter.name}\n\nSkill body content.`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('SkillRegistry.generatePrompt()', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function makeTempDir(): string {
+    const dir = createTempDir();
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  // ─── Feature Flag Gating ───────────────────────────────────────────────
+
+  describe('Feature Flag Gating', () => {
+    it('should return empty string when enabled is not set (default off)', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root] });
+      expect(registry.size()).toBe(1);
+      expect(registry.generatePrompt()).toBe('');
+    });
+
+    it('should return empty string when enabled is false', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: false });
+      expect(registry.generatePrompt()).toBe('');
+    });
+
+    it('should generate XML when enabled is true', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+      expect(xml).toContain('<available_skills>');
+      expect(xml).toContain('</available_skills>');
+      expect(xml).toContain('<name>my-skill</name>');
+    });
+
+    it('should return empty string when enabled but no skills discovered', () => {
+      const root = makeTempDir();
+      // Empty root — no skills
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      expect(registry.generatePrompt()).toBe('');
+    });
+  });
+
+  // ─── XML Generation ────────────────────────────────────────────────────
+
+  describe('XML Generation', () => {
+    it('should produce valid XML structure with name, description, location', () => {
+      const root = makeTempDir();
+      const skillDir = createSkillFixture(root, 'code-review', {
+        name: 'code-review',
+        description: 'Review code for quality and correctness',
+      });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toMatch(/^<available_skills>\n/);
+      expect(xml).toMatch(/\n<\/available_skills>$/);
+      expect(xml).toContain('  <skill>');
+      expect(xml).toContain('  </skill>');
+      expect(xml).toContain('    <name>code-review</name>');
+      expect(xml).toContain('    <description>Review code for quality and correctness</description>');
+      expect(xml).toContain(`    <location>${skillDir}</location>`);
+    });
+
+    it('should include multiple skills', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+
+      // Count skill blocks
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should escape XML special characters in skill fields', () => {
+      const root = makeTempDir();
+      const skillDir = join(root, 'html-tools');
+      mkdirSync(skillDir, { recursive: true });
+      // Description with XML-unsafe characters
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: html-tools',
+        'description: "Tools for <html> & \'CSS\\" parsing"',
+        '---',
+        '',
+        '# HTML Tools',
+      ].join('\n'), 'utf-8');
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>html-tools</name>');
+      // Should escape < > & ' "
+      expect(xml).toContain('&lt;html&gt;');
+      expect(xml).toContain('&amp;');
+    });
+  });
+
+  // ─── Subset Filtering ─────────────────────────────────────────────────
+
+  describe('Subset Filtering', () => {
+    it('should filter to requested skill names', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+      createSkillFixture(root, 'deployment', { name: 'deployment', description: 'Deploy apps' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['code-review', 'testing'] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+      expect(xml).not.toContain('<name>deployment</name>');
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should return empty string when no requested skills exist', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['nonexistent'] });
+
+      expect(xml).toBe('');
+    });
+
+    it('should return all skills when skills array is empty', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: [] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+    });
+
+    it('should return all skills when no options provided', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+      createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).toContain('<name>testing</name>');
+    });
+
+    it('should gracefully handle mix of existing and non-existing names', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt({ skills: ['code-review', 'nonexistent'] });
+
+      expect(xml).toContain('<name>code-review</name>');
+      expect(xml).not.toContain('nonexistent');
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(1);
+    });
+  });
+
+  // ─── maxDiscoveredSkills Cap ───────────────────────────────────────────
+
+  describe('maxDiscoveredSkills Cap', () => {
+    it('should limit skills to maxDiscoveredSkills', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 2,
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should return empty string when maxDiscoveredSkills is 0', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 0,
+      });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toBe('');
+    });
+
+    it('should return all skills when maxDiscoveredSkills exceeds count', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 100,
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should apply maxDiscoveredSkills after subset filter', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        maxDiscoveredSkills: 1,
+      });
+
+      // Request 2 skills but cap at 1
+      const xml = registry.generatePrompt({ skills: ['skill-a', 'skill-b'] });
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(1);
+    });
+
+    it('should not apply cap when maxDiscoveredSkills is undefined', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
+
+      const registry = new SkillRegistry({
+        skillRoots: [root],
+        enabled: true,
+        // maxDiscoveredSkills not set
+      });
+      const xml = registry.generatePrompt();
+
+      const skillBlocks = xml.match(/<skill>/g);
+      expect(skillBlocks).toHaveLength(3);
+    });
+  });
+
+  // ─── Prompt Composition ────────────────────────────────────────────────
+
+  describe('Prompt Composition', () => {
+    it('should compose naturally with other prompt sections', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+
+      // Simulate composing with tool prompt
+      const toolPrompt = 'Available Tools:\n\n- my-tool: Does things';
+      const skillPrompt = registry.generatePrompt();
+
+      const systemPrompt = [toolPrompt, skillPrompt].filter(Boolean).join('\n\n');
+
+      expect(systemPrompt).toContain('Available Tools:');
+      expect(systemPrompt).toContain('<available_skills>');
+      expect(systemPrompt).toContain('code-review');
+    });
+
+    it('should not add extra content when disabled (composable as empty)', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: false });
+
+      const toolPrompt = 'Available Tools:\n\n- my-tool: Does things';
+      const skillPrompt = registry.generatePrompt();
+
+      const systemPrompt = [toolPrompt, skillPrompt].filter(Boolean).join('\n\n');
+
+      // Should only contain tool prompt, no skills XML
+      expect(systemPrompt).toBe(toolPrompt);
+      expect(systemPrompt).not.toContain('<available_skills>');
+    });
+  });
+
+  // ─── Edge Cases ────────────────────────────────────────────────────────
+
+  describe('Edge Cases', () => {
+    it('should handle undefined options gracefully', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt(undefined);
+
+      expect(xml).toContain('<name>my-skill</name>');
+    });
+
+    it('should handle empty registry with enabled flag', () => {
+      const root = makeTempDir();
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+
+      expect(registry.generatePrompt()).toBe('');
+      expect(registry.generatePrompt({ skills: ['anything'] })).toBe('');
+    });
+
+    it('should reflect registry changes after re-scan', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      expect(registry.generatePrompt()).toContain('<name>skill-a</name>');
+
+      // Add another skill and re-scan
+      createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
+      registry.discover();
+
+      const xml = registry.generatePrompt();
+      expect(xml).toContain('<name>skill-a</name>');
+      expect(xml).toContain('<name>skill-b</name>');
+    });
+
+    it('should produce consistent XML across multiple calls', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml1 = registry.generatePrompt();
+      const xml2 = registry.generatePrompt();
+
+      expect(xml1).toBe(xml2);
+    });
+  });
+});

--- a/packages/skills/tests/registry.test.ts
+++ b/packages/skills/tests/registry.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for SkillRegistry
+ *
+ * Covers: constructor auto-discovery, query API (get, getAll, has, size, getNames),
+ * duplicate handling, event system, scan errors, malformed skill recovery.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../src/registry.js';
+import { SkillRegistryEvent } from '../src/types.js';
+
+/**
+ * Create a temp directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-registry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, content: string): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('SkillRegistry', () => {
+  let tempDir: string;
+  let tempDirs: string[] = [];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Constructor and Auto-Discovery', () => {
+    it('should discover skills on construction', () => {
+      createSkillFixture(tempDir, 'my-skill', `---
+name: my-skill
+description: A test skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('my-skill')).toBe(true);
+    });
+
+    it('should handle empty roots', () => {
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should handle non-existent roots without crashing', () => {
+      const registry = new SkillRegistry({ skillRoots: ['/does/not/exist'] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should discover skills from multiple roots', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+      createSkillFixture(root2, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      expect(registry.size()).toBe(2);
+    });
+
+    it('should skip invalid skills without aborting', () => {
+      createSkillFixture(tempDir, 'valid-skill', `---
+name: valid-skill
+description: A valid skill
+---
+body`);
+
+      // Invalid: missing required description
+      createSkillFixture(tempDir, 'invalid-skill', `---
+name: invalid-skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('valid-skill')).toBe(true);
+      expect(registry.has('invalid-skill')).toBe(false);
+    });
+  });
+
+  describe('Query API', () => {
+    let registry: SkillRegistry;
+
+    beforeEach(() => {
+      createSkillFixture(tempDir, 'alpha', `---
+name: alpha
+description: Alpha skill
+license: MIT
+---
+Alpha body`);
+      createSkillFixture(tempDir, 'beta', `---
+name: beta
+description: Beta skill for testing
+---
+Beta body`);
+
+      registry = new SkillRegistry({ skillRoots: [tempDir] });
+    });
+
+    it('should get a skill by name', () => {
+      const skill = registry.get('alpha');
+      expect(skill).toBeDefined();
+      expect(skill!.metadata.name).toBe('alpha');
+      expect(skill!.metadata.description).toBe('Alpha skill');
+    });
+
+    it('should return undefined for non-existent skill', () => {
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should return all skills', () => {
+      const all = registry.getAll();
+      expect(all).toHaveLength(2);
+      const names = all.map(s => s.metadata.name).sort();
+      expect(names).toEqual(['alpha', 'beta']);
+    });
+
+    it('should check if skill exists', () => {
+      expect(registry.has('alpha')).toBe(true);
+      expect(registry.has('gamma')).toBe(false);
+    });
+
+    it('should return correct size', () => {
+      expect(registry.size()).toBe(2);
+    });
+
+    it('should return all skill names', () => {
+      const names = registry.getNames().sort();
+      expect(names).toEqual(['alpha', 'beta']);
+    });
+
+    it('should include optional metadata fields', () => {
+      const skill = registry.get('alpha');
+      expect(skill!.metadata.license).toBe('MIT');
+    });
+
+    it('should include skill path and root path', () => {
+      const skill = registry.get('alpha');
+      expect(skill!.skillPath).toContain('alpha');
+      expect(skill!.rootPath).toBe(tempDir);
+    });
+  });
+
+  describe('Duplicate Handling', () => {
+    it('should keep first root version on duplicate name', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'shared', `---
+name: shared
+description: From root 1
+---
+body1`);
+      createSkillFixture(root2, 'shared', `---
+name: shared
+description: From root 2
+---
+body2`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      expect(registry.size()).toBe(1);
+
+      const skill = registry.get('shared')!;
+      expect(skill.metadata.description).toBe('From root 1');
+      expect(skill.rootPath).toBe(tempDir);
+    });
+
+    it('should emit warning for duplicate', () => {
+      const root2 = createTempDir();
+      tempDirs.push(root2);
+
+      createSkillFixture(tempDir, 'dup', `---
+name: dup
+description: First
+---
+body`);
+      createSkillFixture(root2, 'dup', `---
+name: dup
+description: Second
+---
+body`);
+
+      const warnings: unknown[] = [];
+      // Create registry with pre-registered handler won't work since
+      // discovery happens in constructor. Use getScanErrors instead.
+      const registry = new SkillRegistry({ skillRoots: [tempDir, root2] });
+      const errors = registry.getScanErrors();
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors.some(e => e.error.includes('Duplicate skill name'))).toBe(true);
+    });
+  });
+
+  describe('Name-Directory Mismatch', () => {
+    it('should reject skill where name does not match directory', () => {
+      createSkillFixture(tempDir, 'wrong-dir', `---
+name: my-skill
+description: Name does not match directory
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+      expect(registry.getScanErrors()).toHaveLength(1);
+      expect(registry.getScanErrors()[0].error).toContain('must match parent directory name');
+    });
+  });
+
+  describe('Malformed Skill Recovery', () => {
+    it('should skip skill with malformed YAML', () => {
+      createSkillFixture(tempDir, 'bad-yaml', `---
+name: [broken
+  yaml: {{invalid
+---
+body`);
+
+      createSkillFixture(tempDir, 'good-skill', `---
+name: good-skill
+description: Valid skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+      expect(registry.has('good-skill')).toBe(true);
+    });
+
+    it('should skip skill with empty frontmatter', () => {
+      createSkillFixture(tempDir, 'empty-front', `---
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+
+    it('should skip skill with no frontmatter at all', () => {
+      createSkillFixture(tempDir, 'no-front', `# Just markdown\n\nNo frontmatter here.`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(0);
+    });
+  });
+
+  describe('Event System', () => {
+    it('should emit skill:discovered events', () => {
+      createSkillFixture(tempDir, 'event-skill', `---
+name: event-skill
+description: Triggers events
+---
+body`);
+
+      // We need to register handler before discovery runs.
+      // Since discovery runs in constructor, we use discover() re-scan.
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const discoveredSkills: unknown[] = [];
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, (data) => {
+        discoveredSkills.push(data);
+      });
+
+      // Re-scan to trigger events with our handler
+      registry.discover();
+      expect(discoveredSkills).toHaveLength(1);
+    });
+
+    it('should emit skill:warning events for invalid skills', () => {
+      createSkillFixture(tempDir, 'invalid', `---
+name: invalid
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const warnings: unknown[] = [];
+      registry.on(SkillRegistryEvent.SKILL_WARNING, (data) => {
+        warnings.push(data);
+      });
+
+      registry.discover();
+      expect(warnings).toHaveLength(1);
+    });
+
+    it('should support off() to remove handlers', () => {
+      createSkillFixture(tempDir, 'off-test', `---
+name: off-test
+description: Test off
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      const events: unknown[] = [];
+      const handler = (data: unknown) => events.push(data);
+
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, handler);
+      registry.discover();
+      expect(events).toHaveLength(1);
+
+      registry.off(SkillRegistryEvent.SKILL_DISCOVERED, handler);
+      registry.discover();
+      // Should still be 1, not 2 — handler was removed
+      expect(events).toHaveLength(1);
+    });
+
+    it('should not crash if event handler throws', () => {
+      createSkillFixture(tempDir, 'crash-test', `---
+name: crash-test
+description: Handler will throw
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+      registry.on(SkillRegistryEvent.SKILL_DISCOVERED, () => {
+        throw new Error('Handler exploded!');
+      });
+
+      // Should not throw
+      expect(() => registry.discover()).not.toThrow();
+    });
+  });
+
+  describe('Re-scan (discover)', () => {
+    it('should clear and re-populate on discover()', () => {
+      createSkillFixture(tempDir, 'initial', `---
+name: initial
+description: Initial skill
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+
+      // Add another skill on disk
+      createSkillFixture(tempDir, 'added', `---
+name: added
+description: Added after init
+---
+body`);
+
+      registry.discover();
+      expect(registry.size()).toBe(2);
+      expect(registry.has('added')).toBe(true);
+    });
+
+    it('should reflect removed skills after re-scan', () => {
+      createSkillFixture(tempDir, 'to-remove', `---
+name: to-remove
+description: Will be removed
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.size()).toBe(1);
+
+      // Remove from disk
+      rmSync(join(tempDir, 'to-remove'), { recursive: true, force: true });
+
+      registry.discover();
+      expect(registry.size()).toBe(0);
+    });
+  });
+
+  describe('getScanErrors', () => {
+    it('should return empty array on clean scan', () => {
+      createSkillFixture(tempDir, 'clean', `---
+name: clean
+description: No issues
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      expect(registry.getScanErrors()).toEqual([]);
+    });
+
+    it('should collect parse errors', () => {
+      createSkillFixture(tempDir, 'broken', `---
+name: UPPERCASE
+description: Bad name
+---
+body`);
+
+      const registry = new SkillRegistry({ skillRoots: [tempDir] });
+      const errors = registry.getScanErrors();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].path).toContain('broken');
+    });
+  });
+});

--- a/packages/skills/tests/scanner.test.ts
+++ b/packages/skills/tests/scanner.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for Skill Directory Scanner
+ *
+ * Covers: scanSkillRoot, scanAllSkillRoots, expandHome
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  scanSkillRoot,
+  scanAllSkillRoots,
+  expandHome,
+} from '../src/scanner.js';
+
+/**
+ * Create a temporary directory for test fixtures.
+ */
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Create a skill directory with a SKILL.md file under a given root.
+ */
+function createSkillFixture(root: string, dirName: string, content: string): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+describe('expandHome', () => {
+  it('should expand ~ to home directory', () => {
+    const result = expandHome('~/some/path');
+    expect(result).not.toContain('~');
+    expect(result).toContain('some/path');
+  });
+
+  it('should leave absolute paths unchanged', () => {
+    expect(expandHome('/foo/bar')).toBe('/foo/bar');
+  });
+
+  it('should leave relative paths unchanged', () => {
+    const result = expandHome('./relative/path');
+    expect(result).toContain('relative/path');
+  });
+});
+
+describe('scanSkillRoot', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return empty array for non-existent root', () => {
+    const result = scanSkillRoot('/non/existent/path/that/does/not/exist');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array for empty root', () => {
+    tempDir = createTempDir();
+    const result = scanSkillRoot(tempDir);
+    expect(result).toEqual([]);
+  });
+
+  it('should discover a valid skill directory', () => {
+    tempDir = createTempDir();
+    createSkillFixture(tempDir, 'my-skill', `---
+name: my-skill
+description: A test skill
+---
+# My Skill`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].dirName).toBe('my-skill');
+    expect(result[0].content).toContain('name: my-skill');
+    expect(result[0].rootPath).toBe(tempDir);
+  });
+
+  it('should discover multiple skills', () => {
+    tempDir = createTempDir();
+    createSkillFixture(tempDir, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+    createSkillFixture(tempDir, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(2);
+
+    const names = result.map(c => c.dirName).sort();
+    expect(names).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('should skip directories without SKILL.md', () => {
+    tempDir = createTempDir();
+    mkdirSync(join(tempDir, 'no-skill-dir'), { recursive: true });
+    writeFileSync(join(tempDir, 'no-skill-dir', 'README.md'), 'not a skill', 'utf-8');
+
+    createSkillFixture(tempDir, 'valid-skill', `---
+name: valid-skill
+description: Valid
+---
+body`);
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].dirName).toBe('valid-skill');
+  });
+
+  it('should skip files at root level (not directories)', () => {
+    tempDir = createTempDir();
+    writeFileSync(join(tempDir, 'README.md'), '# Not a skill', 'utf-8');
+
+    const result = scanSkillRoot(tempDir);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('scanAllSkillRoots', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it('should scan multiple roots', () => {
+    const root1 = createTempDir();
+    const root2 = createTempDir();
+    tempDirs.push(root1, root2);
+
+    createSkillFixture(root1, 'skill-a', `---
+name: skill-a
+description: Skill A
+---
+body`);
+    createSkillFixture(root2, 'skill-b', `---
+name: skill-b
+description: Skill B
+---
+body`);
+
+    const result = scanAllSkillRoots([root1, root2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('should handle mix of existing and non-existing roots', () => {
+    const root1 = createTempDir();
+    tempDirs.push(root1);
+
+    createSkillFixture(root1, 'my-skill', `---
+name: my-skill
+description: A skill
+---
+body`);
+
+    const result = scanAllSkillRoots([root1, '/does/not/exist']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('should return empty for all non-existing roots', () => {
+    const result = scanAllSkillRoots(['/nonexistent1', '/nonexistent2']);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/skills/tests/trust.test.ts
+++ b/packages/skills/tests/trust.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Tests for Skill Trust Policies and Execution Guardrails
+ *
+ * Covers:
+ * - Trust policy configuration model (workspace, trusted, untrusted)
+ * - normalizeRootConfig() — string and object root normalization
+ * - isScriptResource() — script path detection
+ * - evaluateTrustPolicy() — policy engine logic for all trust levels
+ * - read-skill-resource trust enforcement (scripts blocked from untrusted roots)
+ * - allowUntrustedScripts override
+ * - Trust policy events (TRUST_POLICY_DENIED, TRUST_POLICY_ALLOWED)
+ * - getAllowedTools() API
+ * - Security regression: path traversal + untrusted script denial + policy bypass
+ * - Backward compatibility: plain string roots default to untrusted
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillRegistry } from '../src/registry.js';
+import { SkillRegistryEvent, TrustPolicyReason } from '../src/types.js';
+import type { TrustLevel } from '../src/types.js';
+import {
+  evaluateTrustPolicy,
+  isScriptResource,
+  normalizeRootConfig,
+} from '../src/trust.js';
+import {
+  createReadSkillResourceTool,
+} from '../src/activation.js';
+
+// ─── Fixture Helpers ─────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `skill-trust-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createSkillFixture(
+  root: string,
+  dirName: string,
+  frontmatter: string,
+  body: string,
+): string {
+  const skillDir = join(root, dirName);
+  mkdirSync(skillDir, { recursive: true });
+  const content = `---\n${frontmatter}\n---\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+function createResourceFile(skillDir: string, relativePath: string, content: string): string {
+  const fullPath = join(skillDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+// ─── normalizeRootConfig ─────────────────────────────────────────────────
+
+describe('normalizeRootConfig', () => {
+  it('should convert a plain string to untrusted SkillRootConfig', () => {
+    const result = normalizeRootConfig('/some/path');
+    expect(result).toEqual({ path: '/some/path', trust: 'untrusted' });
+  });
+
+  it('should pass through SkillRootConfig objects unchanged', () => {
+    const input = { path: '/some/path', trust: 'trusted' as TrustLevel };
+    const result = normalizeRootConfig(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should normalize workspace trust level', () => {
+    const result = normalizeRootConfig({ path: '.agentskills', trust: 'workspace' });
+    expect(result.trust).toBe('workspace');
+  });
+});
+
+// ─── isScriptResource ────────────────────────────────────────────────────
+
+describe('isScriptResource', () => {
+  it('should return true for scripts/ prefix', () => {
+    expect(isScriptResource('scripts/setup.sh')).toBe(true);
+  });
+
+  it('should return true for nested scripts/ paths', () => {
+    expect(isScriptResource('scripts/init/bootstrap.sh')).toBe(true);
+  });
+
+  it('should return true for exact "scripts" path', () => {
+    expect(isScriptResource('scripts')).toBe(true);
+  });
+
+  it('should return false for references/ prefix', () => {
+    expect(isScriptResource('references/guide.md')).toBe(false);
+  });
+
+  it('should return false for assets/ prefix', () => {
+    expect(isScriptResource('assets/logo.png')).toBe(false);
+  });
+
+  it('should return false for root-level files', () => {
+    expect(isScriptResource('README.md')).toBe(false);
+  });
+
+  it('should return false for paths containing "scripts" but not as prefix', () => {
+    expect(isScriptResource('references/scripts-guide.md')).toBe(false);
+  });
+
+  it('should handle backslash separators', () => {
+    expect(isScriptResource('scripts\\setup.sh')).toBe(true);
+  });
+
+  it('should detect scripts with leading ./ prefix', () => {
+    expect(isScriptResource('./scripts/setup.sh')).toBe(true);
+  });
+
+  it('should detect scripts case-insensitively', () => {
+    expect(isScriptResource('Scripts/setup.sh')).toBe(true);
+    expect(isScriptResource('SCRIPTS/SETUP.SH')).toBe(true);
+  });
+
+  it('should handle collapsed repeated separators', () => {
+    expect(isScriptResource('scripts//setup.sh')).toBe(true);
+  });
+
+  it('should handle leading whitespace', () => {
+    expect(isScriptResource('  scripts/setup.sh')).toBe(true);
+  });
+
+  it('should detect exact "Scripts" path case-insensitively', () => {
+    expect(isScriptResource('Scripts')).toBe(true);
+  });
+});
+
+// ─── evaluateTrustPolicy ─────────────────────────────────────────────────
+
+describe('evaluateTrustPolicy', () => {
+  describe('non-script resources', () => {
+    it('should allow references/ from any trust level', () => {
+      for (const trust of ['workspace', 'trusted', 'untrusted'] as TrustLevel[]) {
+        const decision = evaluateTrustPolicy('references/guide.md', trust);
+        expect(decision.allowed).toBe(true);
+        expect(decision.reason).toBe(TrustPolicyReason.NOT_SCRIPT);
+      }
+    });
+
+    it('should allow assets/ from untrusted roots', () => {
+      const decision = evaluateTrustPolicy('assets/logo.png', 'untrusted');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.NOT_SCRIPT);
+    });
+
+    it('should allow root-level files from untrusted roots', () => {
+      const decision = evaluateTrustPolicy('README.md', 'untrusted');
+      expect(decision.allowed).toBe(true);
+    });
+  });
+
+  describe('workspace trust', () => {
+    it('should allow scripts from workspace roots', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'workspace');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.WORKSPACE_TRUST);
+    });
+
+    it('should include descriptive message', () => {
+      const decision = evaluateTrustPolicy('scripts/run.sh', 'workspace');
+      expect(decision.message).toContain('workspace trust');
+    });
+  });
+
+  describe('trusted roots', () => {
+    it('should allow scripts from trusted roots', () => {
+      const decision = evaluateTrustPolicy('scripts/deploy.sh', 'trusted');
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.TRUSTED_ROOT);
+    });
+  });
+
+  describe('untrusted roots', () => {
+    it('should deny scripts from untrusted roots by default', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted');
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED);
+    });
+
+    it('should include remediation guidance in denial message', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted');
+      expect(decision.message).toContain('allowUntrustedScripts');
+      expect(decision.message).toContain('trusted');
+      expect(decision.message).toContain('workspace');
+    });
+
+    it('should allow scripts when allowUntrustedScripts override is true', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted', true);
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_ALLOWED);
+    });
+
+    it('should deny scripts when allowUntrustedScripts is false', () => {
+      const decision = evaluateTrustPolicy('scripts/setup.sh', 'untrusted', false);
+      expect(decision.allowed).toBe(false);
+    });
+  });
+});
+
+// ─── Trust enforcement integration (read-skill-resource) ─────────────────
+
+describe('read-skill-resource trust enforcement', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should allow non-script resources from untrusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Guide');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // default untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+    expect(result).toBe('# Guide');
+  });
+
+  it('should deny script resources from untrusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\nrm -rf /');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // default untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toContain('Script access denied');
+    expect(result).toContain('untrusted');
+  });
+
+  it('should allow script resources from workspace roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho hello');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho hello');
+  });
+
+  it('should allow script resources from trusted roots', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho hello');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'trusted' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho hello');
+  });
+
+  it('should allow untrusted scripts when allowUntrustedScripts is true', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho ok');
+
+    const registry = new SkillRegistry({
+      skillRoots: [tempDir], // default untrusted
+      allowUntrustedScripts: true,
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+    expect(result).toBe('#!/bin/bash\necho ok');
+  });
+
+  it('should emit TRUST_POLICY_DENIED event when script is blocked', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', 'danger');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.name).toBe('my-skill');
+    expect(event.resourcePath).toBe('scripts/setup.sh');
+    expect(event.trustLevel).toBe('untrusted');
+    expect(event.reason).toBe(TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED);
+  });
+
+  it('should emit TRUST_POLICY_ALLOWED event for trusted scripts', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/setup.sh', '#!/bin/bash\necho ok');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'scripts/setup.sh' });
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as Record<string, unknown>;
+    expect(event.name).toBe('my-skill');
+    expect(event.reason).toBe(TrustPolicyReason.WORKSPACE_TRUST);
+  });
+
+  it('should not emit TRUST_POLICY_ALLOWED for non-script resources', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'references/guide.md', '# Guide');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const events: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, (data) => events.push(data));
+
+    const tool = createReadSkillResourceTool(registry);
+    await tool.invoke({ name: 'my-skill', path: 'references/guide.md' });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should handle mixed trust levels across roots', async () => {
+    const trustedRoot = createTempDir();
+    const untrustedRoot = createTempDir();
+    tempDirs.push(trustedRoot, untrustedRoot);
+
+    const trustedSkillDir = createSkillFixture(trustedRoot, 'trusted-skill', 'name: trusted-skill\ndescription: Trusted', '\nbody');
+    createResourceFile(trustedSkillDir, 'scripts/deploy.sh', '#!/bin/bash\ndeploy');
+
+    const untrustedSkillDir = createSkillFixture(untrustedRoot, 'community-skill', 'name: community-skill\ndescription: Community', '\nbody');
+    createResourceFile(untrustedSkillDir, 'scripts/setup.sh', '#!/bin/bash\nsetup');
+
+    const registry = new SkillRegistry({
+      skillRoots: [
+        { path: trustedRoot, trust: 'trusted' },
+        { path: untrustedRoot, trust: 'untrusted' },
+      ],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    // Trusted skill — scripts allowed
+    const trustedResult = await tool.invoke({ name: 'trusted-skill', path: 'scripts/deploy.sh' });
+    expect(trustedResult).toContain('deploy');
+
+    // Untrusted skill — scripts denied
+    const untrustedResult = await tool.invoke({ name: 'community-skill', path: 'scripts/setup.sh' });
+    expect(untrustedResult).toContain('Script access denied');
+  });
+});
+
+// ─── Security regression tests ───────────────────────────────────────────
+
+describe('Security regression — trust policy', () => {
+  let tempDir: string;
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    tempDirs = [tempDir];
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should block path traversal even with trusted roots', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '../../../etc/passwd' });
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should block absolute paths even with trusted roots', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: '/etc/passwd' });
+    expect(result).toContain('Absolute resource paths');
+  });
+
+  it('should deny nested scripts/ path from untrusted root', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/nested/deep.sh', '#!/bin/bash\nrm -rf /');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] }); // untrusted
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/nested/deep.sh' });
+    expect(result).toContain('Script access denied');
+  });
+
+  it('should not bypass trust via path tricks like scripts/../scripts/file', async () => {
+    // '../' is caught by path traversal check before trust policy
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts/run.sh', 'danger');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts/../scripts/run.sh' });
+    expect(result).toContain('Path traversal');
+  });
+
+  it('should deny "scripts" path (no trailing slash) from untrusted root', async () => {
+    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    createResourceFile(skillDir, 'scripts', 'file-named-scripts');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+
+    const result = await tool.invoke({ name: 'my-skill', path: 'scripts' });
+    expect(result).toContain('Script access denied');
+  });
+});
+
+// ─── getAllowedTools ─────────────────────────────────────────────────────
+
+describe('SkillRegistry.getAllowedTools()', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return allowedTools from frontmatter', () => {
+    createSkillFixture(tempDir, 'code-review',
+      'name: code-review\ndescription: Code review\nallowed-tools:\n  - read_file\n  - grep_search',
+      '\n# Code Review');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('code-review');
+
+    expect(allowed).toEqual(['read_file', 'grep_search']);
+  });
+
+  it('should return undefined for skills without allowed-tools', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('my-skill');
+
+    expect(allowed).toBeUndefined();
+  });
+
+  it('should return undefined for non-existent skills', () => {
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const allowed = registry.getAllowedTools('nonexistent');
+
+    expect(allowed).toBeUndefined();
+  });
+});
+
+// ─── Backward compatibility ──────────────────────────────────────────────
+
+describe('Backward compatibility', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should accept plain string roots and default to untrusted', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const skill = registry.get('my-skill');
+
+    expect(skill).toBeDefined();
+    expect(skill!.trustLevel).toBe('untrusted');
+  });
+
+  it('should accept mixed string and config objects', () => {
+    const root2 = createTempDir();
+
+    createSkillFixture(tempDir, 'skill-a', 'name: skill-a\ndescription: A', '\nbody');
+    createSkillFixture(root2, 'skill-b', 'name: skill-b\ndescription: B', '\nbody');
+
+    const registry = new SkillRegistry({
+      skillRoots: [
+        tempDir,  // plain string → untrusted
+        { path: root2, trust: 'workspace' },
+      ],
+    });
+
+    expect(registry.get('skill-a')!.trustLevel).toBe('untrusted');
+    expect(registry.get('skill-b')!.trustLevel).toBe('workspace');
+
+    rmSync(root2, { recursive: true, force: true });
+  });
+
+  it('should preserve all existing SkillRegistry query APIs', () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    expect(registry.get('my-skill')).toBeDefined();
+    expect(registry.has('my-skill')).toBe(true);
+    expect(registry.size()).toBe(1);
+    expect(registry.getNames()).toEqual(['my-skill']);
+    expect(registry.getAll().length).toBe(1);
+    expect(registry.getScanErrors().length).toBe(0);
+  });
+});

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -114,22 +114,35 @@
 **Branch:** `feat/st-07004-migrate-skills-tests`
 
 ### Checklist
-- [ ] Create branch `feat/st-07004-migrate-skills-tests`
-- [ ] Create draft PR with story ID in title
-- [ ] Move skills unit tests from `packages/core/` to `packages/skills/tests/`
-  - parser tests (34), scanner tests (10), registry tests (27), prompt tests (23), activation tests (40), trust tests (41)
-- [ ] Move conformance suite (35 tests) to `packages/skills/tests/`
-- [ ] Move fixture skill packs to `packages/skills/tests/fixtures/`
-- [ ] Update test imports from `@agentforge/core` skills paths to `@agentforge/skills` or relative paths
-- [ ] Verify no test files referencing skills remain in `packages/core/tests/`
-- [ ] Run `pnpm test --run` — same test count, 0 regressions
-- [ ] Verify conformance suite runs within the skills package
-- [ ] Add or update story documentation at `docs/st07004-migrate-skills-tests.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create branch `feat/st-07004-migrate-skills-tests`
+- [x] Create draft PR with story ID in title
+  - PR #55: https://github.com/TVScoundrel/agentforge/pull/55
+- [x] Move skills unit tests from `packages/core/` to `packages/skills/tests/`
+  - parser tests (34), scanner tests (10), registry tests (27), prompt tests (23), activation tests (40), trust tests (46)
+  - Restored from git history (deleted in ST-07003), placed in `packages/skills/tests/`
+- [x] Move conformance suite (35 tests) to `packages/skills/tests/`
+- [x] Move fixture skill packs to `packages/skills/tests/fixtures/`
+  - 3 malformed fixtures, 1 untrusted fixture (with references + scripts), 2 valid fixtures (with references + scripts)
+- [x] Update test imports from `@agentforge/core` skills paths to `@agentforge/skills` or relative paths
+  - `../../src/skills/*` → `../src/*` (15 import statements across 7 files)
+  - `../../src/tools/types.js` → `@agentforge/core` (2 import statements in activation.test.ts, conformance.test.ts)
+- [x] Verify no test files referencing skills remain in `packages/core/tests/`
+  - Confirmed: no files matching `*skill*` or `*trust*`, no `grep` hits for "skills"
+- [x] Run `pnpm test --run` — same test count, 0 regressions
+  - 159 passed | 1 skipped (160 files); 2337 passed | 17 skipped (2354 tests); 0 failures
+  - Test count matches pre-ST-07003 baseline (215 skills tests restored)
+- [x] Verify conformance suite runs within the skills package
+  - `pnpm test --run --project skills` — 7 passed (7 files), 215 passed (215 tests)
+- [x] Add or update story documentation at `docs/st07004-migrate-skills-tests.md` (or document why not required)
+  - Not required — straightforward file migration with import updates, no architectural decisions. Checklist captures all details.
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - This story IS the test migration. All 215 tests restored and passing in new location.
+- [x] Update `docs-site/changelog.md` `[Unreleased]` section with changes from this story (or document why not applicable)
+- [x] Run full test suite before finalizing the PR and record results
+  - 159 passed | 1 skipped (160 files); 2337 passed | 17 skipped (2354 tests); 0 failures
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - 0 errors, 109 warnings (all pre-existing `@typescript-eslint/no-explicit-any`)
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-07-story-tasks.md
+++ b/planning/checklists/epic-07-story-tasks.md
@@ -118,7 +118,7 @@
 - [x] Create draft PR with story ID in title
   - PR #55: https://github.com/TVScoundrel/agentforge/pull/55
 - [x] Move skills unit tests from `packages/core/` to `packages/skills/tests/`
-  - parser tests (34), scanner tests (10), registry tests (27), prompt tests (23), activation tests (40), trust tests (46)
+  - parser tests (32), scanner tests (12), registry tests (27), prompt tests (23), activation tests (40), trust tests (46)
   - Restored from git history (deleted in ST-07003), placed in `packages/skills/tests/`
 - [x] Move conformance suite (35 tests) to `packages/skills/tests/`
 - [x] Move fixture skill packs to `packages/skills/tests/fixtures/`

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 stories
+- **In Progress:** 1 stories
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 1 stories
@@ -20,11 +20,16 @@
 - **Estimate:** 2 hours
 - **Dependencies:** ST-07001 (merged)
 
+---
+
+## In Progress
+
 ### ST-07004: Migrate Tests and Fixtures
 - **Epic:** EP-07
 - **Priority:** P0 (Critical)
 - **Estimate:** 4 hours
 - **Dependencies:** ST-07002 (merged)
+- **PR:** #55
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 stories
-- **In Progress:** 1 stories
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 stories
 - **Blocked:** 0 stories
 - **Backlog:** 1 stories
 
@@ -23,6 +23,12 @@
 ---
 
 ## In Progress
+
+_No stories currently in progress_
+
+---
+
+## In Review
 
 ### ST-07004: Migrate Tests and Fixtures
 - **Epic:** EP-07


### PR DESCRIPTION
## ST-07004: Migrate Tests and Fixtures

### Story
Migrate all skills test files (215 tests across 7 files) and fixture skill packs from `packages/core/tests/skills/` to `packages/skills/tests/`, completing the test side of the skills extraction (EP-07).

### What Changed

**Test files migrated** (restored from git history — deleted in ST-07003, now in `packages/skills/tests/`):
- `activation.test.ts` — 40 tests (skill activation tools, resource loading, path security)
- `conformance.test.ts` — 35 tests (fixture-based conformance suite against committed skill packs)
- `parser.test.ts` — 34 tests (SKILL.md YAML frontmatter parsing and validation)
- `prompt.test.ts` — 23 tests (generatePrompt XML output, filtering, escaping)
- `registry.test.ts` — 27 tests (SkillRegistry lifecycle, scanning, query API)
- `scanner.test.ts` — 10 tests (filesystem scanning, home expansion, multi-root)
- `trust.test.ts` — 46 tests (trust policies, script detection, resource blocking)

**Fixture skill packs migrated** to `packages/skills/tests/fixtures/`:
- `valid/` — code-review, test-generator (with references + scripts)
- `malformed/` — bad-frontmatter, name-mismatch, no-frontmatter
- `untrusted/` — community-tool (with references + scripts)

**Import updates** (15 skills imports + 2 core imports across 7 files):
- `../../src/skills/*` → `../src/*` (relative to new test location)
- `../../src/tools/types.js` → `@agentforge/core` (ToolCategory enum)

### Acceptance Criteria Coverage
- ✅ All 7 skills test files migrated to `packages/skills/tests/`
- ✅ All fixture skill packs migrated to `packages/skills/tests/fixtures/`
- ✅ Test imports updated to correct relative/package paths
- ✅ No skills test files or references remain in `packages/core/tests/`
- ✅ Conformance suite runs within skills package (215/215 pass)
- ✅ Full test count restored to pre-ST-07003 baseline (2337 tests)

### Validation Performed
- `pnpm test --run --project skills` → **7 files passed, 215 tests passed**
- `pnpm test --run` → **159 passed | 1 skipped (160 files); 2337 passed | 17 skipped (2354 tests); 0 failures**
- `pnpm lint` → **0 errors, 109 warnings** (all pre-existing `@typescript-eslint/no-explicit-any`)
- `pnpm -r build` → all 6 packages build successfully (ESM+CJS+DTS)
- `grep -rl "skills" packages/core/tests/` → no matches (core is clean)

### Status
Ready for review.

