### PR TITLE
ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns

### DIFF
--- a/docs/st08003-tools-patterns-type-hardening.md
+++ b/docs/st08003-tools-patterns-type-hardening.md
@@ -11,6 +11,7 @@ This story focused on top-warning files with behavior-preserving refactors from 
 - `packages/patterns/src/multi-agent/agent.ts`
 - `packages/patterns/src/multi-agent/utils.ts`
 - `packages/patterns/src/multi-agent/types.ts`
+- `packages/patterns/src/multi-agent/nodes.ts`
 - `packages/tools/src/data/neo4j/connection.ts`
 - `packages/tools/src/data/neo4j/utils/result-formatter.ts`
 

--- a/docs/st08003-tools-patterns-type-hardening.md
+++ b/docs/st08003-tools-patterns-type-hardening.md
@@ -1,0 +1,65 @@
+# ST-08003: Tools/Patterns Runtime Type Hardening
+
+## Scope
+Hardening pass for high-warning runtime files in:
+- `packages/patterns/src/**`
+- `packages/tools/src/**`
+
+This story focused on top-warning files with behavior-preserving refactors from `any` to `unknown` and concrete helper types.
+
+## Files Touched
+- `packages/patterns/src/multi-agent/agent.ts`
+- `packages/patterns/src/multi-agent/utils.ts`
+- `packages/patterns/src/multi-agent/types.ts`
+- `packages/tools/src/data/neo4j/connection.ts`
+- `packages/tools/src/data/neo4j/utils/result-formatter.ts`
+
+## Type Design Notes
+- Replaced broad `any`-typed graph/tool boundaries with `unknown` + narrowing helpers.
+- Added record/result extraction helpers for ReAct agent outputs to keep runtime safety while preserving existing behavior.
+- Replaced Neo4j query parameter/result `any` signatures with typed `unknown` boundaries and safe conversions.
+- Kept public API behavior compatible; no intentional runtime behavior changes.
+
+## Warning Delta (`@typescript-eslint/no-explicit-any`)
+Captured using:
+- `pnpm exec eslint packages/tools/src packages/patterns/src --ext .ts -f json`
+
+### Aggregate (tools + patterns `src/**`)
+- Before: `164`
+- After: `120`
+- Delta: `-44`
+
+### Package Split
+- `packages/tools/src/**`: `82 -> 70` (`-12`)
+- `packages/patterns/src/**`: `82 -> 50` (`-32`)
+
+### Touched File Deltas
+- `packages/patterns/src/multi-agent/agent.ts`: `17 -> 0`
+- `packages/patterns/src/multi-agent/utils.ts`: `10 -> 0`
+- `packages/patterns/src/multi-agent/types.ts`: `5 -> 0`
+- `packages/tools/src/data/neo4j/connection.ts`: `6 -> 0`
+- `packages/tools/src/data/neo4j/utils/result-formatter.ts`: `6 -> 0`
+
+## Validation
+Focused validation:
+- `pnpm --filter @agentforge/patterns typecheck`
+- `pnpm --filter @agentforge/tools typecheck`
+- `pnpm exec eslint <touched files>`
+- `pnpm test --run packages/patterns/tests/multi-agent/agent.test.ts packages/patterns/tests/multi-agent/utils.test.ts packages/tools/tests/data/neo4j.test.ts`
+  - Result: `20 passed`, `13 skipped` (`neo4j` integration suite skipped by design unless enabled)
+
+Full-suite validation and full lint are tracked in the story checklist before PR readiness.
+
+Full validation before PR readiness:
+- `pnpm test --run`
+  - Result: `146` passed, `16` skipped test files (`162` total)
+  - Result: `2074` passed, `286` skipped tests (`2360` total)
+- `pnpm lint`
+  - Result: exit code `0` (no lint errors)
+  - Warning baseline snapshot:
+    - `packages/cli`: `27` warnings
+    - `packages/core`: `233` warnings
+    - `packages/tools`: `208` warnings
+    - `packages/patterns`: `72` warnings
+    - `packages/testing`: `57` warnings
+    - `packages/skills`: `2` warnings

--- a/docs/st08003-tools-patterns-type-hardening.md
+++ b/docs/st08003-tools-patterns-type-hardening.md
@@ -18,7 +18,8 @@ This story focused on top-warning files with behavior-preserving refactors from 
 - Replaced broad `any`-typed graph/tool boundaries with `unknown` + narrowing helpers.
 - Added record/result extraction helpers for ReAct agent outputs to keep runtime safety while preserving existing behavior.
 - Replaced Neo4j query parameter/result `any` signatures with typed `unknown` boundaries and safe conversions.
-- Kept public API behavior compatible; no intentional runtime behavior changes.
+- Kept public API signatures compatible.
+- Intentional bug fix: `wrapReActAgent` now passes through the configured `verbose` flag to `handleNodeError` in the catch path, so error logging is no longer silently suppressed when `verbose=true`.
 
 ## Warning Delta (`@typescript-eslint/no-explicit-any`)
 Captured using:

--- a/docs/st08003-tools-patterns-type-hardening.md
+++ b/docs/st08003-tools-patterns-type-hardening.md
@@ -17,7 +17,7 @@ This story focused on top-warning files with behavior-preserving refactors from 
 ## Type Design Notes
 - Replaced broad `any`-typed graph/tool boundaries with `unknown` + narrowing helpers.
 - Added record/result extraction helpers for ReAct agent outputs to keep runtime safety while preserving existing behavior.
-- Replaced Neo4j query parameter/result `any` signatures with typed `unknown` boundaries and safe conversions.
+- Reduced Neo4j query parameter/result explicit `any` usage by introducing typed `unknown` boundaries and safe conversions, while keeping the default query result generic permissive for backward compatibility.
 - Kept public API signatures compatible.
 - Intentional bug fix: `wrapReActAgent` now passes through the configured `verbose` flag to `handleNodeError` in the catch path, so error logging is no longer silently suppressed when `verbose=true`.
 

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -7,6 +7,7 @@
  */
 
 import { StateGraph, END, CompiledStateGraph } from '@langchain/langgraph';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import { createLogger, LogLevel } from '@agentforge/core';
 import { MultiAgentState } from './state.js';
 import type { MultiAgentStateType } from './state.js';
@@ -19,6 +20,11 @@ import { RoutingDecisionSchema } from './schemas.js';
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
 const logger = createLogger('multi-agent:system', { level: logLevel });
 
+type ToolLike = {
+  metadata?: { name?: string };
+  name?: string;
+};
+
 /**
  * Extract tool name from either AgentForge Tool or LangChain tool
  *
@@ -28,15 +34,21 @@ const logger = createLogger('multi-agent:system', { level: logLevel });
  * @param tool - Tool instance (AgentForge or LangChain)
  * @returns Tool name or 'unknown' if not found
  */
