### PR TITLE
ST-08004: Test/Example Typing Policy and Targeted Cleanup

### DIFF
--- a/docs/st08004-test-example-typing-policy.md
+++ b/docs/st08004-test-example-typing-policy.md
@@ -56,3 +56,8 @@ These can be reduced further in follow-up cleanup slices without broad behavior 
   - Result: `2` files passed, `37` tests passed.
 - `pnpm exec eslint packages/core/tests/langgraph/builders/subgraph.test.ts packages/cli/tests/utils/package-manager.test.ts`
   - No `no-explicit-any` warnings in touched files.
+- `pnpm test --run`
+  - Result: `146` passed, `16` skipped test files (`162` total)
+  - Result: `2076` passed, `286` skipped tests (`2362` total)
+- `pnpm lint`
+  - Result: exit code `0` (warnings-only, no lint errors)

--- a/docs/st08004-test-example-typing-policy.md
+++ b/docs/st08004-test-example-typing-policy.md
@@ -1,0 +1,58 @@
+# ST-08004: Test/Example Typing Policy and Targeted Cleanup
+
+## Scope
+Define and apply a practical `no-explicit-any` policy for tests/examples, then remove low-effort warning hotspots without reducing test readability.
+
+## Policy
+
+### 1) Runtime `src/**` code
+- `any` remains discouraged and should be replaced with concrete types or `unknown` + narrowing.
+
+### 2) Tests/examples/templates
+- Prefer concrete types first.
+- Use `unknown` at mock boundaries when exact typing is not worth the maintenance cost.
+- Allow explicit `any` only when required by third-party mock surfaces or intentionally untyped dynamic payloads.
+- When explicit `any` is intentionally kept, add a localized rationale comment (or scoped eslint disable) at the usage site.
+
+## ESLint Scoping Update
+Updated root ESLint config (`eslint.config.js`) to make test/example policy explicit:
+- Added file-scoped override for `tests`, `__tests__`, `examples`, and `templates`.
+- Kept `@typescript-eslint/no-explicit-any` visibility as `warn`.
+- Enabled `ignoreRestArgs: true` in those scopes to reduce mock-signature noise.
+
+## Targeted Cleanup Performed
+
+### Files updated
+- `packages/core/tests/langgraph/builders/subgraph.test.ts`
+  - Replaced broad `as any` edge casts with `unknown`-based casts.
+- `packages/cli/tests/utils/package-manager.test.ts`
+  - Replaced `any`-typed mock parameters with `string`.
+  - Replaced repeated `{} as any`/`{ stdout: ... } as any` mocks with typed helper:
+    - `type ExecaResult = Awaited<ReturnType<typeof execa>>`
+    - `execaResult(...)` factory.
+
+## Lint Delta (`@typescript-eslint/no-explicit-any` in tests/examples/templates)
+Measured with:
+- `pnpm exec eslint packages --ext .ts,.js -f json`
+- Filtered to paths matching `tests|__tests__|examples|templates`.
+
+- Before: `358`
+- After: `283`
+- Delta: `-75`
+
+Focused touched-file deltas:
+- `packages/core/tests/langgraph/builders/subgraph.test.ts`: `46 -> 0`
+- `packages/cli/tests/utils/package-manager.test.ts`: `26 -> 0`
+
+## Remaining Warning Rationale
+Most remaining warnings are in older integration/fixture-heavy tests and examples where:
+- LangGraph or tool mocks rely on dynamic generic boundaries.
+- Test setup intentionally favors concise fixtures over strict type plumbing.
+
+These can be reduced further in follow-up cleanup slices without broad behavior risk.
+
+## Validation
+- `pnpm test --run packages/core/tests/langgraph/builders/subgraph.test.ts packages/cli/tests/utils/package-manager.test.ts`
+  - Result: `2` files passed, `37` tests passed.
+- `pnpm exec eslint packages/core/tests/langgraph/builders/subgraph.test.ts packages/cli/tests/utils/package-manager.test.ts`
+  - No `no-explicit-any` warnings in touched files.

