### PR TITLE
ST-08002: Hardening Pass 1 for @agentforge/core Runtime Hotspots

### DIFF
--- a/docs/st08002-core-runtime-type-hardening.md
+++ b/docs/st08002-core-runtime-type-hardening.md
@@ -1,0 +1,70 @@
+# ST-08002: Core Runtime Type Hardening (Pass 1)
+
+## Summary
+
+Reduced explicit `any` usage in core runtime hotspots by replacing broad `any` types with `unknown`-first boundaries, typed helper aliases, and explicit narrowing where schema metadata is inspected.
+
+## Scope
+
+- `packages/core/src/tools/registry.ts`
+- `packages/core/src/tools/executor.ts`
+- `packages/core/src/resources/http-pool.ts`
+
+## Type Design Decisions
+
+### `tools/registry.ts`
+- Introduced `RegistryTool = Tool<unknown, unknown>` as the default runtime-safe tool shape for storage/query operations.
+- Changed event payload and handlers from `any` to `unknown`.
+- Replaced direct schema `as any` internals access with a typed `getSchemaShape()` helper using `z.ZodObject` narrowing.
+
+### `tools/executor.ts`
+- Replaced `any`-based tool/input/result callbacks with an `ExecutableTool` interface and `unknown` boundaries.
+- Added `toError()` normalization to handle thrown non-`Error` values safely while preserving retry/error hooks.
+- Updated queue and execution signatures to return `unknown`/`unknown[]` instead of `any`.
+
+### `resources/http-pool.ts`
+- Replaced `any` defaults with `unknown` and added generic request payload typing via `RequestConfig<TData>`.
+- Updated `HttpClient` method signatures (`post`, `put`, `request`) to carry typed request payloads without `any`.
+- Preserved runtime behavior (mock client still returns `200 OK` with typed response envelope).
+
+## Warning Count Delta (`@typescript-eslint/no-explicit-any`)
+
+Captured via:
+
+```bash
+pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/executor.ts packages/core/src/resources/http-pool.ts -f json
+```
+
+### Per file
+
+- `packages/core/src/tools/registry.ts`: `25 -> 0`
+- `packages/core/src/tools/executor.ts`: `21 -> 0`
+- `packages/core/src/resources/http-pool.ts`: `18 -> 0`
+
+### Total reduction in targeted files
+
+- `64` warnings removed
+
+### Baseline impact (`src/**`)
+
+From `pnpm lint:explicit-any:baseline`:
+
+- `core: 256 -> 192` (`-64`)
+- Workspace total: `496 -> 432` (`-64`)
+
+## Validation
+
+Commands run:
+
+```bash
+pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/executor.ts packages/core/src/resources/http-pool.ts packages/core/tests/resources/http-pool.test.ts
+pnpm --filter @agentforge/core typecheck
+pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/executor.test.ts packages/core/tests/resources/http-pool.test.ts
+pnpm lint:explicit-any:baseline
+```
+
+Results:
+
+- Lint/typecheck passed for touched code.
+- Focused tests passed (`58` tests across touched core areas).
+- Baseline gate passed and reported improvement.

--- a/docs/st08002-core-runtime-type-hardening.md
+++ b/docs/st08002-core-runtime-type-hardening.md
@@ -68,3 +68,11 @@ Results:
 - Lint/typecheck passed for touched code.
 - Focused tests passed (`58` tests across touched core areas).
 - Baseline gate passed and reported improvement.
+
+## Finalization Gates
+
+- `pnpm test --run`:
+  - `146` passed | `16` skipped (test files)
+  - `2073` passed | `286` skipped (tests)
+- `pnpm lint`:
+  - Passed with warnings-only output (0 errors).

--- a/packages/core/src/resources/http-pool.ts
+++ b/packages/core/src/resources/http-pool.ts
@@ -19,24 +19,32 @@ export interface HttpPoolConfig extends PoolConfig {
 }
 
 export interface HttpClient {
-  get<T = any>(url: string, config?: RequestConfig): Promise<HttpResponse<T>>;
-  post<T = any>(url: string, data?: any, config?: RequestConfig): Promise<HttpResponse<T>>;
-  put<T = any>(url: string, data?: any, config?: RequestConfig): Promise<HttpResponse<T>>;
-  delete<T = any>(url: string, config?: RequestConfig): Promise<HttpResponse<T>>;
-  request<T = any>(config: RequestConfig): Promise<HttpResponse<T>>;
+  get<T = unknown>(url: string, config?: RequestConfig): Promise<HttpResponse<T>>;
+  post<T = unknown, TData = unknown>(
+    url: string,
+    data?: TData,
+    config?: RequestConfig<TData>
+  ): Promise<HttpResponse<T>>;
+  put<T = unknown, TData = unknown>(
+    url: string,
+    data?: TData,
+    config?: RequestConfig<TData>
+  ): Promise<HttpResponse<T>>;
+  delete<T = unknown>(url: string, config?: RequestConfig): Promise<HttpResponse<T>>;
+  request<T = unknown, TData = unknown>(config: RequestConfig<TData>): Promise<HttpResponse<T>>;
   close(): Promise<void>;
 }
 