-function getToolName(tool: any): string {
+function getToolName(tool: unknown): string {
+  if (!tool || typeof tool !== 'object') {
+    return 'unknown';
+  }
+
+  const candidate = tool as ToolLike;
+
   // AgentForge Tool: has metadata.name
-  if (tool.metadata?.name) {
-    return tool.metadata.name;
+  if (candidate.metadata?.name) {
+    return candidate.metadata.name;
   }
 
   // LangChain tool: has name directly
-  if (tool.name) {
-    return tool.name;
+  if (candidate.name) {
+    return candidate.name;
   }
 
   // Fallback
@@ -149,7 +161,7 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
 
     // Add structured output for routing decisions (forces JSON response)
     if (supervisor.strategy === 'llm-based') {
-      configuredModel = configuredModel.withStructuredOutput!(RoutingDecisionSchema) as any;
+      configuredModel = configuredModel.withStructuredOutput!(RoutingDecisionSchema) as unknown as typeof configuredModel;
     }
 
     supervisorConfig.model = configuredModel;
@@ -213,7 +225,7 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
           agents,
           count: agents.length
         });
-        return agents as any; // LangGraph supports returning arrays for parallel execution
+        return agents; // LangGraph supports returning arrays for parallel execution
       }
       // Single agent routing
       logger.info('Supervisor router: single agent routing', {
@@ -272,11 +284,11 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
   workflow.addConditionalEdges('aggregator', aggregatorRouter, [END]);
 
   // Compile the graph with checkpointer if provided
-  const compiled = workflow.compile(checkpointer ? { checkpointer } : undefined);
+  const compiled = workflow.compile(checkpointer ? { checkpointer } : undefined) as unknown as MultiAgentSystemWithRegistry;
 
   // Wrap the invoke method to inject worker capabilities into the initial state
   const originalInvoke = compiled.invoke.bind(compiled);
-  compiled.invoke = async function(input: Partial<MultiAgentStateType>, config?: any) {
+  compiled.invoke = (async function(input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
     // Merge worker capabilities with any workers in the input
     const mergedInput = {
       ...input,
@@ -286,12 +298,15 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
       },
     };
 
-    return originalInvoke(mergedInput, config);
-  } as any;
+    return originalInvoke(
+      mergedInput as Parameters<typeof originalInvoke>[0],
+      config as Parameters<typeof originalInvoke>[1]
+    );
+  }) as unknown as typeof compiled.invoke;
 
   // Wrap the stream method to inject worker capabilities into the initial state
   const originalStream = compiled.stream.bind(compiled);
-  compiled.stream = async function(input: Partial<MultiAgentStateType>, config?: any) {
+  compiled.stream = (async function(input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
     // Merge worker capabilities with any workers in the input
     const mergedInput = {
       ...input,
@@ -301,8 +316,11 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
       },
     };
 
-    return originalStream(mergedInput, config);
-  } as any;
+    return originalStream(
+      mergedInput as Parameters<typeof originalStream>[0],
+      config as Parameters<typeof originalStream>[1]
+    );
+  }) as unknown as typeof compiled.stream;
 
   return compiled as MultiAgentSystemWithRegistry;
 }