--- a/docs/st08004-test-example-typing-policy.md
+++ b/docs/st08004-test-example-typing-policy.md
@@ -24,7 +24,7 @@ Updated root ESLint config (`eslint.config.js`) to make test/example policy expl
 
 ### Files updated
 - `packages/core/tests/langgraph/builders/subgraph.test.ts`
-  - Replaced broad `as any` edge casts with `unknown`-based casts.
+  - Replaced `START/END as any` edge casts with string node IDs `__start__`/`__end__` (the conventional LangGraph start/end node names used in this repo).
 - `packages/cli/tests/utils/package-manager.test.ts`
   - Replaced `any`-typed mock parameters with `string`.
   - Replaced repeated `{} as any`/`{ stdout: ... } as any` mocks with typed helper:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,5 +22,17 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-console': 'off',
     },
+  },
+  {
+    files: [
+      '**/tests/**/*.{ts,tsx,js,mjs,cjs}',
+      '**/__tests__/**/*.{ts,tsx,js,mjs,cjs}',
+      '**/examples/**/*.{ts,tsx,js,mjs,cjs}',
+      '**/templates/**/*.{ts,tsx,js,mjs,cjs}',
+    ],
+    rules: {
+      // Tests/examples frequently use variadic mock signatures; keep visibility while reducing noise.
+      '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
+    },
   }
 );

--- a/packages/cli/tests/utils/package-manager.test.ts
+++ b/packages/cli/tests/utils/package-manager.test.ts
@@ -15,6 +15,10 @@ import { execa } from 'execa';
 vi.mock('fs-extra');
 vi.mock('execa');
 