-export interface RequestConfig {
+export interface RequestConfig<TData = unknown> {
   url?: string;
   method?: string;
   headers?: Record<string, string>;
-  params?: Record<string, any>;
-  data?: any;
+  params?: Record<string, unknown>;
+  data?: TData;
   timeout?: number;
 }
 
-export interface HttpResponse<T = any> {
+export interface HttpResponse<T = unknown> {
   data: T;
   status: number;
   statusText: string;
@@ -61,25 +69,35 @@ export interface HttpPoolOptions {
 class MockHttpClient implements HttpClient {
   private closed = false;
 
-  constructor(private config: HttpConfig) {}
+  constructor(private readonly _config: HttpConfig) {}
 
-  async get<T = any>(url: string, config?: RequestConfig): Promise<HttpResponse<T>> {
+  async get<T = unknown>(url: string, config?: RequestConfig): Promise<HttpResponse<T>> {
     return this.request<T>({ ...config, url, method: 'GET' });
   }
 
-  async post<T = any>(url: string, data?: any, config?: RequestConfig): Promise<HttpResponse<T>> {
+  async post<T = unknown, TData = unknown>(
+    url: string,
+    data?: TData,
+    config?: RequestConfig<TData>
+  ): Promise<HttpResponse<T>> {
     return this.request<T>({ ...config, url, method: 'POST', data });
   }
 
-  async put<T = any>(url: string, data?: any, config?: RequestConfig): Promise<HttpResponse<T>> {
+  async put<T = unknown, TData = unknown>(
+    url: string,
+    data?: TData,
+    config?: RequestConfig<TData>
+  ): Promise<HttpResponse<T>> {
     return this.request<T>({ ...config, url, method: 'PUT', data });
   }
 
-  async delete<T = any>(url: string, config?: RequestConfig): Promise<HttpResponse<T>> {
+  async delete<T = unknown>(url: string, config?: RequestConfig): Promise<HttpResponse<T>> {
     return this.request<T>({ ...config, url, method: 'DELETE' });
   }
 
-  async request<T = any>(config: RequestConfig): Promise<HttpResponse<T>> {
+  async request<T = unknown, TData = unknown>(
+    _config: RequestConfig<TData>
+  ): Promise<HttpResponse<T>> {
     if (this.closed) {
       throw new Error('Client is closed');
     }
@@ -139,7 +157,9 @@ export class HttpPool {
     return this.pool.release(client);
   }
 
-  async request<T = any>(config: RequestConfig): Promise<HttpResponse<T>> {
+  async request<T = unknown, TData = unknown>(
+    config: RequestConfig<TData>
+  ): Promise<HttpResponse<T>> {
     const client = await this.acquire();
     try {
       return await client.request<T>(config);
@@ -164,4 +184,3 @@ export class HttpPool {
 export function createHttpPool(options: HttpPoolOptions): HttpPool {
   return new HttpPool(options);
 }
-

--- a/packages/core/src/tools/executor.ts
+++ b/packages/core/src/tools/executor.ts
@@ -61,7 +61,7 @@ interface QueuedExecution extends ToolExecution {
   timestamp: number;
 }
 
-interface ExecutableTool<TInput = unknown, TOutput = unknown> {
+export interface ExecutableTool<TInput = unknown, TOutput = unknown> {
   metadata?: {
     name?: string;
   };
@@ -228,6 +228,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       return result;
     } catch (error) {
       const duration = Date.now() - startTime;
+      const normalizedError = toError(error);
 
       // Update metrics
       metrics.totalExecutions++;
@@ -236,9 +237,8 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       metrics.averageDuration = metrics.totalDuration / metrics.totalExecutions;
       metrics.byPriority[priority]++;
 
-      onExecutionError?.(tool, input, toError(error), duration);
-
-      throw error;
+      onExecutionError?.(tool, input, normalizedError, duration);
+      throw normalizedError;
     }
   }
 

--- a/packages/core/src/tools/executor.ts
+++ b/packages/core/src/tools/executor.ts
@@ -23,15 +23,25 @@ export interface ToolExecutorConfig {
   maxConcurrent?: number;
   timeout?: number;
   retryPolicy?: RetryPolicy;
-  priorityFn?: (tool: any) => Priority;
-  onExecutionStart?: (tool: any, input: any) => void;
-  onExecutionComplete?: (tool: any, input: any, result: any, duration: number) => void;
-  onExecutionError?: (tool: any, input: any, error: Error, duration: number) => void;
+  priorityFn?: (tool: ExecutableTool) => Priority;
+  onExecutionStart?: (tool: ExecutableTool, input: unknown) => void;
+  onExecutionComplete?: (
+    tool: ExecutableTool,
+    input: unknown,
+    result: unknown,
+    duration: number
+  ) => void;
+  onExecutionError?: (
+    tool: ExecutableTool,
+    input: unknown,
+    error: Error,
+    duration: number
+  ) => void;
 }
 
 export interface ToolExecution {
-  tool: any;
-  input: any;
+  tool: ExecutableTool;
+  input: unknown;
   priority?: Priority;
 }
 
@@ -45,10 +55,18 @@ export interface ExecutionMetrics {
 }
 
 interface QueuedExecution extends ToolExecution {
-  resolve: (value: any) => void;
+  resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   priority: Priority;
   timestamp: number;
+}
+
+interface ExecutableTool<TInput = unknown, TOutput = unknown> {
+  metadata?: {
+    name?: string;
+  };
+  invoke?: (input: TInput) => Promise<TOutput>;
+  execute?: (input: TInput) => Promise<TOutput>;
 }
 
 const PRIORITY_ORDER: Record<Priority, number> = {
@@ -106,14 +124,22 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
     return Math.min(delay, maxDelay);
   }
 
+  function toError(error: unknown): Error {
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error(String(error));
+  }
+
   /**
    * Execute a tool with retry logic
    */
   async function executeWithRetry(
-    tool: any,
-    input: any,
+    tool: ExecutableTool,
+    input: unknown,
     policy?: RetryPolicy
-  ): Promise<any> {
+  ): Promise<unknown> {
     // Require invoke() as the primary method (industry standard)
     // Fall back to execute() only for backward compatibility with tools created before v0.11.0
     const executeFn = tool.invoke || tool.execute;
@@ -144,7 +170,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       try {
         return await executeFn.call(tool, input);
       } catch (error) {
-        lastError = error as Error;
+        lastError = toError(error);
 
         // Check if error is retryable
         if (policy.retryableErrors && policy.retryableErrors.length > 0) {
@@ -171,10 +197,10 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
    * Execute a single tool
    */
   async function executeSingle(
-    tool: any,
-    input: any,
+    tool: ExecutableTool,
+    input: unknown,
     priority: Priority
-  ): Promise<any> {
+  ): Promise<unknown> {
     const startTime = Date.now();
 
     try {
@@ -210,7 +236,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       metrics.averageDuration = metrics.totalDuration / metrics.totalExecutions;
       metrics.byPriority[priority]++;
 
-      onExecutionError?.(tool, input, error as Error, duration);
+      onExecutionError?.(tool, input, toError(error), duration);
 
       throw error;
     }
@@ -252,10 +278,10 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
    * Execute a tool
    */
   async function execute(
-    tool: any,
-    input: any,
+    tool: ExecutableTool,
+    input: unknown,
     options: { priority?: Priority } = {}
-  ): Promise<any> {
+  ): Promise<unknown> {
     const priority = options.priority || priorityFn(tool);
 
     return new Promise((resolve, reject) => {
@@ -275,7 +301,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
   /**
    * Execute multiple tools in parallel
    */
-  async function executeParallel(executions: ToolExecution[]): Promise<any[]> {
+  async function executeParallel(executions: ToolExecution[]): Promise<unknown[]> {
     return Promise.all(
       executions.map((exec) =>
         execute(exec.tool, exec.input, { priority: exec.priority })
@@ -321,5 +347,3 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
     getQueueStatus,
   };
 }
-
-

--- a/packages/core/src/tools/executor.ts
+++ b/packages/core/src/tools/executor.ts
@@ -165,20 +165,27 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       return await executeFn.call(tool, input);
     }
 
+    if (!Number.isInteger(policy.maxAttempts) || policy.maxAttempts < 1) {
+      throw new Error(
+        `Invalid retry policy: maxAttempts must be an integer >= 1 (received ${String(policy.maxAttempts)})`
+      );
+    }
+
     let lastError: Error | undefined;
     for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
       try {
         return await executeFn.call(tool, input);
       } catch (error) {
-        lastError = toError(error);
+        const currentError = toError(error);
+        lastError = currentError;
 
         // Check if error is retryable
         if (policy.retryableErrors && policy.retryableErrors.length > 0) {
           const isRetryable = policy.retryableErrors.some((msg) =>
-            lastError!.message.includes(msg)
+            currentError.message.includes(msg)
           );
           if (!isRetryable) {
-            throw lastError;
+            throw currentError;
           }
         }
 
@@ -190,7 +197,7 @@ export function createToolExecutor(config: ToolExecutorConfig = {}) {
       }
     }
 
-    throw lastError;
+    throw lastError ?? new Error('Tool execution failed after retries');
   }
 
   /**

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -41,6 +41,10 @@ export type EventHandler = (data: unknown) => void;
 
 type RegistryTool = Tool<unknown, unknown>;
 
+function eraseToolType<TInput, TOutput>(tool: Tool<TInput, TOutput>): RegistryTool {
+  return tool as unknown as RegistryTool;
+}
+
 /**
  * Options for generating tool prompts
  */
@@ -119,7 +123,8 @@ export class ToolRegistry {
    * registry.register(readFileTool);
    * ```
    */
-  register(tool: RegistryTool): void {
+  register<TInput, TOutput>(tool: Tool<TInput, TOutput>): void {
+    const erasedTool = eraseToolType(tool);
     const name = tool.metadata.name;
     
     if (this.tools.has(name)) {
@@ -128,7 +133,7 @@ export class ToolRegistry {
       );
     }
 
-    this.tools.set(name, tool);
+    this.tools.set(name, erasedTool);
     this.emit(RegistryEvent.TOOL_REGISTERED, tool);
   }
 
@@ -203,7 +208,8 @@ export class ToolRegistry {
    * const updated = registry.update('read-file', newReadFileTool);
    * ```
    */
-  update(name: string, tool: RegistryTool): boolean {
+  update<TInput, TOutput>(name: string, tool: Tool<TInput, TOutput>): boolean {
+    const erasedTool = eraseToolType(tool);
     if (!this.tools.has(name)) {
       return false;
     }
@@ -216,7 +222,7 @@ export class ToolRegistry {
       );
     }
 
-    this.tools.set(name, tool);
+    this.tools.set(name, erasedTool);
     this.emit(RegistryEvent.TOOL_UPDATED, { name, tool });
     return true;
   }
@@ -309,7 +315,7 @@ export class ToolRegistry {
    * registry.registerMany([tool1, tool2, tool3]);
    * ```
    */
-  registerMany(tools: RegistryTool[]): void {
+  registerMany<TInput, TOutput>(tools: Tool<TInput, TOutput>[]): void {
     // Check for duplicates within the input list first
     const inputNames = new Set<string>();
     const duplicatesInInput: string[] = [];

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -315,7 +315,7 @@ export class ToolRegistry {
    * registry.registerMany([tool1, tool2, tool3]);
    * ```
    */
-  registerMany<TInput, TOutput>(tools: Tool<TInput, TOutput>[]): void {
+  registerMany(tools: RegistryTool[]): void {
     // Check for duplicates within the input list first
     const inputNames = new Set<string>();
     const duplicatesInInput: string[] = [];

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -310,7 +310,7 @@ export class ToolRegistry {
   /**
    * Register multiple tools at once
    *
-   * @param tools - Array of tools to register
+   * @param tools - Iterable of tools to register
    * @throws Error if any tool name conflicts with existing tools
    *
    * @example

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -40,6 +40,9 @@ export enum RegistryEvent {
 export type EventHandler = (data: unknown) => void;
 
 type RegistryTool = Tool<unknown, unknown>;
+// Use `never` for erased input so heterogeneous Tool<TInput, TOutput> values
+// remain assignable through the contravariant invoke parameter.
+type RegisterManyTool = Tool<never, unknown>;
 
 function eraseToolType<TInput, TOutput>(tool: Tool<TInput, TOutput>): RegistryTool {
   return tool as unknown as RegistryTool;
@@ -315,12 +318,14 @@ export class ToolRegistry {
    * registry.registerMany([tool1, tool2, tool3]);
    * ```
    */
-  registerMany(tools: RegistryTool[]): void {
+  registerMany(tools: Iterable<RegisterManyTool>): void {
+    const toolsToRegister = Array.from(tools);
+
     // Check for duplicates within the input list first
     const inputNames = new Set<string>();
     const duplicatesInInput: string[] = [];
 
-    for (const tool of tools) {
+    for (const tool of toolsToRegister) {
       const name = tool.metadata.name;
       if (inputNames.has(name)) {
         duplicatesInInput.push(name);
@@ -337,7 +342,7 @@ export class ToolRegistry {
 
     // Check for conflicts with existing tools
     const conflicts: string[] = [];
-    for (const tool of tools) {
+    for (const tool of toolsToRegister) {
       if (this.tools.has(tool.metadata.name)) {
         conflicts.push(tool.metadata.name);
       }
@@ -350,7 +355,7 @@ export class ToolRegistry {
     }
 
     // Register all tools
-    for (const tool of tools) {
+    for (const tool of toolsToRegister) {
       this.register(tool);
     }
   }

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -19,6 +19,7 @@
 import { Tool, ToolCategory, ToolRelations } from './types.js';
 import { toLangChainTools as convertToLangChainTools } from '../langchain/converter.js';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
 import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 
 const logger = createLogger('agentforge:core:tools:registry', { level: LogLevel.INFO });
@@ -36,7 +37,9 @@ export enum RegistryEvent {
 /**
  * Event handler type
  */
-export type EventHandler = (data: any) => void;
+export type EventHandler = (data: unknown) => void;
+
+type RegistryTool = Tool<unknown, unknown>;
 
 /**
  * Options for generating tool prompts
@@ -102,7 +105,7 @@ export interface PromptOptions {
  * ```
  */
 export class ToolRegistry {
-  private tools: Map<string, Tool<any, any>> = new Map();
+  private tools: Map<string, RegistryTool> = new Map();
   private eventHandlers: Map<RegistryEvent, Set<EventHandler>> = new Map();
 
   /**
@@ -116,7 +119,7 @@ export class ToolRegistry {
    * registry.register(readFileTool);
    * ```
    */
-  register(tool: Tool<any, any>): void {
+  register(tool: RegistryTool): void {
     const name = tool.metadata.name;
     
     if (this.tools.has(name)) {
@@ -143,7 +146,7 @@ export class ToolRegistry {
    * }
    * ```
    */
-  get(name: string): Tool<any, any> | undefined {
+  get(name: string): RegistryTool | undefined {
     return this.tools.get(name);
   }
 
@@ -200,7 +203,7 @@ export class ToolRegistry {
    * const updated = registry.update('read-file', newReadFileTool);
    * ```
    */
-  update(name: string, tool: Tool<any, any>): boolean {
+  update(name: string, tool: RegistryTool): boolean {
     if (!this.tools.has(name)) {
       return false;
     }
@@ -229,7 +232,7 @@ export class ToolRegistry {
    * console.log(`Total tools: ${allTools.length}`);
    * ```
    */
-  getAll(): Tool<any, any>[] {
+  getAll(): RegistryTool[] {
     return Array.from(this.tools.values());
   }
 
@@ -244,7 +247,7 @@ export class ToolRegistry {
    * const fileTools = registry.getByCategory(ToolCategory.FILE_SYSTEM);
    * ```
    */
-  getByCategory(category: ToolCategory): Tool<any, any>[] {
+  getByCategory(category: ToolCategory): RegistryTool[] {
     return this.getAll().filter((tool) => tool.metadata.category === category);
   }
 
@@ -259,7 +262,7 @@ export class ToolRegistry {
    * const fileTools = registry.getByTag('file');
    * ```
    */
-  getByTag(tag: string): Tool<any, any>[] {
+  getByTag(tag: string): RegistryTool[] {
     return this.getAll().filter((tool) =>
       tool.metadata.tags?.includes(tag)
     );
@@ -279,7 +282,7 @@ export class ToolRegistry {
    * // Returns tools with 'file' in name or description
    * ```
    */
-  search(query: string): Tool<any, any>[] {
+  search(query: string): RegistryTool[] {
     const lowerQuery = query.toLowerCase();
 
     return this.getAll().filter((tool) => {
@@ -306,7 +309,7 @@ export class ToolRegistry {
    * registry.registerMany([tool1, tool2, tool3]);
    * ```
    */
-  registerMany(tools: Tool<any, any>[]): void {
+  registerMany(tools: RegistryTool[]): void {
     // Check for duplicates within the input list first
     const inputNames = new Set<string>();
     const duplicatesInInput: string[] = [];
@@ -436,7 +439,7 @@ export class ToolRegistry {
    * @param data - The event data
    * @private
    */
-  private emit(event: RegistryEvent, data: any): void {
+  private emit(event: RegistryEvent, data: unknown): void {
     const handlers = this.eventHandlers.get(event);
     if (handlers) {
       handlers.forEach((handler) => {
@@ -534,7 +537,7 @@ export class ToolRegistry {
 
     if (groupByCategory) {
       // Group tools by category
-      const toolsByCategory = new Map<ToolCategory, Tool<any, any>[]>();
+      const toolsByCategory = new Map<ToolCategory, RegistryTool[]>();
 
       for (const tool of tools) {
         const category = tool.metadata.category;
@@ -588,7 +591,7 @@ export class ToolRegistry {
    * @private
    */
   private formatToolForPrompt(
-    tool: Tool<any, any>,
+    tool: RegistryTool,
     options: {
       includeExamples?: boolean;
       includeNotes?: boolean;
@@ -661,13 +664,14 @@ export class ToolRegistry {
     lines.push(`- ${metadata.name}: ${metadata.description}`);
 
     // Get schema properties
-    const schemaShape = (tool.schema as any)._def?.shape?.();
+    const schemaShape = this.getSchemaShape(tool.schema);
     if (schemaShape) {
       const params = Object.keys(schemaShape);
       if (params.length > 0) {
         const paramDescriptions = params.map((param) => {
           const field = schemaShape[param];
-          const type = field._def?.typeName?.replace('Zod', '').toLowerCase() || 'any';
+          const typeName = field._def.typeName;
+          const type = typeName.replace('Zod', '').toLowerCase();
           return `${param} (${type})`;
         });
         lines.push(`  Parameters: ${paramDescriptions.join(', ')}`);
@@ -744,5 +748,14 @@ export class ToolRegistry {
 
     return lines;
   }
-}
 
+  private getSchemaShape(
+    schema: z.ZodSchema<unknown>
+  ): z.ZodRawShape | undefined {
+    if (schema instanceof z.ZodObject) {
+      return schema.shape;
+    }
+
+    return undefined;
+  }
+}

--- a/packages/core/tests/resources/http-pool.test.ts
+++ b/packages/core/tests/resources/http-pool.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHttpPool, HttpPool } from '../../src/resources/http-pool.js';
+
+describe('HttpPool', () => {
+  const pools: HttpPool[] = [];
+
+  afterEach(async () => {
+    for (const pool of pools) {
+      await pool.clear();
+    }
+    pools.length = 0;
+  });
+
+  it('executes requests through pooled clients', async () => {
+    const pool = createHttpPool({
+      config: { baseURL: 'https://example.com' },
+      pool: { max: 2 },
+    });
+    pools.push(pool);
+
+    const response = await pool.request<{ ok: boolean }>({
+      url: '/health',
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.statusText).toBe('OK');
+    expect(response.data).toEqual({});
+  });
+
+  it('tracks acquire and release pool metrics', async () => {
+    const pool = createHttpPool({
+      config: { baseURL: 'https://example.com' },
+      pool: { max: 1 },
+    });
+    pools.push(pool);
+
+    const client = await pool.acquire();
+    const acquiredStats = pool.getStats();
+    expect(acquiredStats.acquired).toBe(1);
+
+    await pool.release(client);
+    const releasedStats = pool.getStats();
+    expect(releasedStats.acquired).toBe(0);
+    expect(releasedStats.available).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects new acquires after draining', async () => {
+    const pool = createHttpPool({
+      config: { baseURL: 'https://example.com' },
+      pool: { max: 1 },
+    });
+    pools.push(pool);
+
+    await pool.drain();
+    await expect(pool.acquire()).rejects.toThrow('Pool is draining');
+  });
+});

--- a/packages/core/tests/resources/http-pool.test.ts
+++ b/packages/core/tests/resources/http-pool.test.ts
@@ -18,7 +18,7 @@ describe('HttpPool', () => {
     });
     pools.push(pool);
 
-    const response = await pool.request<{ ok: boolean }>({
+    const response = await pool.request({
       url: '/health',
       method: 'GET',
     });

--- a/packages/core/tests/tools/executor.test.ts
+++ b/packages/core/tests/tools/executor.test.ts
@@ -156,6 +156,27 @@ describe('Tool Executor', () => {
       expect(result).toBe('Success after 2 attempts');
       expect(attempts).toBe(2);
     });
+
+    it('should throw a clear error when maxAttempts is less than 1', async () => {
+      const invoke = vi.fn(async (input: string) => `Result: ${input}`);
+      const tool = {
+        name: 'invalid-retry-policy-tool',
+        invoke,
+      };
+
+      const executor = createToolExecutor({
+        retryPolicy: {
+          maxAttempts: 0,
+          backoff: 'fixed',
+          initialDelay: 10,
+        },
+      });
+
+      await expect(executor.execute(tool, 'test')).rejects.toThrow(
+        'Invalid retry policy: maxAttempts must be an integer >= 1'
+      );
+      expect(invoke).not.toHaveBeenCalled();
+    });
   });
 
   describe('metrics tracking', () => {
@@ -270,4 +291,3 @@ describe('Tool Executor', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -59,10 +59,13 @@
 - [x] Add or update story documentation at `docs/st08002-core-runtime-type-hardening.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Added focused `http-pool` tests and re-ran touched-area validations
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` → 146 passed | 16 skipped (162 files); 2073 passed | 286 skipped (2359 tests)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` → 0 errors (warnings-only across workspace)
 - [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #60 marked ready: https://github.com/TVScoundrel/agentforge/pull/60
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -46,7 +46,8 @@
 
 ### Checklist
 - [x] Create branch `codex/fix/st-08002-core-runtime-type-hardening`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #60: https://github.com/TVScoundrel/agentforge/pull/60
 - [x] Replace explicit `any` usage in `packages/core/src/tools/registry.ts` hotspots with `unknown` + narrowing or specific generic constraints
 - [x] Replace explicit `any` usage in `packages/core/src/tools/executor.ts` hotspots with stronger domain typing
 - [x] Replace explicit `any` usage in `packages/core/src/resources/http-pool.ts` hotspots with safer typed boundaries

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -63,7 +63,10 @@
   - `pnpm test --run` → 146 passed | 16 skipped (162 files); 2073 passed | 286 skipped (2359 tests)
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` → 0 errors (warnings-only across workspace)
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
+  - `6a28091` refactor(st-08002): harden core runtime typing hotspots
+  - `a7208e2` chore(st-08002): record draft PR creation
+  - `3080b0d` docs(st-08002): finalize validation and review status
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #60 marked ready: https://github.com/TVScoundrel/agentforge/pull/60
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -42,18 +42,22 @@
 
 ## ST-08002: Hardening Pass 1 for `@agentforge/core` Runtime Hotspots
 
-**Branch:** `fix/st-08002-core-runtime-type-hardening`
+**Branch:** `codex/fix/st-08002-core-runtime-type-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-08002-core-runtime-type-hardening`
+- [x] Create branch `codex/fix/st-08002-core-runtime-type-hardening`
 - [ ] Create draft PR with story ID in title
-- [ ] Replace explicit `any` usage in `packages/core/src/tools/registry.ts` hotspots with `unknown` + narrowing or specific generic constraints
-- [ ] Replace explicit `any` usage in `packages/core/src/tools/executor.ts` hotspots with stronger domain typing
-- [ ] Replace explicit `any` usage in `packages/core/src/resources/http-pool.ts` hotspots with safer typed boundaries
-- [ ] Add focused tests or adapt existing tests to validate behavior remains unchanged in touched areas
-- [ ] Record before/after warning counts for touched files in PR/story docs
-- [ ] Add or update story documentation at `docs/st08002-core-runtime-type-hardening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Replace explicit `any` usage in `packages/core/src/tools/registry.ts` hotspots with `unknown` + narrowing or specific generic constraints
+- [x] Replace explicit `any` usage in `packages/core/src/tools/executor.ts` hotspots with stronger domain typing
+- [x] Replace explicit `any` usage in `packages/core/src/resources/http-pool.ts` hotspots with safer typed boundaries
+- [x] Add focused tests or adapt existing tests to validate behavior remains unchanged in touched areas
+  - Added `packages/core/tests/resources/http-pool.test.ts`
+  - Ran targeted touched-area tests (`registry`, `executor`, `http-pool`) → 58 passed
+- [x] Record before/after warning counts for touched files in PR/story docs
+  - Recorded in `docs/st08002-core-runtime-type-hardening.md` (`25/21/18 -> 0/0/0`, core `256 -> 192`)
+- [x] Add or update story documentation at `docs/st08002-core-runtime-type-hardening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused `http-pool` tests and re-ran touched-area validations
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -743,7 +743,7 @@
 **Priority:** P0 (Critical)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** In Review (PR #59, 2026-03-06)
+**Status:** Merged (PR #59, 2026-03-09)
 
 **Acceptance criteria:**
 - [ ] Baseline counts for `@typescript-eslint/no-explicit-any` are captured for `packages/**/src/**/*.ts` and documented in the story documentation
@@ -760,6 +760,7 @@
 **Priority:** P1 (High)
 **Estimate:** 4 hours
 **Dependencies:** ST-08001
+**Status:** In Review (PR #60, 2026-03-10)
 
 **Acceptance criteria:**
 - [ ] High-volume `@typescript-eslint/no-explicit-any` warnings are reduced in `packages/core/src/tools/registry.ts`, `packages/core/src/tools/executor.ts`, and `packages/core/src/resources/http-pool.ts`

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 1 story
+- **In Progress:** 0 stories
+- **In Review:** 2 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -20,10 +20,7 @@ _No stories currently ready_
 
 ## In Progress
 
-- [ ] ST-08002 Hardening Pass 1 for `@agentforge/core` Runtime Hotspots
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08002: Hardening Pass 1 for @agentforge/core Runtime Hotspots`)
-  - Branch: `codex/fix/st-08002-core-runtime-type-hardening`
-  - Dependencies: ST-08001 (merged)
+_No stories currently in progress_
 
 ---
 
@@ -33,6 +30,10 @@ _No stories currently ready_
   - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08001: Establish Explicit 'any' Baseline and No-Regression Gate for src/**`)
   - PR: https://github.com/TVScoundrel/agentforge/pull/59
   - Dependencies: None
+- [ ] ST-08002 Hardening Pass 1 for `@agentforge/core` Runtime Hotspots
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08002: Hardening Pass 1 for @agentforge/core Runtime Hotspots`)
+  - PR: https://github.com/TVScoundrel/agentforge/pull/60
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -96,4 +97,4 @@ _No stories currently blocked_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001 merged (PR #59); ST-08002 is in progress and ST-08003/ST-08004 remain queued in Backlog
+- ST-08001 merged (PR #59); ST-08002 is in review (PR #60) and ST-08003/ST-08004 remain queued in Backlog

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,14 +1,14 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-06
+**Last Updated:** 2026-03-10
 
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 1 story
 - **Blocked:** 0 stories
-- **Backlog:** 3 stories
+- **Backlog:** 2 stories
 
 ---
 
@@ -20,7 +20,10 @@ _No stories currently ready_
 
 ## In Progress
 
-_No stories currently in progress_
+- [ ] ST-08002 Hardening Pass 1 for `@agentforge/core` Runtime Hotspots
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08002: Hardening Pass 1 for @agentforge/core Runtime Hotspots`)
+  - Branch: `codex/fix/st-08002-core-runtime-type-hardening`
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -41,15 +44,12 @@ _No stories currently blocked_
 
 ## Backlog
 
-- [ ] ST-08002 Hardening Pass 1 for `@agentforge/core` Runtime Hotspots
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08002: Hardening Pass 1 for @agentforge/core Runtime Hotspots`)
-  - Dependencies: ST-08001
 - [ ] ST-08003 Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
   - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns`)
-  - Dependencies: ST-08001
+  - Dependencies: ST-08001 (merged)
 - [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
   - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
-  - Dependencies: ST-08001
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -96,4 +96,4 @@ _No stories currently blocked_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001 is in review (PR #59); ST-08002 through ST-08004 remain queued in Backlog
+- ST-08001 merged (PR #59); ST-08002 is in progress and ST-08003/ST-08004 remain queued in Backlog


### PR DESCRIPTION
## Story
- ST-08002: Hardening Pass 1 for `@agentforge/core` Runtime Hotspots

## What Changed
- Replaced explicit `any` hotspots in:
  - `packages/core/src/tools/registry.ts`
  - `packages/core/src/tools/executor.ts`
  - `packages/core/src/resources/http-pool.ts`
- Introduced `unknown`-first runtime boundaries (`RegistryTool`, `ExecutableTool`) and typed narrowing helpers.
- Added focused tests for HTTP pool behavior:
  - `packages/core/tests/resources/http-pool.test.ts`
- Added story documentation with warning deltas and design notes:
  - `docs/st08002-core-runtime-type-hardening.md`
- Updated story execution trackers:
  - `planning/kanban-queue.md`
  - `planning/checklists/epic-08-story-tasks.md`

## Acceptance Criteria Coverage
- [x] Reduced high-volume `no-explicit-any` warnings in the 3 target core runtime files.
- [x] Replacements use `unknown` + narrowing / stronger domain typing.
- [x] No behavior regressions in existing tests for touched areas.
- [x] Story docs summarize key type-design decisions and narrowing patterns.
- [x] Story doc added at `docs/st08002-core-runtime-type-hardening.md`.

## Warning Delta (Targeted Files)
- `packages/core/src/tools/registry.ts`: `25 -> 0`
- `packages/core/src/tools/executor.ts`: `21 -> 0`
- `packages/core/src/resources/http-pool.ts`: `18 -> 0`
- Total reduction in targeted files: `-64`
- Baseline impact: `core 256 -> 192`, workspace total `496 -> 432`

## Validation Performed
- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/executor.ts packages/core/src/resources/http-pool.ts -f json`
- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/executor.ts packages/core/src/resources/http-pool.ts packages/core/tests/resources/http-pool.test.ts`
- `pnpm --filter @agentforge/core typecheck`
- `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/executor.test.ts packages/core/tests/resources/http-pool.test.ts`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
  - 146 passed | 16 skipped (162 files)
  - 2073 passed | 286 skipped (2359 tests)
- `pnpm lint` (0 errors, warnings-only output)

## Status
- Ready for review.