@@ -353,9 +371,9 @@ export class MultiAgentSystemBuilder {
     name: string;
     description?: string;
     capabilities: string[];
-    tools?: any[];
+    tools?: WorkerConfig['tools'];
     systemPrompt?: string;
-    model?: any;
+    model?: WorkerConfig['model'];
   }>): this {
     if (this.compiled) {
       throw new Error('Cannot register workers after the system has been compiled');
@@ -408,10 +426,10 @@ export class MultiAgentSystemBuilder {
 /**
  * Extended multi-agent system with worker registration support
  */
-export interface MultiAgentSystemWithRegistry extends CompiledStateGraph<any, any, any> {
+export interface MultiAgentSystemWithRegistry extends CompiledStateGraph<string, unknown> {
   _workerRegistry?: Record<string, WorkerCapabilities>;
-  _originalInvoke?: typeof CompiledStateGraph.prototype.invoke;
-  _originalStream?: typeof CompiledStateGraph.prototype.stream;
+  _originalInvoke?: MultiAgentSystemWithRegistry['invoke'];
+  _originalStream?: MultiAgentSystemWithRegistry['stream'];
 }
 
 /**
@@ -447,7 +465,7 @@ export function registerWorkers(
     name: string;
     description?: string;
     capabilities: string[];
-    tools?: any[];
+    tools?: WorkerConfig['tools'];
     systemPrompt?: string;
   }>
 ): void {
@@ -476,7 +494,7 @@ export function registerWorkers(
   if (!system._originalInvoke) {
     system._originalInvoke = system.invoke.bind(system);
 
-    system.invoke = async function(input: Partial<MultiAgentStateType>, config?: any) {
+    system.invoke = (async function(input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
       // Merge registered workers with any workers in the input
       const mergedInput = {
         ...input,
@@ -486,15 +504,18 @@ export function registerWorkers(
         },
       };
 
-      return system._originalInvoke!(mergedInput, config);
-    } as any;
+      return system._originalInvoke!(
+        mergedInput as Parameters<NonNullable<typeof system._originalInvoke>>[0],
+        config as Parameters<NonNullable<typeof system._originalInvoke>>[1]
+      );
+    }) as unknown as typeof system.invoke;
   }
 
   // Wrap the stream method to inject workers into state (only once)
   if (!system._originalStream) {
     system._originalStream = system.stream.bind(system);
 
-    system.stream = async function(input: Partial<MultiAgentStateType>, config?: any) {
+    system.stream = (async function(input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
       // Merge registered workers with any workers in the input
       const mergedInput = {
         ...input,
@@ -504,8 +525,11 @@ export function registerWorkers(
         },
       };
 
-      return system._originalStream!(mergedInput, config);
-    } as any;
+      return system._originalStream!(
+        mergedInput as Parameters<NonNullable<typeof system._originalStream>>[0],
+        config as Parameters<NonNullable<typeof system._originalStream>>[1]
+      );
+    }) as unknown as typeof system.stream;
   }
 }
 

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -18,7 +18,7 @@ import { RoutingDecisionSchema } from './schemas.js';
 
 // Create logger for agent system
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('multi-agent:system', { level: logLevel });
+const logger = createLogger('agentforge:patterns:multi-agent:system', { level: logLevel });
 
 type ToolLike = {
   metadata?: { name?: string };

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -40,12 +40,12 @@ function getToolName(tool: unknown): string {
   const candidate = tool as ToolLike;
 
   // AgentForge Tool: has metadata.name
-  if (candidate.metadata?.name) {
+  if (typeof candidate.metadata?.name === 'string') {
     return candidate.metadata.name;
   }
 
   // LangChain tool: has name directly
-  if (candidate.name) {
+  if (typeof candidate.name === 'string') {
     return candidate.name;
   }
 

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -424,7 +424,7 @@ export class MultiAgentSystemBuilder {
 /**
  * Extended multi-agent system with worker registration support
  */
-export interface MultiAgentSystemWithRegistry extends CompiledStateGraph<string, unknown> {
+export interface MultiAgentSystemWithRegistry extends CompiledStateGraph<MultiAgentStateType, unknown> {
   _workerRegistry?: Record<string, WorkerCapabilities>;
   _originalInvoke?: MultiAgentSystemWithRegistry['invoke'];
   _originalStream?: MultiAgentSystemWithRegistry['stream'];

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -472,7 +472,7 @@ export function registerWorkers(
   console.warn(
     '[AgentForge] registerWorkers() on a compiled system only updates worker capabilities in state.\n' +
     'It does NOT add worker nodes to the graph. Use MultiAgentSystemBuilder for proper worker registration.\n' +
-    'See: https://github.com/agentforge/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
+    'See: https://github.com/TVScoundrel/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
   );
 
   // Initialize registry if it doesn't exist

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -8,7 +8,7 @@
 
 import { StateGraph, END, CompiledStateGraph } from '@langchain/langgraph';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import { createLogger, LogLevel } from '@agentforge/core';
+import { createPatternLogger } from '../shared/deduplication.js';
 import { MultiAgentState } from './state.js';
 import type { MultiAgentStateType } from './state.js';
 import type { MultiAgentSystemConfig, MultiAgentRouter, WorkerConfig } from './types.js';
@@ -16,9 +16,7 @@ import { createSupervisorNode, createWorkerNode, createAggregatorNode } from './
 import type { WorkerCapabilities } from './schemas.js';
 import { RoutingDecisionSchema } from './schemas.js';
 
-// Create logger for agent system
-const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('agentforge:patterns:multi-agent:system', { level: logLevel });
+const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
 
 type ToolLike = {
   metadata?: { name?: string };

--- a/packages/patterns/src/multi-agent/nodes.ts
+++ b/packages/patterns/src/multi-agent/nodes.ts
@@ -17,7 +17,7 @@ import { handleNodeError } from '../shared/error-handling.js';
 
 // Create logger for nodes
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('multi-agent:nodes', { level: logLevel });
+const logger = createLogger('agentforge:patterns:multi-agent:nodes', { level: logLevel });
 
 /**
  * Default system prompt for aggregator
@@ -324,7 +324,9 @@ Execute the assigned task using your skills and tools. Provide a clear, actionab
             toolCount: tools.length,
             toolNames: tools.map(t => t.metadata.name)
           });
-          const langchainTools = toLangChainTools(tools);
+          const langchainTools = toLangChainTools(
+            tools as unknown as Parameters<typeof toLangChainTools>[0]
+          );
           modelToUse = model!.bindTools(langchainTools);
         }
 
@@ -623,4 +625,3 @@ Please synthesize these results into a comprehensive response that addresses the
     }
   };
 }
-

--- a/packages/patterns/src/multi-agent/nodes.ts
+++ b/packages/patterns/src/multi-agent/nodes.ts
@@ -7,17 +7,16 @@
  */
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
-import { toLangChainTools, createLogger, LogLevel } from '@agentforge/core';
+import { toLangChainTools } from '@agentforge/core';
 import type { MultiAgentStateType } from './state.js';
 import type { SupervisorConfig, WorkerConfig, AggregatorConfig } from './types.js';
 import type { AgentMessage, TaskAssignment, TaskResult } from './schemas.js';
 import { getRoutingStrategy } from './routing.js';
 import { isReActAgent, wrapReActAgent } from './utils.js';
+import { createPatternLogger } from '../shared/deduplication.js';
 import { handleNodeError } from '../shared/error-handling.js';
 
-// Create logger for nodes
-const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('agentforge:patterns:multi-agent:nodes', { level: logLevel });
+const logger = createPatternLogger('agentforge:patterns:multi-agent:nodes');
 
 /**
  * Default system prompt for aggregator

--- a/packages/patterns/src/multi-agent/nodes.ts
+++ b/packages/patterns/src/multi-agent/nodes.ts
@@ -18,6 +18,14 @@ import { handleNodeError } from '../shared/error-handling.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:nodes');
 
+function convertWorkerToolsForLangChain(tools: WorkerConfig['tools']) {
+  // Single unsafe boundary for heterogeneous Tool<TInput, TOutput> values.
+  const safeTools = tools ?? [];
+  return toLangChainTools(
+    safeTools as unknown as Parameters<typeof toLangChainTools>[0]
+  );
+}
+
 /**
  * Default system prompt for aggregator
  */
@@ -323,9 +331,7 @@ Execute the assigned task using your skills and tools. Provide a clear, actionab
             toolCount: tools.length,
             toolNames: tools.map(t => t.metadata.name)
           });
-          const langchainTools = toLangChainTools(
-            tools as unknown as Parameters<typeof toLangChainTools>[0]
-          );
+          const langchainTools = convertWorkerToolsForLangChain(tools);
           modelToUse = model!.bindTools(langchainTools);
         }
 

--- a/packages/patterns/src/multi-agent/types.ts
+++ b/packages/patterns/src/multi-agent/types.ts
@@ -136,7 +136,7 @@ export interface WorkerConfig {
    * });
    * ```
    */
-  agent?: CompiledStateGraph<string, unknown>;
+  agent?: CompiledStateGraph<unknown, unknown>;
 }
 
 /**

--- a/packages/patterns/src/multi-agent/types.ts
+++ b/packages/patterns/src/multi-agent/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { CompiledStateGraph, BaseCheckpointSaver } from '@langchain/langgraph';
 import type { Tool } from '@agentforge/core';
 import type { MultiAgentStateType } from './state.js';
@@ -78,7 +79,7 @@ export interface WorkerConfig {
   /**
    * Available tools for this worker
    */
-  tools?: Tool<any, any>[];
+  tools?: Tool<unknown, unknown>[];
 
   /**
    * System prompt for the worker
@@ -99,7 +100,7 @@ export interface WorkerConfig {
    * The config parameter contains LangGraph runtime configuration including
    * thread_id for checkpointing, which is required for interrupt functionality.
    */
-  executeFn?: (state: MultiAgentStateType, config?: any) => Promise<Partial<MultiAgentStateType>>;
+  executeFn?: (state: MultiAgentStateType, config?: RunnableConfig) => Promise<Partial<MultiAgentStateType>>;
 
   /**
    * ReAct agent instance
@@ -123,7 +124,7 @@ export interface WorkerConfig {
    * });
    * ```
    */
-  agent?: CompiledStateGraph<any, any>;
+  agent?: CompiledStateGraph<string, unknown>;
 }
 
 /**
@@ -249,7 +250,7 @@ export type MultiAgentNode = 'supervisor' | 'aggregator' | string; // string for
 /**
  * Route type for multi-agent graph
  */
-export type MultiAgentRoute = 'continue' | 'aggregate' | 'end' | string; // string for worker IDs
+export type MultiAgentRoute = 'continue' | 'aggregate' | 'end' | string | string[]; // string/string[] for worker IDs
 
 /**
  * Router function type
@@ -270,4 +271,3 @@ export interface RoutingStrategyImpl {
    */
   route: (state: MultiAgentStateType, config: SupervisorConfig) => Promise<RoutingDecision>;
 }
-

--- a/packages/patterns/src/multi-agent/types.ts
+++ b/packages/patterns/src/multi-agent/types.ts
@@ -13,6 +13,18 @@ import type { Tool } from '@agentforge/core';
 import type { MultiAgentStateType } from './state.js';
 import type { RoutingStrategy, WorkerCapabilities, RoutingDecision } from './schemas.js';
 
+// Use `never` for input erasure so heterogeneous Tool<TInput, TOutput> values
+// remain assignable through the contravariant invoke parameter.
+type WorkerTool = Tool<never, unknown>;
+
+/**
+ * Runtime config passed to worker execution functions.
+ *
+ * Includes LangGraph's RunnableConfig while remaining open to caller-defined
+ * keys used by integrations.
+ */
+export type WorkerExecutionConfig = RunnableConfig | Record<string, unknown>;
+
 /**
  * Configuration for the supervisor node
  */
@@ -79,7 +91,7 @@ export interface WorkerConfig {
   /**
    * Available tools for this worker
    */
-  tools?: Tool<unknown, unknown>[];
+  tools?: WorkerTool[];
 
   /**
    * System prompt for the worker
@@ -100,7 +112,7 @@ export interface WorkerConfig {
    * The config parameter contains LangGraph runtime configuration including
    * thread_id for checkpointing, which is required for interrupt functionality.
    */
-  executeFn?: (state: MultiAgentStateType, config?: RunnableConfig) => Promise<Partial<MultiAgentStateType>>;
+  executeFn?: (state: MultiAgentStateType, config?: WorkerExecutionConfig) => Promise<Partial<MultiAgentStateType>>;
 
   /**
    * ReAct agent instance

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CompiledStateGraph } from '@langchain/langgraph';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { MultiAgentStateType } from './state.js';
 import type { TaskResult } from './schemas.js';
 import { createLogger, LogLevel } from '@agentforge/core';
@@ -17,6 +18,61 @@ import { handleNodeError } from '../shared/error-handling.js';
 // Log level can be controlled via LOG_LEVEL environment variable
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
 const logger = createLogger('multi-agent', { level: logLevel });
+
+type ReActAgentGraph = CompiledStateGraph<string, unknown>;
+
+interface ReActAction {
+  name?: unknown;
+}
+
+interface ReActResultShape {
+  messages?: Array<{ content?: unknown }>;
+  actions?: ReActAction[];
+  iteration?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getReActResultShape(value: unknown): ReActResultShape {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const messages = Array.isArray(value.messages)
+    ? value.messages.filter((message): message is { content?: unknown } => isRecord(message))
+    : undefined;
+
+  const actions = Array.isArray(value.actions)
+    ? value.actions.filter((action): action is ReActAction => isRecord(action))
+    : undefined;
+
+  return {
+    messages,
+    actions,
+    iteration: value.iteration,
+  };
+}
+
+function extractResponse(result: unknown): string {
+  const { messages } = getReActResultShape(result);
+  const lastMessage = messages?.[messages.length - 1];
+  return typeof lastMessage?.content === 'string' ? lastMessage.content : 'No response';
+}
+
+function extractToolsUsed(result: unknown): string[] {
+  const { actions } = getReActResultShape(result);
+  const names = actions
+    ?.map((action) => action.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0) || [];
+  return [...new Set(names)];
+}
+
+function extractIteration(result: unknown): number {
+  const { iteration } = getReActResultShape(result);
+  return typeof iteration === 'number' ? iteration : 0;
+}
 
 /**
  * Check if an object is a ReAct agent (CompiledStateGraph)
@@ -34,11 +90,13 @@ const logger = createLogger('multi-agent', { level: logLevel });
  * console.log(isReActAgent({})); // false
  * ```
  */
-export function isReActAgent(obj: any): obj is CompiledStateGraph<any, any> {
-  return (
+export function isReActAgent(obj: unknown): obj is ReActAgentGraph {
+  return Boolean(
     obj &&
     typeof obj === 'object' &&
+    'invoke' in obj &&
     typeof obj.invoke === 'function' &&
+    'stream' in obj &&
     typeof obj.stream === 'function' &&
     // Additional check to ensure it's not just any object with invoke/stream
     (obj.constructor?.name === 'CompiledGraph' || obj.constructor?.name === 'CompiledStateGraph')
@@ -72,10 +130,10 @@ export function isReActAgent(obj: any): obj is CompiledStateGraph<any, any> {
  */
 export function wrapReActAgent(
   workerId: string,
-  agent: CompiledStateGraph<any, any>,
+  agent: ReActAgentGraph,
   verbose = false
-): (state: MultiAgentStateType, config?: any) => Promise<Partial<MultiAgentStateType>> {
-  return async (state: MultiAgentStateType, config?: any): Promise<Partial<MultiAgentStateType>> => {
+): (state: MultiAgentStateType, config?: RunnableConfig) => Promise<Partial<MultiAgentStateType>> {
+  return async (state: MultiAgentStateType, config?: RunnableConfig): Promise<Partial<MultiAgentStateType>> => {
     try {
       logger.debug('Wrapping ReAct agent execution', { workerId });
 
@@ -109,13 +167,15 @@ export function wrapReActAgent(
         ? `${config.configurable.thread_id}:worker:${workerId}`
         : undefined;
 
-      const workerConfig = workerThreadId ? {
-        ...config,
-        configurable: {
-          ...config.configurable,
-          thread_id: workerThreadId
+      const workerConfig: RunnableConfig | undefined = workerThreadId
+        ? {
+          ...config,
+          configurable: {
+            ...(config?.configurable ?? {}),
+            thread_id: workerThreadId
+          }
         }
-      } : config;
+        : config;
 
       logger.debug('Invoking ReAct agent with worker-specific config', {
         workerId,
@@ -127,7 +187,7 @@ export function wrapReActAgent(
       // Invoke ReAct agent with worker-specific config for separate checkpoint namespace
       // This ensures that when the worker's ReAct agent calls interrupt(), the checkpoint
       // is saved in a separate namespace and can be resumed independently
-      const result: any = await agent.invoke(
+      const result = await agent.invoke(
         {
           messages: [{ role: 'user', content: task }],
         },
@@ -135,7 +195,7 @@ export function wrapReActAgent(
       );
 
       // Extract response from ReAct agent's messages
-      const response = result.messages?.[result.messages.length - 1]?.content || 'No response';
+      const response = extractResponse(result);
 
       logger.debug('Received response from ReAct agent', {
         workerId,
@@ -143,8 +203,7 @@ export function wrapReActAgent(
       });
 
       // Extract tools used from ReAct agent's actions
-      const toolsUsed = result.actions?.map((action: any) => action.name).filter(Boolean) || [];
-      const uniqueTools = [...new Set(toolsUsed)]; // Remove duplicates
+      const uniqueTools = extractToolsUsed(result);
 
       if (uniqueTools.length > 0) {
         logger.debug('Tools used by ReAct agent', { workerId, tools: uniqueTools });
@@ -159,7 +218,7 @@ export function wrapReActAgent(
         success: true,
         metadata: {
           agent_type: 'react',
-          iterations: result.iteration || 0,
+          iterations: extractIteration(result),
           tools_used: uniqueTools,
         },
       };
@@ -168,9 +227,9 @@ export function wrapReActAgent(
       return {
         completedTasks: [taskResult],
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Handle error with proper GraphInterrupt detection
-      const errorMessage = handleNodeError(error, `react-agent:${workerId}`, false);
+      const errorMessage = handleNodeError(error, `react-agent:${workerId}`, verbose);
 
       logger.error('Error in ReAct agent execution', {
         workerId,
@@ -206,4 +265,3 @@ export function wrapReActAgent(
     }
   };
 }
-

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -55,22 +55,22 @@ function getReActResultShape(value: unknown): ReActResultShape {
   };
 }
 
-function extractResponse(result: unknown): string {
-  const { messages } = getReActResultShape(result);
+function extractResponse(resultShape: ReActResultShape): string {
+  const { messages } = resultShape;
   const lastMessage = messages?.[messages.length - 1];
   return typeof lastMessage?.content === 'string' ? lastMessage.content : 'No response';
 }
 
-function extractToolsUsed(result: unknown): string[] {
-  const { actions } = getReActResultShape(result);
+function extractToolsUsed(resultShape: ReActResultShape): string[] {
+  const { actions } = resultShape;
   const names = actions
     ?.map((action) => action.name)
     .filter((name): name is string => typeof name === 'string' && name.length > 0) || [];
   return [...new Set(names)];
 }
 
-function extractIteration(result: unknown): number {
-  const { iteration } = getReActResultShape(result);
+function extractIteration(resultShape: ReActResultShape): number {
+  const { iteration } = resultShape;
   return typeof iteration === 'number' ? iteration : 0;
 }
 
@@ -193,9 +193,10 @@ export function wrapReActAgent(
         },
         workerConfig  // Worker-specific config with unique thread_id
       );
+      const resultShape = getReActResultShape(result);
 
       // Extract response from ReAct agent's messages
-      const response = extractResponse(result);
+      const response = extractResponse(resultShape);
 
       logger.debug('Received response from ReAct agent', {
         workerId,
@@ -203,7 +204,7 @@ export function wrapReActAgent(
       });
 
       // Extract tools used from ReAct agent's actions
-      const uniqueTools = extractToolsUsed(result);
+      const uniqueTools = extractToolsUsed(resultShape);
 
       if (uniqueTools.length > 0) {
         logger.debug('Tools used by ReAct agent', { workerId, tools: uniqueTools });
@@ -218,7 +219,7 @@ export function wrapReActAgent(
         success: true,
         metadata: {
           agent_type: 'react',
-          iterations: extractIteration(result),
+          iterations: extractIteration(resultShape),
           tools_used: uniqueTools,
         },
       };

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -60,11 +60,53 @@ function getReActResultShape(value: unknown): ReActResultShape {
   };
 }
 
+function safeSerializeContent(content: unknown): string | undefined {
+  if (content === null || content === undefined) {
+    return undefined;
+  }
+
+  if (typeof content === 'string') {
+    return content.length > 0 ? content : undefined;
+  }
+
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((part): string => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (isRecord(part) && typeof part.text === 'string' && part.text.length > 0) {
+          return part.text;
+        }
+        try {
+          return JSON.stringify(part);
+        } catch {
+          return String(part);
+        }
+      })
+      .filter((part) => part.length > 0);
+
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+
+  try {
+    const serialized = JSON.stringify(content);
+    if (typeof serialized === 'string' && serialized.length > 0 && serialized !== 'null') {
+      return serialized;
+    }
+  } catch {
+    // Fallback handled below.
+  }
+
+  const fallback = String(content);
+  return fallback.length > 0 ? fallback : undefined;
+}
+
 function extractResponse(resultShape: ReActResultShape): string {
   const { messages } = resultShape;
   const lastMessage = messages?.[messages.length - 1];
-  const content = lastMessage?.content;
-  return typeof content === 'string' && content.length > 0 ? content : 'No response';
+  const serialized = safeSerializeContent(lastMessage?.content);
+  return serialized ?? 'No response';
 }
 
 function extractToolsUsed(resultShape: ReActResultShape): string[] {

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -63,7 +63,8 @@ function getReActResultShape(value: unknown): ReActResultShape {
 function extractResponse(resultShape: ReActResultShape): string {
   const { messages } = resultShape;
   const lastMessage = messages?.[messages.length - 1];
-  return typeof lastMessage?.content === 'string' ? lastMessage.content : 'No response';
+  const content = lastMessage?.content;
+  return typeof content === 'string' && content.length > 0 ? content : 'No response';
 }
 
 function extractToolsUsed(resultShape: ReActResultShape): string[] {
@@ -76,7 +77,7 @@ function extractToolsUsed(resultShape: ReActResultShape): string[] {
 
 function extractIteration(resultShape: ReActResultShape): number {
   const { iteration } = resultShape;
-  return typeof iteration === 'number' ? iteration : 0;
+  return typeof iteration === 'number' && Number.isFinite(iteration) ? iteration : 0;
 }
 
 /**

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -11,13 +11,14 @@ import type { CompiledStateGraph } from '@langchain/langgraph';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { MultiAgentStateType } from './state.js';
 import type { TaskResult } from './schemas.js';
+import type { WorkerExecutionConfig } from './types.js';
 import { createLogger, LogLevel } from '@agentforge/core';
 import { handleNodeError } from '../shared/error-handling.js';
 
 // Create logger for multi-agent utils
 // Log level can be controlled via LOG_LEVEL environment variable
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('multi-agent', { level: logLevel });
+const logger = createLogger('agentforge:patterns:multi-agent:utils', { level: logLevel });
 
 type ReActAgentGraph = CompiledStateGraph<string, unknown>;
 
@@ -33,6 +34,13 @@ interface ReActResultShape {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function toRunnableConfig(config: WorkerExecutionConfig | undefined): RunnableConfig | undefined {
+  if (!isRecord(config)) {
+    return undefined;
+  }
+  return config as RunnableConfig;
 }
 
 function getReActResultShape(value: unknown): ReActResultShape {
@@ -132,10 +140,14 @@ export function wrapReActAgent(
   workerId: string,
   agent: ReActAgentGraph,
   verbose = false
-): (state: MultiAgentStateType, config?: RunnableConfig) => Promise<Partial<MultiAgentStateType>> {
-  return async (state: MultiAgentStateType, config?: RunnableConfig): Promise<Partial<MultiAgentStateType>> => {
+): (state: MultiAgentStateType, config?: WorkerExecutionConfig) => Promise<Partial<MultiAgentStateType>> {
+  return async (
+    state: MultiAgentStateType,
+    config?: WorkerExecutionConfig
+  ): Promise<Partial<MultiAgentStateType>> => {
     try {
       logger.debug('Wrapping ReAct agent execution', { workerId });
+      const runnableConfig = toRunnableConfig(config);
 
       // Find current assignment for this worker
       const currentAssignment = state.activeAssignments.find(
@@ -163,23 +175,23 @@ export function wrapReActAgent(
       // Generate worker-specific thread_id for separate checkpoint namespace
       // This allows the worker's ReAct agent to have its own checkpoint that can be resumed independently
       // Format: {parent_thread_id}:worker:{workerId}
-      const workerThreadId = config?.configurable?.thread_id
-        ? `${config.configurable.thread_id}:worker:${workerId}`
+      const workerThreadId = runnableConfig?.configurable?.thread_id
+        ? `${runnableConfig.configurable.thread_id}:worker:${workerId}`
         : undefined;
 
       const workerConfig: RunnableConfig | undefined = workerThreadId
         ? {
-          ...config,
+          ...runnableConfig,
           configurable: {
-            ...(config?.configurable ?? {}),
+            ...(runnableConfig?.configurable ?? {}),
             thread_id: workerThreadId
           }
         }
-        : config;
+        : runnableConfig;
 
       logger.debug('Invoking ReAct agent with worker-specific config', {
         workerId,
-        parentThreadId: config?.configurable?.thread_id,
+        parentThreadId: runnableConfig?.configurable?.thread_id,
         workerThreadId,
         hasConfig: !!workerConfig
       });

--- a/packages/patterns/src/multi-agent/utils.ts
+++ b/packages/patterns/src/multi-agent/utils.ts
@@ -12,13 +12,10 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { MultiAgentStateType } from './state.js';
 import type { TaskResult } from './schemas.js';
 import type { WorkerExecutionConfig } from './types.js';
-import { createLogger, LogLevel } from '@agentforge/core';
+import { createPatternLogger } from '../shared/deduplication.js';
 import { handleNodeError } from '../shared/error-handling.js';
 
-// Create logger for multi-agent utils
-// Log level can be controlled via LOG_LEVEL environment variable
-const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('agentforge:patterns:multi-agent:utils', { level: logLevel });
+const logger = createPatternLogger('agentforge:patterns:multi-agent:utils');
 
 type ReActAgentGraph = CompiledStateGraph<string, unknown>;
 
@@ -33,7 +30,7 @@ interface ReActResultShape {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function toRunnableConfig(config: WorkerExecutionConfig | undefined): RunnableConfig | undefined {

--- a/packages/patterns/tests/multi-agent/utils.test.ts
+++ b/packages/patterns/tests/multi-agent/utils.test.ts
@@ -186,6 +186,114 @@ describe('Multi-Agent Utils', () => {
       expect(mockReActAgent.invoke).not.toHaveBeenCalled();
       expect(result).toEqual({});
     });
+
+    it('should serialize structured non-string response content', async () => {
+      const mockReActAgent = {
+        invoke: vi.fn(async () => ({
+          messages: [
+            {
+              content: [
+                { type: 'text', text: 'Structured response' },
+                { type: 'meta', source: 'tool-a' },
+              ],
+            },
+          ],
+          actions: [],
+          iteration: 1,
+        })),
+      } as any;
+
+      const state: MultiAgentStateType = {
+        input: 'Test input',
+        messages: [],
+        workers: {
+          worker1: {
+            skills: ['skill1'],
+            tools: [],
+            available: true,
+            currentWorkload: 1,
+          },
+        },
+        currentAgent: 'worker1',
+        routingHistory: [],
+        activeAssignments: [
+          {
+            id: 'assignment-1',
+            workerId: 'worker1',
+            task: 'Summarize result',
+            priority: 5,
+            assignedAt: Date.now(),
+          },
+        ],
+        completedTasks: [],
+        handoffs: [],
+        status: 'executing',
+        iteration: 1,
+        maxIterations: 10,
+        response: '',
+      };
+
+      const wrappedAgent = wrapReActAgent('worker1', mockReActAgent);
+      const result = await wrappedAgent(state);
+      const taskResult = result.completedTasks?.[0];
+
+      expect(taskResult?.success).toBe(true);
+      expect(taskResult?.result).toContain('Structured response');
+      expect(taskResult?.result).toContain('"source":"tool-a"');
+    });
+
+    it('should emit more error console output when verbose is enabled', async () => {
+      const mockReActAgent = {
+        invoke: vi.fn(async () => {
+          throw new Error('forced failure');
+        }),
+      } as any;
+
+      const state: MultiAgentStateType = {
+        input: 'Test input',
+        messages: [],
+        workers: {
+          worker1: {
+            skills: ['skill1'],
+            tools: [],
+            available: true,
+            currentWorkload: 1,
+          },
+        },
+        currentAgent: 'worker1',
+        routingHistory: [],
+        activeAssignments: [
+          {
+            id: 'assignment-1',
+            workerId: 'worker1',
+            task: 'Fail task',
+            priority: 5,
+            assignedAt: Date.now(),
+          },
+        ],
+        completedTasks: [],
+        handoffs: [],
+        status: 'executing',
+        iteration: 1,
+        maxIterations: 10,
+        response: '',
+      };
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const nonVerboseAgent = wrapReActAgent('worker1', mockReActAgent, false);
+      await nonVerboseAgent(state);
+      const nonVerboseCalls = consoleErrorSpy.mock.calls.length;
+
+      consoleErrorSpy.mockClear();
+
+      const verboseAgent = wrapReActAgent('worker1', mockReActAgent, true);
+      await verboseAgent(state);
+      const verboseCalls = consoleErrorSpy.mock.calls.length;
+
+      consoleErrorSpy.mockRestore();
+
+      expect(verboseCalls).toBeGreaterThan(nonVerboseCalls);
+    });
   });
 });
-

--- a/packages/tools/src/data/neo4j/connection.ts
+++ b/packages/tools/src/data/neo4j/connection.ts
@@ -12,8 +12,7 @@ const logger = createLogger('agentforge:tools:neo4j:pool');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Keep legacy query helper compatibility for untyped callers.
 type Neo4jQueryResult = any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Keep permissive query parameter typing for backward compatibility.
-type Neo4jQueryParameters = Record<string, any>;
+type Neo4jQueryParameters = Record<string, unknown>;
 
 /**
  * Neo4j connection pool singleton

--- a/packages/tools/src/data/neo4j/connection.ts
+++ b/packages/tools/src/data/neo4j/connection.ts
@@ -10,6 +10,11 @@ import type { Neo4jConfig } from './types.js';
 
 const logger = createLogger('agentforge:tools:neo4j:pool');
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Keep legacy query helper compatibility for untyped callers.
+type Neo4jQueryResult = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Keep permissive query parameter typing for backward compatibility.
+type Neo4jQueryParameters = Record<string, any>;
+
 /**
  * Neo4j connection pool singleton
  */
@@ -97,9 +102,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a query with automatic session management
    */
-  async executeQuery<T = unknown>(
+  async executeQuery<T = Neo4jQueryResult>(
     cypher: string,
-    parameters?: Record<string, unknown>,
+    parameters?: Neo4jQueryParameters,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);
@@ -114,9 +119,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a read query
    */
-  async executeReadQuery<T = unknown>(
+  async executeReadQuery<T = Neo4jQueryResult>(
     cypher: string,
-    parameters?: Record<string, unknown>,
+    parameters?: Neo4jQueryParameters,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);
@@ -131,9 +136,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a write query
    */
-  async executeWriteQuery<T = unknown>(
+  async executeWriteQuery<T = Neo4jQueryResult>(
     cypher: string,
-    parameters?: Record<string, unknown>,
+    parameters?: Neo4jQueryParameters,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);

--- a/packages/tools/src/data/neo4j/connection.ts
+++ b/packages/tools/src/data/neo4j/connection.ts
@@ -97,9 +97,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a query with automatic session management
    */
-  async executeQuery<T = any>(
+  async executeQuery<T = unknown>(
     cypher: string,
-    parameters?: Record<string, any>,
+    parameters?: Record<string, unknown>,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);
@@ -114,9 +114,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a read query
    */
-  async executeReadQuery<T = any>(
+  async executeReadQuery<T = unknown>(
     cypher: string,
-    parameters?: Record<string, any>,
+    parameters?: Record<string, unknown>,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);
@@ -131,9 +131,9 @@ class Neo4jConnectionPool {
   /**
    * Execute a write query
    */
-  async executeWriteQuery<T = any>(
+  async executeWriteQuery<T = unknown>(
     cypher: string,
-    parameters?: Record<string, any>,
+    parameters?: Record<string, unknown>,
     database?: string
   ): Promise<T[]> {
     const session = this.getSession(database);
@@ -216,4 +216,3 @@ export async function initializeFromEnv(): Promise<void> {
 
   await neo4jPool.initialize(config);
 }
-

--- a/packages/tools/src/data/neo4j/utils/result-formatter.ts
+++ b/packages/tools/src/data/neo4j/utils/result-formatter.ts
@@ -114,8 +114,7 @@ export function formatResults(records: Neo4jRecord[]): Array<Record<string, unkn
   return records.map((record) => {
     const formatted: Record<string, unknown> = {};
     for (const key of record.keys) {
-      const lookupKey = String(key);
-      formatted[lookupKey] = formatValue(record.get(lookupKey));
+      formatted[String(key)] = formatValue(record.get(key));
     }
     return formatted;
   });

--- a/packages/tools/src/data/neo4j/utils/result-formatter.ts
+++ b/packages/tools/src/data/neo4j/utils/result-formatter.ts
@@ -8,9 +8,21 @@ import { Node, Relationship, Path, Integer } from 'neo4j-driver';
 import type { Neo4jNode, Neo4jRelationship, Neo4jPath } from '../types.js';
 
 type Neo4jRecord = {
+  keys: string[];
+  get: (key: string) => unknown;
+};
+
+type RawNeo4jRecord = {
   keys: PropertyKey[];
   get: (key: PropertyKey) => unknown;
 };
+
+function normalizeRecord(record: RawNeo4jRecord): Neo4jRecord {
+  return {
+    keys: record.keys.map((key) => String(key)),
+    get: (key: string) => record.get(key),
+  };
+}
 
 /**
  * Convert Neo4j Integer to JavaScript number or string
@@ -110,11 +122,12 @@ export function formatPath(path: Path): Neo4jPath {
 /**
  * Format query results to JSON-serializable format
  */
-export function formatResults(records: Neo4jRecord[]): Array<Record<string, unknown>> {
-  return records.map((record) => {
+export function formatResults(records: RawNeo4jRecord[]): Array<Record<string, unknown>> {
+  return records.map((rawRecord) => {
+    const record = normalizeRecord(rawRecord);
     const formatted: Record<string, unknown> = {};
     for (const key of record.keys) {
-      formatted[String(key)] = formatValue(record.get(key));
+      formatted[key] = formatValue(record.get(key));
     }
     return formatted;
   });

--- a/packages/tools/src/data/neo4j/utils/result-formatter.ts
+++ b/packages/tools/src/data/neo4j/utils/result-formatter.ts
@@ -18,9 +18,20 @@ type RawNeo4jRecord = {
 };
 
 function normalizeRecord(record: RawNeo4jRecord): Neo4jRecord {
+  const originalKeyByString = new Map<string, PropertyKey>();
+  const normalizedKeys: string[] = [];
+
+  for (const key of record.keys) {
+    const keyString = String(key);
+    if (!originalKeyByString.has(keyString)) {
+      originalKeyByString.set(keyString, key);
+      normalizedKeys.push(keyString);
+    }
+  }
+
   return {
-    keys: record.keys.map((key) => String(key)),
-    get: (key: string) => record.get(key),
+    keys: normalizedKeys,
+    get: (key: string) => record.get(originalKeyByString.get(key) ?? key),
   };
 }
 

--- a/packages/tools/src/data/neo4j/utils/result-formatter.ts
+++ b/packages/tools/src/data/neo4j/utils/result-formatter.ts
@@ -114,7 +114,8 @@ export function formatResults(records: Neo4jRecord[]): Array<Record<string, unkn
   return records.map((record) => {
     const formatted: Record<string, unknown> = {};
     for (const key of record.keys) {
-      formatted[String(key)] = formatValue(record.get(key));
+      const lookupKey = String(key);
+      formatted[lookupKey] = formatValue(record.get(lookupKey));
     }
     return formatted;
   });

--- a/packages/tools/src/data/neo4j/utils/result-formatter.ts
+++ b/packages/tools/src/data/neo4j/utils/result-formatter.ts
@@ -7,6 +7,11 @@
 import { Node, Relationship, Path, Integer } from 'neo4j-driver';
 import type { Neo4jNode, Neo4jRelationship, Neo4jPath } from '../types.js';
 
+type Neo4jRecord = {
+  keys: PropertyKey[];
+  get: (key: PropertyKey) => unknown;
+};
+
 /**
  * Convert Neo4j Integer to JavaScript number or string
  */
@@ -20,7 +25,7 @@ export function formatInteger(value: Integer): number | string {
 /**
  * Format any Neo4j value to JSON-serializable format
  */
-export function formatValue(value: any): any {
+export function formatValue(value: unknown): unknown {
   if (value === null || value === undefined) {
     return value;
   }
@@ -52,7 +57,7 @@ export function formatValue(value: any): any {
 
   // Handle objects
   if (typeof value === 'object') {
-    const formatted: Record<string, any> = {};
+    const formatted: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
       formatted[key] = formatValue(val);
     }
@@ -69,7 +74,7 @@ export function formatNode(node: Node): Neo4jNode {
   return {
     identity: formatInteger(node.identity),
     labels: node.labels,
-    properties: formatValue(node.properties),
+    properties: formatValue(node.properties) as Neo4jNode['properties'],
   };
 }
 
@@ -82,7 +87,7 @@ export function formatRelationship(rel: Relationship): Neo4jRelationship {
     type: rel.type,
     start: formatInteger(rel.start),
     end: formatInteger(rel.end),
-    properties: formatValue(rel.properties),
+    properties: formatValue(rel.properties) as Neo4jRelationship['properties'],
   };
 }
 
@@ -105,13 +110,12 @@ export function formatPath(path: Path): Neo4jPath {
 /**
  * Format query results to JSON-serializable format
  */
-export function formatResults(records: any[]): any[] {
+export function formatResults(records: Neo4jRecord[]): Array<Record<string, unknown>> {
   return records.map((record) => {
-    const formatted: Record<string, any> = {};
+    const formatted: Record<string, unknown> = {};
     for (const key of record.keys) {
-      formatted[key] = formatValue(record.get(key));
+      formatted[String(key)] = formatValue(record.get(key));
     }
     return formatted;
   });
 }
-

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -82,19 +82,31 @@
 ### Checklist
 - [x] Create branch `fix/st-08003-tools-patterns-type-hardening`
   - Created as `codex/fix/st-08003-tools-patterns-type-hardening` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
-- [ ] Reduce explicit `any` usage in top warning files under `packages/tools/src/**`
-- [ ] Reduce explicit `any` usage in top warning files under `packages/patterns/src/**`
-- [ ] Introduce shared helper types where useful to avoid repeated broad casts
-- [ ] Confirm no public API regressions for touched signatures (or explicitly document intentional changes)
-- [ ] Add focused tests or adapt existing tests for behavior-sensitive changes
-- [ ] Record before/after warning counts for touched files in PR/story docs
-- [ ] Add or update story documentation at `docs/st08003-tools-patterns-type-hardening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create draft PR with story ID in title
+  - PR #61: https://github.com/TVScoundrel/agentforge/pull/61
+- [x] Reduce explicit `any` usage in top warning files under `packages/tools/src/**`
+  - Eliminated explicit-`any` usage in `packages/tools/src/data/neo4j/connection.ts` and `packages/tools/src/data/neo4j/utils/result-formatter.ts`
+- [x] Reduce explicit `any` usage in top warning files under `packages/patterns/src/**`
+  - Eliminated explicit-`any` usage in `packages/patterns/src/multi-agent/agent.ts`, `utils.ts`, and `types.ts`
+- [x] Introduce shared helper types where useful to avoid repeated broad casts
+  - Added ReAct result-narrowing helpers in `packages/patterns/src/multi-agent/utils.ts`
+- [x] Confirm no public API regressions for touched signatures (or explicitly document intentional changes)
+  - No intentional API behavior changes; package typechecks pass after refactor
+- [x] Add focused tests or adapt existing tests for behavior-sensitive changes
+  - `pnpm test --run packages/patterns/tests/multi-agent/agent.test.ts packages/patterns/tests/multi-agent/utils.test.ts packages/tools/tests/data/neo4j.test.ts` -> 20 passed, 13 skipped
+- [x] Record before/after warning counts for touched files in PR/story docs
+  - Recorded in `docs/st08003-tools-patterns-type-hardening.md` (`164 -> 120`, delta `-44`)
+- [x] Add or update story documentation at `docs/st08003-tools-patterns-type-hardening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Existing tests cover touched multi-agent/neo4j behavior; focused suite re-run and passing
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `146 passed | 16 skipped` files; `2074 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - Commits on branch: `21d51bd`, `3dc27f9` (plus checklist/tracker sync in finalization commit)
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #61 marked ready: https://github.com/TVScoundrel/agentforge/pull/61
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -85,7 +85,7 @@
 - [x] Create draft PR with story ID in title
   - PR #61: https://github.com/TVScoundrel/agentforge/pull/61
 - [x] Reduce explicit `any` usage in top warning files under `packages/tools/src/**`
-  - Eliminated explicit-`any` usage in `packages/tools/src/data/neo4j/connection.ts` and `packages/tools/src/data/neo4j/utils/result-formatter.ts`
+  - Reduced explicit-`any` usage in `packages/tools/src/data/neo4j/connection.ts` and `packages/tools/src/data/neo4j/utils/result-formatter.ts`; remaining usage is confined to a single suppressed legacy boundary in `connection.ts`
 - [x] Reduce explicit `any` usage in top warning files under `packages/patterns/src/**`
   - Eliminated explicit-`any` usage in `packages/patterns/src/multi-agent/agent.ts`, `utils.ts`, and `types.ts`
 - [x] Introduce shared helper types where useful to avoid repeated broad casts

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -77,10 +77,11 @@
 
 ## ST-08003: Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
 
-**Branch:** `fix/st-08003-tools-patterns-type-hardening`
+**Branch:** `codex/fix/st-08003-tools-patterns-type-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-08003-tools-patterns-type-hardening`
+- [x] Create branch `fix/st-08003-tools-patterns-type-hardening`
+  - Created as `codex/fix/st-08003-tools-patterns-type-hardening` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
 - [ ] Reduce explicit `any` usage in top warning files under `packages/tools/src/**`
 - [ ] Reduce explicit `any` usage in top warning files under `packages/patterns/src/**`

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -91,7 +91,7 @@
 - [x] Introduce shared helper types where useful to avoid repeated broad casts
   - Added ReAct result-narrowing helpers in `packages/patterns/src/multi-agent/utils.ts`
 - [x] Confirm no public API regressions for touched signatures (or explicitly document intentional changes)
-  - No intentional API behavior changes; package typechecks pass after refactor
+  - Public signatures remain compatible; intentional bug fix documented: `wrapReActAgent` error path now honors configured `verbose` logging
 - [x] Add focused tests or adapt existing tests for behavior-sensitive changes
   - `pnpm test --run packages/patterns/tests/multi-agent/agent.test.ts packages/patterns/tests/multi-agent/utils.test.ts packages/tools/tests/data/neo4j.test.ts` -> 20 passed, 13 skipped
 - [x] Record before/after warning counts for touched files in PR/story docs

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -80,7 +80,7 @@
 **Branch:** `codex/fix/st-08003-tools-patterns-type-hardening`
 
 ### Checklist
-- [x] Create branch `fix/st-08003-tools-patterns-type-hardening`
+- [x] Create branch `codex/fix/st-08003-tools-patterns-type-hardening`
   - Created as `codex/fix/st-08003-tools-patterns-type-hardening` (workspace branch-prefix policy)
 - [x] Create draft PR with story ID in title
   - PR #61: https://github.com/TVScoundrel/agentforge/pull/61

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -777,6 +777,7 @@
 **Priority:** P1 (High)
 **Estimate:** 4 hours
 **Dependencies:** ST-08001
+**Status:** In Progress (2026-03-10)
 
 **Acceptance criteria:**
 - [ ] `@typescript-eslint/no-explicit-any` warnings are reduced in high-warning runtime files within `packages/tools/src/**` and `packages/patterns/src/**`

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -777,7 +777,7 @@
 **Priority:** P1 (High)
 **Estimate:** 4 hours
 **Dependencies:** ST-08001
-**Status:** In Progress (2026-03-10)
+**Status:** In Review (PR #61, 2026-03-10)
 
 **Acceptance criteria:**
 - [ ] `@typescript-eslint/no-explicit-any` warnings are reduced in high-warning runtime files within `packages/tools/src/**` and `packages/patterns/src/**`

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,9 +14,6 @@
 
 ## Ready
 
-- [ ] ST-08003 Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns`)
-  - Dependencies: ST-08001 (merged)
 - [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
   - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
   - Dependencies: ST-08001 (merged)
@@ -25,7 +22,10 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- [ ] ST-08003 Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns`)
+  - Branch: `codex/fix/st-08003-tools-patterns-type-hardening`
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -90,4 +90,4 @@ _No stories currently in backlog_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001 and ST-08002 merged (PR #59, PR #60); ST-08003 and ST-08004 promoted to Ready
+- ST-08001 and ST-08002 merged (PR #59, PR #60); ST-08003 moved to In Progress and ST-08004 remains Ready

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -22,16 +22,17 @@
 
 ## In Progress
 
-- [ ] ST-08003 Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns`)
-  - Branch: `codex/fix/st-08003-tools-patterns-type-hardening`
-  - Dependencies: ST-08001 (merged)
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- [ ] ST-08003 Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08003: Hardening Pass 1 for @agentforge/tools and @agentforge/patterns`)
+  - Branch: `codex/fix/st-08003-tools-patterns-type-hardening`
+  - PR: https://github.com/TVScoundrel/agentforge/pull/61
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -90,4 +91,4 @@ _No stories currently in backlog_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001 and ST-08002 merged (PR #59, PR #60); ST-08003 moved to In Progress and ST-08004 remains Ready
+- ST-08001 and ST-08002 merged (PR #59, PR #60); ST-08003 moved to In Review (PR #61) and ST-08004 remains Ready


### PR DESCRIPTION
## Story
ST-08003 - Hardening Pass 1 for `@agentforge/tools` and `@agentforge/patterns`

## What Changed
- Reduced explicit `any` usage in high-warning runtime files for tools/patterns.
- Added safer `unknown` boundaries and narrowing helpers for multi-agent ReAct flows.
- Hardened Neo4j connection/result formatting types with behavior-preserving refactors.
- Fixed a logging-path bug in `wrapReActAgent`: error handling now honors the configured `verbose` flag instead of always suppressing error output.
- Updated story documentation with warning deltas and validation evidence.

## Acceptance Criteria Coverage
- [x] `@typescript-eslint/no-explicit-any` warnings reduced in high-warning runtime files under `packages/tools/src/**` and `packages/patterns/src/**`
- [x] Shared helper/type aliases introduced where useful to avoid repeated broad casts
- [x] Public function signatures remain backward compatible (with one intentional non-breaking bug fix in verbose error logging)
- [x] Tests covering touched packages pass with no functional regressions
- [x] Story documentation updated at `docs/st08003-tools-patterns-type-hardening.md`

## Validation Performed
- Focused package checks
  - `pnpm --filter @agentforge/patterns typecheck`
  - `pnpm --filter @agentforge/tools typecheck`
  - `pnpm exec eslint packages/patterns/src/multi-agent/agent.ts packages/patterns/src/multi-agent/utils.ts packages/patterns/src/multi-agent/types.ts packages/tools/src/data/neo4j/connection.ts packages/tools/src/data/neo4j/utils/result-formatter.ts`
  - `pnpm test --run packages/patterns/tests/multi-agent/agent.test.ts packages/patterns/tests/multi-agent/utils.test.ts packages/tools/tests/data/neo4j.test.ts` -> `20 passed`, `13 skipped`
- Full repo gates
  - `pnpm test --run` -> `146 passed | 16 skipped` files; `2074 passed | 286 skipped` tests
  - `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Warning Delta (Tools + Patterns src)
- Before: `164`
- After: `120`
- Delta: `-44`

## Status
Ready for review