+type ExecaResult = Awaited<ReturnType<typeof execa>>;
+
+const execaResult = (stdout = ''): ExecaResult => ({ stdout } as unknown as ExecaResult);
+
 describe('Package Manager Utils', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -22,7 +26,7 @@ describe('Package Manager Utils', () => {
 
   describe('detectPackageManager', () => {
     it('should detect pnpm from lock file', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(async (path: any) => {
+      vi.mocked(fs.pathExists).mockImplementation(async (path: string) => {
         return path.includes('pnpm-lock.yaml');
       });
 
@@ -31,7 +35,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should detect yarn from lock file', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(async (path: any) => {
+      vi.mocked(fs.pathExists).mockImplementation(async (path: string) => {
         return path.includes('yarn.lock');
       });
 
@@ -40,7 +44,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should detect npm from lock file', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(async (path: any) => {
+      vi.mocked(fs.pathExists).mockImplementation(async (path: string) => {
         return path.includes('package-lock.json');
       });
 
@@ -50,7 +54,7 @@ describe('Package Manager Utils', () => {
 
     it('should detect pnpm from availability', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValueOnce({ stdout: '8.0.0' } as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult('8.0.0'));
 
       const pm = await detectPackageManager('/test');
       expect(pm).toBe('pnpm');
@@ -60,7 +64,7 @@ describe('Package Manager Utils', () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
       vi.mocked(execa)
         .mockRejectedValueOnce(new Error('pnpm not found'))
-        .mockResolvedValueOnce({ stdout: '1.22.0' } as any);
+        .mockResolvedValueOnce(execaResult('1.22.0'));
 
       const pm = await detectPackageManager('/test');
       expect(pm).toBe('yarn');
@@ -105,7 +109,7 @@ describe('Package Manager Utils', () => {
 
   describe('installDependencies', () => {
     it('should install dependencies with npm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await installDependencies('/test', 'npm');
 
@@ -116,7 +120,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should install dependencies with pnpm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await installDependencies('/test', 'pnpm');
 
@@ -127,7 +131,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should install dependencies with yarn', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await installDependencies('/test', 'yarn');
 
@@ -138,7 +142,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should default to pnpm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await installDependencies('/test');
 
@@ -152,7 +156,7 @@ describe('Package Manager Utils', () => {
   describe('addDependency', () => {
     it('should add production dependency with npm', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'lodash', { packageManager: 'npm' });
 
@@ -164,7 +168,7 @@ describe('Package Manager Utils', () => {
 
     it('should add dev dependency with npm', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'vitest', { packageManager: 'npm', dev: true });
 
@@ -176,7 +180,7 @@ describe('Package Manager Utils', () => {
 
     it('should add production dependency with pnpm', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'lodash', { packageManager: 'pnpm' });
 
@@ -188,7 +192,7 @@ describe('Package Manager Utils', () => {
 
     it('should add dev dependency with pnpm', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'vitest', { packageManager: 'pnpm', dev: true });
 
@@ -200,7 +204,7 @@ describe('Package Manager Utils', () => {
 
     it('should add production dependency with yarn', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'lodash', { packageManager: 'yarn' });
 
@@ -212,7 +216,7 @@ describe('Package Manager Utils', () => {
 
     it('should add dev dependency with yarn', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(false);
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'vitest', { packageManager: 'yarn', dev: true });
 
@@ -223,10 +227,10 @@ describe('Package Manager Utils', () => {
     });
 
     it('should auto-detect package manager', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(async (path: any) => {
+      vi.mocked(fs.pathExists).mockImplementation(async (path: string) => {
         return path.includes('pnpm-lock.yaml');
       });
-      vi.mocked(execa).mockResolvedValue({} as any);
+      vi.mocked(execa).mockResolvedValue(execaResult());
 
       await addDependency('/test', 'lodash');
 
@@ -239,7 +243,7 @@ describe('Package Manager Utils', () => {
 
   describe('runScript', () => {
     it('should run script with npm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await runScript('/test', 'build', 'npm');
 
@@ -250,7 +254,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should run script with pnpm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await runScript('/test', 'build', 'pnpm');
 
@@ -261,7 +265,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should run script with yarn', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await runScript('/test', 'test', 'yarn');
 
@@ -272,7 +276,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should default to pnpm', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await runScript('/test', 'lint');
 
@@ -285,7 +289,7 @@ describe('Package Manager Utils', () => {
 
   describe('publishPackage', () => {
     it('should publish with default options', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await publishPackage('/test');
 
@@ -296,7 +300,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should publish with custom tag', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await publishPackage('/test', { tag: 'beta' });
 
@@ -307,7 +311,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should publish with restricted access', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await publishPackage('/test', { access: 'restricted' });
 
@@ -318,7 +322,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should run dry-run publish', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await publishPackage('/test', { dryRun: true });
 
@@ -329,7 +333,7 @@ describe('Package Manager Utils', () => {
     });
 
     it('should publish with all options', async () => {
-      vi.mocked(execa).mockResolvedValueOnce({} as any);
+      vi.mocked(execa).mockResolvedValueOnce(execaResult());
 
       await publishPackage('/test', {
         tag: 'next',
@@ -344,4 +348,3 @@ describe('Package Manager Utils', () => {
     });
   });
 });
-

--- a/packages/core/tests/langgraph/builders/subgraph.test.ts
+++ b/packages/core/tests/langgraph/builders/subgraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { StateGraph, Annotation, START, END } from '@langchain/langgraph';
+import { StateGraph, Annotation } from '@langchain/langgraph';
 import { createSubgraph, composeGraphs } from '../../../src/langgraph/builders/subgraph';
 
 describe('Subgraph Composition', () => {
@@ -22,9 +22,9 @@ describe('Subgraph Composition', () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub1', (state) => ({ messages: ['sub1'], count: 1 }));
         graph.addNode('sub2', (state) => ({ messages: ['sub2'], count: 1 }));
-        graph.addEdge(START as unknown as string, 'sub1' as unknown as string);
-        graph.addEdge('sub1' as unknown as string, 'sub2' as unknown as string);
-        graph.addEdge('sub2' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'sub1');
+        graph.addEdge('sub1', 'sub2');
+        graph.addEdge('sub2', '__end__');
         return graph;
       });
 
@@ -47,9 +47,9 @@ describe('Subgraph Composition', () => {
       const processingSubgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('step1', (state) => ({ messages: ['step1'], count: 1 }));
         graph.addNode('step2', (state) => ({ messages: ['step2'], count: 1 }));
-        graph.addEdge(START as unknown as string, 'step1' as unknown as string);
-        graph.addEdge('step1' as unknown as string, 'step2' as unknown as string);
-        graph.addEdge('step2' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'step1');
+        graph.addEdge('step1', 'step2');
+        graph.addEdge('step2', '__end__');
         return graph;
       });
 
@@ -60,10 +60,10 @@ describe('Subgraph Composition', () => {
       mainGraph.addNode('process', processingSubgraph);
       mainGraph.addNode('finalize', (state) => ({ messages: ['finalize'], count: 1 }));
 
-      mainGraph.addEdge(START as unknown as string, 'prepare' as unknown as string);
-      mainGraph.addEdge('prepare' as unknown as string, 'process' as unknown as string);
-      mainGraph.addEdge('process' as unknown as string, 'finalize' as unknown as string);
-      mainGraph.addEdge('finalize' as unknown as string, END as unknown as string);
+      mainGraph.addEdge('__start__', 'prepare');
+      mainGraph.addEdge('prepare', 'process');
+      mainGraph.addEdge('process', 'finalize');
+      mainGraph.addEdge('finalize', '__end__');
 
       const app = mainGraph.compile();
       const result = await app.invoke({
@@ -84,8 +84,8 @@ describe('Subgraph Composition', () => {
       // Create inner subgraph
       const innerSubgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('inner', (state) => ({ messages: ['inner'], count: 1 }));
-        graph.addEdge(START as unknown as string, 'inner' as unknown as string);
-        graph.addEdge('inner' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'inner');
+        graph.addEdge('inner', '__end__');
         return graph;
       });
 
@@ -95,10 +95,10 @@ describe('Subgraph Composition', () => {
         // @ts-expect-error - LangGraph's complex generic types don't infer well here
         graph.addNode('nested', innerSubgraph);
         graph.addNode('outer2', (state) => ({ messages: ['outer2'], count: 1 }));
-        graph.addEdge(START as unknown as string, 'outer1' as unknown as string);
-        graph.addEdge('outer1' as unknown as string, 'nested' as unknown as string);
-        graph.addEdge('nested' as unknown as string, 'outer2' as unknown as string);
-        graph.addEdge('outer2' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'outer1');
+        graph.addEdge('outer1', 'nested');
+        graph.addEdge('nested', 'outer2');
+        graph.addEdge('outer2', '__end__');
         return graph;
       });
 
@@ -119,8 +119,8 @@ describe('Subgraph Composition', () => {
     it('should add subgraph as a node to parent graph', async () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub', (state) => ({ messages: ['sub'], count: 1 }));
-        graph.addEdge(START as unknown as string, 'sub' as unknown as string);
-        graph.addEdge('sub' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'sub');
+        graph.addEdge('sub', '__end__');
         return graph;
       });
 
@@ -129,9 +129,9 @@ describe('Subgraph Composition', () => {
 
       composeGraphs(mainGraph, subgraph, { name: 'subgraph_node' });
 
-      mainGraph.addEdge(START as unknown as string, 'main' as unknown as string);
-      mainGraph.addEdge('main' as unknown as string, 'subgraph_node' as unknown as string);
-      mainGraph.addEdge('subgraph_node' as unknown as string, END as unknown as string);
+      mainGraph.addEdge('__start__', 'main');
+      mainGraph.addEdge('main', 'subgraph_node');
+      mainGraph.addEdge('subgraph_node', '__end__');
 
       const app = mainGraph.compile();
       const result = await app.invoke({
@@ -148,8 +148,8 @@ describe('Subgraph Composition', () => {
     it('should return parent graph for chaining', () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub', (state) => state);
-        graph.addEdge(START as unknown as string, 'sub' as unknown as string);
-        graph.addEdge('sub' as unknown as string, END as unknown as string);
+        graph.addEdge('__start__', 'sub');
+        graph.addEdge('sub', '__end__');
         return graph;
       });
 
@@ -160,4 +160,3 @@ describe('Subgraph Composition', () => {
     });
   });
 });
-

--- a/packages/core/tests/langgraph/builders/subgraph.test.ts
+++ b/packages/core/tests/langgraph/builders/subgraph.test.ts
@@ -22,9 +22,9 @@ describe('Subgraph Composition', () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub1', (state) => ({ messages: ['sub1'], count: 1 }));
         graph.addNode('sub2', (state) => ({ messages: ['sub2'], count: 1 }));
-        graph.addEdge(START as any, 'sub1' as any);
-        graph.addEdge('sub1' as any, 'sub2' as any);
-        graph.addEdge('sub2' as any, END as any);
+        graph.addEdge(START as unknown as string, 'sub1' as unknown as string);
+        graph.addEdge('sub1' as unknown as string, 'sub2' as unknown as string);
+        graph.addEdge('sub2' as unknown as string, END as unknown as string);
         return graph;
       });
 
@@ -47,9 +47,9 @@ describe('Subgraph Composition', () => {
       const processingSubgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('step1', (state) => ({ messages: ['step1'], count: 1 }));
         graph.addNode('step2', (state) => ({ messages: ['step2'], count: 1 }));
-        graph.addEdge(START as any, 'step1' as any);
-        graph.addEdge('step1' as any, 'step2' as any);
-        graph.addEdge('step2' as any, END as any);
+        graph.addEdge(START as unknown as string, 'step1' as unknown as string);
+        graph.addEdge('step1' as unknown as string, 'step2' as unknown as string);
+        graph.addEdge('step2' as unknown as string, END as unknown as string);
         return graph;
       });
 
@@ -60,10 +60,10 @@ describe('Subgraph Composition', () => {
       mainGraph.addNode('process', processingSubgraph);
       mainGraph.addNode('finalize', (state) => ({ messages: ['finalize'], count: 1 }));
 
-      mainGraph.addEdge(START as any, 'prepare' as any);
-      mainGraph.addEdge('prepare' as any, 'process' as any);
-      mainGraph.addEdge('process' as any, 'finalize' as any);
-      mainGraph.addEdge('finalize' as any, END as any);
+      mainGraph.addEdge(START as unknown as string, 'prepare' as unknown as string);
+      mainGraph.addEdge('prepare' as unknown as string, 'process' as unknown as string);
+      mainGraph.addEdge('process' as unknown as string, 'finalize' as unknown as string);
+      mainGraph.addEdge('finalize' as unknown as string, END as unknown as string);
 
       const app = mainGraph.compile();
       const result = await app.invoke({
@@ -84,8 +84,8 @@ describe('Subgraph Composition', () => {
       // Create inner subgraph
       const innerSubgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('inner', (state) => ({ messages: ['inner'], count: 1 }));
-        graph.addEdge(START as any, 'inner' as any);
-        graph.addEdge('inner' as any, END as any);
+        graph.addEdge(START as unknown as string, 'inner' as unknown as string);
+        graph.addEdge('inner' as unknown as string, END as unknown as string);
         return graph;
       });
 
@@ -95,10 +95,10 @@ describe('Subgraph Composition', () => {
         // @ts-expect-error - LangGraph's complex generic types don't infer well here
         graph.addNode('nested', innerSubgraph);
         graph.addNode('outer2', (state) => ({ messages: ['outer2'], count: 1 }));
-        graph.addEdge(START as any, 'outer1' as any);
-        graph.addEdge('outer1' as any, 'nested' as any);
-        graph.addEdge('nested' as any, 'outer2' as any);
-        graph.addEdge('outer2' as any, END as any);
+        graph.addEdge(START as unknown as string, 'outer1' as unknown as string);
+        graph.addEdge('outer1' as unknown as string, 'nested' as unknown as string);
+        graph.addEdge('nested' as unknown as string, 'outer2' as unknown as string);
+        graph.addEdge('outer2' as unknown as string, END as unknown as string);
         return graph;
       });
 
@@ -119,8 +119,8 @@ describe('Subgraph Composition', () => {
     it('should add subgraph as a node to parent graph', async () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub', (state) => ({ messages: ['sub'], count: 1 }));
-        graph.addEdge(START as any, 'sub' as any);
-        graph.addEdge('sub' as any, END as any);
+        graph.addEdge(START as unknown as string, 'sub' as unknown as string);
+        graph.addEdge('sub' as unknown as string, END as unknown as string);
         return graph;
       });
 
@@ -129,9 +129,9 @@ describe('Subgraph Composition', () => {
 
       composeGraphs(mainGraph, subgraph, { name: 'subgraph_node' });
 
-      mainGraph.addEdge(START as any, 'main' as any);
-      mainGraph.addEdge('main' as any, 'subgraph_node' as any);
-      mainGraph.addEdge('subgraph_node' as any, END as any);
+      mainGraph.addEdge(START as unknown as string, 'main' as unknown as string);
+      mainGraph.addEdge('main' as unknown as string, 'subgraph_node' as unknown as string);
+      mainGraph.addEdge('subgraph_node' as unknown as string, END as unknown as string);
 
       const app = mainGraph.compile();
       const result = await app.invoke({
@@ -148,8 +148,8 @@ describe('Subgraph Composition', () => {
     it('should return parent graph for chaining', () => {
       const subgraph = createSubgraph<State>(TestState, (graph) => {
         graph.addNode('sub', (state) => state);
-        graph.addEdge(START as any, 'sub' as any);
-        graph.addEdge('sub' as any, END as any);
+        graph.addEdge(START as unknown as string, 'sub' as unknown as string);
+        graph.addEdge('sub' as unknown as string, END as unknown as string);
         return graph;
       });
 

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -121,12 +121,17 @@
   - Created as `codex/chore/st-08004-test-example-typing-policy` (workspace branch-prefix policy)
 - [x] Create draft PR with story ID in title
   - PR #62: https://github.com/TVScoundrel/agentforge/pull/62
-- [ ] Define and document policy for acceptable `any` usage in tests/examples vs required `unknown`/specific typing
-- [ ] Update ESLint configuration/scoping if needed so policy is explicit and enforceable
-- [ ] Remove low-effort explicit-`any` warnings in tests/examples while preserving readability
-- [ ] Capture lint output deltas and rationale for any remaining intentional `any` usage
-- [ ] Add or update story documentation at `docs/st08004-test-example-typing-policy.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Define and document policy for acceptable `any` usage in tests/examples vs required `unknown`/specific typing
+  - Policy documented in `docs/st08004-test-example-typing-policy.md`
+- [x] Update ESLint configuration/scoping if needed so policy is explicit and enforceable
+  - Added test/example/template scoped `no-explicit-any` rule override in root `eslint.config.js`
+- [x] Remove low-effort explicit-`any` warnings in tests/examples while preserving readability
+  - Cleaned hotspots in `packages/core/tests/langgraph/builders/subgraph.test.ts` and `packages/cli/tests/utils/package-manager.test.ts`
+- [x] Capture lint output deltas and rationale for any remaining intentional `any` usage
+  - Recorded in `docs/st08004-test-example-typing-policy.md` (`358 -> 283`, delta `-75`)
+- [x] Add or update story documentation at `docs/st08004-test-example-typing-policy.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Ran focused touched-area tests for updated files (37 passed)
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -114,11 +114,10 @@
 
 ## ST-08004: Test/Example Typing Policy and Targeted Cleanup
 
-**Branch:** `chore/st-08004-test-example-typing-policy`
+**Branch:** `codex/chore/st-08004-test-example-typing-policy`
 
 ### Checklist
-- [x] Create branch `chore/st-08004-test-example-typing-policy`
-  - Created as `codex/chore/st-08004-test-example-typing-policy` (workspace branch-prefix policy)
+- [x] Create branch `codex/chore/st-08004-test-example-typing-policy`
 - [x] Create draft PR with story ID in title
   - PR #62: https://github.com/TVScoundrel/agentforge/pull/62
 - [x] Define and document policy for acceptable `any` usage in tests/examples vs required `unknown`/specific typing

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -132,8 +132,15 @@
 - [x] Add or update story documentation at `docs/st08004-test-example-typing-policy.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Ran focused touched-area tests for updated files (37 passed)
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `146 passed | 16 skipped` files; `2076 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `8d1d88f` chore(st-08004): start story execution and move to in-progress
+  - `4668ad0` chore(st-08004): record draft pr and tracker links
+  - `59f5d0b` refactor(st-08004): apply test typing policy and reduce any hotspots
+  - Plus finalization commit for in-review transition and checklist completion
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #62 marked ready: https://github.com/TVScoundrel/agentforge/pull/62
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -140,7 +140,7 @@
   - `8d1d88f` chore(st-08004): start story execution and move to in-progress
   - `4668ad0` chore(st-08004): record draft pr and tracker links
   - `59f5d0b` refactor(st-08004): apply test typing policy and reduce any hotspots
-  - Plus finalization commit for in-review transition and checklist completion
+  - `deb505c` docs(st-08004): finalize validation and move story to in-review
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #62 marked ready: https://github.com/TVScoundrel/agentforge/pull/62
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -117,7 +117,8 @@
 **Branch:** `chore/st-08004-test-example-typing-policy`
 
 ### Checklist
-- [ ] Create branch `chore/st-08004-test-example-typing-policy`
+- [x] Create branch `chore/st-08004-test-example-typing-policy`
+  - Created as `codex/chore/st-08004-test-example-typing-policy` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
 - [ ] Define and document policy for acceptable `any` usage in tests/examples vs required `unknown`/specific typing
 - [ ] Update ESLint configuration/scoping if needed so policy is explicit and enforceable

--- a/planning/checklists/epic-08-story-tasks.md
+++ b/planning/checklists/epic-08-story-tasks.md
@@ -119,7 +119,8 @@
 ### Checklist
 - [x] Create branch `chore/st-08004-test-example-typing-policy`
   - Created as `codex/chore/st-08004-test-example-typing-policy` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #62: https://github.com/TVScoundrel/agentforge/pull/62
 - [ ] Define and document policy for acceptable `any` usage in tests/examples vs required `unknown`/specific typing
 - [ ] Update ESLint configuration/scoping if needed so policy is explicit and enforceable
 - [ ] Remove low-effort explicit-`any` warnings in tests/examples while preserving readability

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -794,7 +794,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-08001
-**Status:** In Progress (branch: `codex/chore/st-08004-test-example-typing-policy`, 2026-03-12)
+**Status:** In Progress (PR #62, branch: `codex/chore/st-08004-test-example-typing-policy`, 2026-03-12)
 
 **Acceptance criteria:**
 - [ ] Policy documented for when `any` is acceptable in tests/examples vs when `unknown`/specific types are required

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -794,6 +794,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-08001
+**Status:** In Progress (branch: `codex/chore/st-08004-test-example-typing-policy`, 2026-03-12)
 
 **Acceptance criteria:**
 - [ ] Policy documented for when `any` is acceptable in tests/examples vs when `unknown`/specific types are required

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -794,7 +794,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-08001
-**Status:** In Progress (PR #62, branch: `codex/chore/st-08004-test-example-typing-policy`, 2026-03-12)
+**Status:** In Review (PR #62, 2026-03-12)
 
 **Acceptance criteria:**
 - [ ] Policy documented for when `any` is acceptable in tests/examples vs when `unknown`/specific types are required

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-11
+**Last Updated:** 2026-03-12
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,15 +14,16 @@
 
 ## Ready
 
-- [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
-  - Dependencies: ST-08001 (merged)
+_No stories currently ready_
 
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
+  - Branch: `codex/chore/st-08004-test-example-typing-policy`
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -87,4 +88,4 @@ _No stories currently in backlog_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001, ST-08002, and ST-08003 merged (PR #59, PR #60, PR #61); ST-08004 remains Ready
+- ST-08001, ST-08002, and ST-08003 merged (PR #59, PR #60, PR #61); ST-08004 moved to In Progress

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,17 +20,17 @@ _No stories currently ready_
 
 ## In Progress
 
-- [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
-  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
-  - Branch: `codex/chore/st-08004-test-example-typing-policy`
-  - PR: https://github.com/TVScoundrel/agentforge/pull/62
-  - Dependencies: ST-08001 (merged)
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
+  - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
+  - Branch: `codex/chore/st-08004-test-example-typing-policy`
+  - PR: https://github.com/TVScoundrel/agentforge/pull/62
+  - Dependencies: ST-08001 (merged)
 
 ---
 
@@ -89,4 +89,4 @@ _No stories currently in backlog_
 - ✅ ST-07006 complete - release scripts and checklist updated for skills package (merged 2026-02-25)
 - Epic 07 (Extract Skills into Dedicated Package) — all 6 stories merged; epic complete
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
-- ST-08001, ST-08002, and ST-08003 merged (PR #59, PR #60, PR #61); ST-08004 moved to In Progress
+- ST-08001, ST-08002, and ST-08003 merged (PR #59, PR #60, PR #61); ST-08004 moved to In Review (PR #62)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -23,6 +23,7 @@ _No stories currently ready_
 - [ ] ST-08004 Test/Example Typing Policy and Targeted Cleanup
   - Checklist: `planning/checklists/epic-08-story-tasks.md` (`## ST-08004: Test/Example Typing Policy and Targeted Cleanup`)
   - Branch: `codex/chore/st-08004-test-example-typing-policy`
+  - PR: https://github.com/TVScoundrel/agentforge/pull/62
   - Dependencies: ST-08001 (merged)
 
 ---


### PR DESCRIPTION
## Story
ST-08004 — Test/Example Typing Policy and Targeted Cleanup

## What Changed
- Added explicit test/example/template `no-explicit-any` scoping in root ESLint config (`ignoreRestArgs: true` for mock-heavy signatures).
- Performed targeted cleanup in high-noise test files:
  - `packages/core/tests/langgraph/builders/subgraph.test.ts`
  - `packages/cli/tests/utils/package-manager.test.ts`
- Added story documentation with policy, warning deltas, and rationale:
  - `docs/st08004-test-example-typing-policy.md`
- Updated planning/checklist trackers for In Progress -> In Review execution flow.

## Acceptance Criteria Coverage
- [x] Policy documented for intentional `any` usage in tests/examples.
- [x] ESLint configuration/scoping updated to make policy explicit and enforceable.
- [x] Targeted cleanup applied to low-effort explicit-`any` hotspots in tests/examples.
- [x] Lint output deltas and rationale for remaining intentional usage captured.
- [x] Story documentation added at `docs/st08004-test-example-typing-policy.md`.

## Validation Performed
- Baseline/after lint analysis for tests/examples/templates (`no-explicit-any`):
  - Before: `358`
  - After: `283`
  - Delta: `-75`
- Focused touched-file validation:
  - `pnpm test --run packages/core/tests/langgraph/builders/subgraph.test.ts packages/cli/tests/utils/package-manager.test.ts`
    - `2` files passed, `37` tests passed
  - `pnpm exec eslint packages/core/tests/langgraph/builders/subgraph.test.ts packages/cli/tests/utils/package-manager.test.ts`
    - No `no-explicit-any` warnings in touched files
- Full required gates:
  - `pnpm test --run` -> `146 passed | 16 skipped` files; `2076 passed | 286 skipped` tests
  - `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status
Ready for review.
