### PR TITLE
ST-09001: Harden Core Tool Composition Contracts

### DIFF
--- a/docs/st09001-core-tool-composition-contracts.md
+++ b/docs/st09001-core-tool-composition-contracts.md
@@ -1,0 +1,44 @@
+# ST-09001: Harden Core Tool Composition Contracts
+
+## Summary
+
+Refactored core tool composition utilities to remove explicit `any` from public contracts, tighten runtime-erased boundaries with `unknown`, and keep composition responsibilities clearer and easier to maintain.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/tools/composition.ts` | Replaced broad `any` signatures with generic `ComposedTool<TInput, TOutput>` and typed config contracts (`ConditionalConfig`, `ComposeToolConfig`) |
+| `packages/core/src/tools/composition.ts` | Added focused helper functions (`isConditionalStep`, `calculateRetryDelay`, `toError`) to separate workflow orchestration from utility concerns |
+| `packages/core/src/tools/composition.ts` | Added invalid retry-option guard (`maxAttempts` must be an integer `>= 1`) to fail fast for misconfiguration |
+| `packages/core/tests/tools/composition.test.ts` | Added 8 focused tests for `sequential`, `parallel`, `conditional`, `composeTool`, `retry`, `timeout`, and `cache` behavior |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/tools/composition.ts`: `13 -> 0` (`-13`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `385 -> 372` (`-13`)
+- `core` package: `189 -> 176` (`-13`)
+
+(After snapshot captured with `pnpm lint:explicit-any:baseline` on 2026-03-12.)
+
+## Compatibility Notes
+
+- Public helper behavior is preserved: existing composition utilities still execute sequential, parallel, conditional, retry, timeout, and cache flows the same way.
+- The retry path now throws a clear configuration error when `maxAttempts < 1` instead of entering an invalid loop path.
+
+## Validation
+
+- `pnpm exec eslint packages/core/src/tools/composition.ts packages/core/tests/tools/composition.test.ts`
+- `pnpm test --run packages/core/tests/tools/composition.test.ts`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `147 passed | 16 skipped` files; `2084 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
+
+## Test Impact
+
+Added focused automated tests for behavior-sensitive composition flows. No skipped or manual-only validations were introduced.

--- a/docs/st09001-core-tool-composition-contracts.md
+++ b/docs/st09001-core-tool-composition-contracts.md
@@ -11,6 +11,7 @@ Refactored core tool composition utilities to remove explicit `any` from public 
 | `packages/core/src/tools/composition.ts` | Replaced broad `any` signatures with generic `ComposedTool<TInput, TOutput>` and typed config contracts (`ConditionalConfig`, `ComposeToolConfig`) |
 | `packages/core/src/tools/composition.ts` | Added focused helper functions (`isConditionalStep`, `calculateRetryDelay`, `toError`) to separate workflow orchestration from utility concerns |
 | `packages/core/src/tools/composition.ts` | Added invalid retry-option guard (`maxAttempts` must be an integer `>= 1`) to fail fast for misconfiguration |
+| `packages/core/src/tools/composition.ts` | Updated `timeout()` to clear scheduled timeout handles after `Promise.race` settles, preventing stale timers when tools complete successfully |
 | `packages/core/tests/tools/composition.test.ts` | Added 8 focused tests for `sequential`, `parallel`, `conditional`, `composeTool`, `retry`, `timeout`, and `cache` behavior |
 
 ## Explicit `any` Warning Delta
@@ -34,7 +35,7 @@ Refactored core tool composition utilities to remove explicit `any` from public 
 ## Validation
 
 - `pnpm exec eslint packages/core/src/tools/composition.ts packages/core/tests/tools/composition.test.ts`
-- `pnpm test --run packages/core/tests/tools/composition.test.ts`
+- `pnpm test --run packages/core/tests/tools/composition.test.ts` (updated to 9 focused tests after timeout cleanup regression guard)
 - `pnpm lint:explicit-any:baseline`
 - `pnpm test --run` -> `147 passed | 16 skipped` files; `2084 passed | 286 skipped` tests
 - `pnpm lint` -> exit `0`; warnings only (`0` errors)

--- a/packages/core/src/tools/composition.ts
+++ b/packages/core/src/tools/composition.ts
@@ -191,14 +191,21 @@ export function timeout<TInput = unknown, TOutput = unknown>(
     name: `timeout(${tool.name})`,
     description: `${tool.description} (with ${ms}ms timeout)`,
     invoke: async (input: TInput): Promise<TOutput> => {
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Tool ${tool.name} timed out after ${ms}ms`)), ms)
-      );
+      let timer: ReturnType<typeof setTimeout> | undefined;
 
-      return Promise.race([
-        tool.invoke(input),
-        timeoutPromise,
-      ]);
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Tool ${tool.name} timed out after ${ms}ms`));
+        }, ms);
+      });
+
+      try {
+        return await Promise.race([tool.invoke(input), timeoutPromise]);
+      } finally {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
+      }
     },
   };
 }

--- a/packages/core/src/tools/composition.ts
+++ b/packages/core/src/tools/composition.ts
@@ -3,34 +3,70 @@
  * @module tools/composition
  */
 
-export interface ComposedTool {
+type RetryBackoffStrategy = 'linear' | 'exponential';
+
+interface RetryOptions {
+  maxAttempts?: number;
+  delay?: number;
+  backoff?: RetryBackoffStrategy;
+}
+
+interface CacheEntry<TOutput> {
+  result: TOutput;
+  timestamp: number;
+}
+
+export interface ComposedTool<TInput = unknown, TOutput = unknown> {
   name: string;
   description: string;
-  invoke: (input: any) => Promise<any>;
+  invoke(input: TInput): Promise<TOutput>;
 }
 
-export interface ConditionalConfig {
-  condition: (input: any) => boolean | Promise<boolean>;
-  onTrue: ComposedTool;
-  onFalse: ComposedTool;
+export interface ConditionalConfig<TInput = unknown, TTrueOutput = unknown, TFalseOutput = unknown> {
+  condition(input: TInput): boolean | Promise<boolean>;
+  onTrue: ComposedTool<TInput, TTrueOutput>;
+  onFalse: ComposedTool<TInput, TFalseOutput>;
 }
 
-export interface ComposeToolConfig {
+export type ComposedStep =
+  | ComposedTool<unknown, unknown>
+  | ComposedTool<unknown, unknown>[]
+  | ConditionalConfig<unknown, unknown, unknown>;
+
+export interface ComposeToolConfig<TOutput = unknown> {
   name: string;
   description?: string;
-  steps: Array<ComposedTool | ComposedTool[] | ConditionalConfig>;
-  transformResult?: (result: any) => any;
+  steps: ComposedStep[];
+  transformResult?: (result: unknown) => TOutput;
+}
+
+function isConditionalStep(step: ComposedStep): step is ConditionalConfig<unknown, unknown, unknown> {
+  return !Array.isArray(step) && 'condition' in step;
+}
+
+function calculateRetryDelay(
+  attempt: number,
+  delay: number,
+  backoff: RetryBackoffStrategy
+): number {
+  return backoff === 'exponential' ? delay * Math.pow(2, attempt - 1) : delay * attempt;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 /**
  * Execute tools sequentially
  */
-export function sequential(tools: ComposedTool[]): ComposedTool {
+export function sequential<TInput = unknown>(
+  tools: ComposedTool<unknown, unknown>[]
+): ComposedTool<TInput, unknown> {
   return {
     name: `sequential(${tools.map((t) => t.name).join(' -> ')})`,
     description: `Execute tools sequentially: ${tools.map((t) => t.name).join(' -> ')}`,
-    invoke: async (input: any) => {
-      let result = input;
+    invoke: async (input: TInput) => {
+      let result: unknown = input;
       for (const tool of tools) {
         result = await tool.invoke(result);
       }
@@ -42,11 +78,13 @@ export function sequential(tools: ComposedTool[]): ComposedTool {
 /**
  * Execute tools in parallel
  */
-export function parallel(tools: ComposedTool[]): ComposedTool {
+export function parallel<TInput = unknown>(
+  tools: ComposedTool<TInput, unknown>[]
+): ComposedTool<TInput, unknown[]> {
   return {
     name: `parallel(${tools.map((t) => t.name).join(', ')})`,
     description: `Execute tools in parallel: ${tools.map((t) => t.name).join(', ')}`,
-    invoke: async (input: any) => {
+    invoke: async (input: TInput) => {
       const results = await Promise.all(tools.map((tool) => tool.invoke(input)));
       return results;
     },
@@ -56,11 +94,13 @@ export function parallel(tools: ComposedTool[]): ComposedTool {
 /**
  * Execute tool conditionally
  */
-export function conditional(config: ConditionalConfig): ComposedTool {
+export function conditional<TInput = unknown, TTrueOutput = unknown, TFalseOutput = unknown>(
+  config: ConditionalConfig<TInput, TTrueOutput, TFalseOutput>
+): ComposedTool<TInput, TTrueOutput | TFalseOutput> {
   return {
     name: `conditional(${config.onTrue.name} | ${config.onFalse.name})`,
     description: `Conditionally execute ${config.onTrue.name} or ${config.onFalse.name}`,
-    invoke: async (input: any) => {
+    invoke: async (input: TInput) => {
       const shouldExecuteTrue = await config.condition(input);
       const tool = shouldExecuteTrue ? config.onTrue : config.onFalse;
       return await tool.invoke(input);
@@ -71,18 +111,20 @@ export function conditional(config: ConditionalConfig): ComposedTool {
 /**
  * Compose tools into a complex workflow
  */
-export function composeTool(config: ComposeToolConfig): ComposedTool {
+export function composeTool<TInput = unknown, TOutput = unknown>(
+  config: ComposeToolConfig<TOutput>
+): ComposedTool<TInput, TOutput> {
   return {
     name: config.name,
     description: config.description || `Composed tool: ${config.name}`,
-    invoke: async (input: any) => {
-      let result = input;
+    invoke: async (input: TInput) => {
+      let result: unknown = input;
 
       for (const step of config.steps) {
         if (Array.isArray(step)) {
           // Parallel execution
           result = await parallel(step).invoke(result);
-        } else if ('condition' in step) {
+        } else if (isConditionalStep(step)) {
           // Conditional execution
           result = await conditional(step).invoke(result);
         } else {
@@ -96,7 +138,7 @@ export function composeTool(config: ComposeToolConfig): ComposedTool {
         result = config.transformResult(result);
       }
 
-      return result;
+      return result as TOutput;
     },
   };
 }
@@ -104,31 +146,30 @@ export function composeTool(config: ComposeToolConfig): ComposedTool {
 /**
  * Create a tool that retries on failure
  */
-export function retry(
-  tool: ComposedTool,
-  options: {
-    maxAttempts?: number;
-    delay?: number;
-    backoff?: 'linear' | 'exponential';
-  } = {}
-): ComposedTool {
+export function retry<TInput = unknown, TOutput = unknown>(
+  tool: ComposedTool<TInput, TOutput>,
+  options: RetryOptions = {}
+): ComposedTool<TInput, TOutput> {
   const { maxAttempts = 3, delay = 1000, backoff = 'exponential' } = options;
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error('Invalid retry options: maxAttempts must be an integer >= 1');
+  }
 
   return {
     name: `retry(${tool.name})`,
     description: `${tool.description} (with retry)`,
-    invoke: async (input: any) => {
-      let lastError: Error | undefined;
+    invoke: async (input: TInput) => {
+      let lastError: Error = new Error(`Tool ${tool.name} failed without an explicit error`);
 
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
           return await tool.invoke(input);
         } catch (error) {
-          lastError = error as Error;
+          lastError = toError(error);
 
           if (attempt < maxAttempts) {
-            const waitTime =
-              backoff === 'exponential' ? delay * Math.pow(2, attempt - 1) : delay * attempt;
+            const waitTime = calculateRetryDelay(attempt, delay, backoff);
             await new Promise((resolve) => setTimeout(resolve, waitTime));
           }
         }
@@ -142,16 +183,21 @@ export function retry(
 /**
  * Create a tool that times out
  */
-export function timeout(tool: ComposedTool, ms: number): ComposedTool {
+export function timeout<TInput = unknown, TOutput = unknown>(
+  tool: ComposedTool<TInput, TOutput>,
+  ms: number
+): ComposedTool<TInput, TOutput> {
   return {
     name: `timeout(${tool.name})`,
     description: `${tool.description} (with ${ms}ms timeout)`,
-    invoke: async (input: any) => {
+    invoke: async (input: TInput): Promise<TOutput> => {
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`Tool ${tool.name} timed out after ${ms}ms`)), ms)
+      );
+
       return Promise.race([
         tool.invoke(input),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error(`Tool ${tool.name} timed out after ${ms}ms`)), ms)
-        ),
+        timeoutPromise,
       ]);
     },
   };
@@ -160,13 +206,16 @@ export function timeout(tool: ComposedTool, ms: number): ComposedTool {
 /**
  * Create a tool that caches results
  */
-export function cache(tool: ComposedTool, ttl?: number): ComposedTool {
-  const cacheMap = new Map<string, { result: any; timestamp: number }>();
+export function cache<TInput = unknown, TOutput = unknown>(
+  tool: ComposedTool<TInput, TOutput>,
+  ttl?: number
+): ComposedTool<TInput, TOutput> {
+  const cacheMap = new Map<string, CacheEntry<TOutput>>();
 
   return {
     name: `cache(${tool.name})`,
     description: `${tool.description} (with caching)`,
-    invoke: async (input: any) => {
+    invoke: async (input: TInput) => {
       const key = JSON.stringify(input);
       const cached = cacheMap.get(key);
 
@@ -183,4 +232,3 @@ export function cache(tool: ComposedTool, ttl?: number): ComposedTool {
     },
   };
 }
-

--- a/packages/core/tests/tools/composition.test.ts
+++ b/packages/core/tests/tools/composition.test.ts
@@ -162,6 +162,26 @@ describe('tool composition utilities', () => {
     );
   });
 
+  it('clears timeout timer when tool completes before deadline', async () => {
+    vi.useFakeTimers();
+
+    const fastTool: ComposedTool<string, string> = {
+      name: 'fast',
+      description: 'Fast tool',
+      invoke: async (input) =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(`done:${input}`), 5);
+        }),
+    };
+
+    const composed = timeout(fastTool, 50);
+    const promise = composed.invoke('job');
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(promise).resolves.toBe('done:job');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('fails with a timeout error when execution exceeds limit', async () => {
     vi.useFakeTimers();
 

--- a/packages/core/tests/tools/composition.test.ts
+++ b/packages/core/tests/tools/composition.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for tool composition utilities
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  cache,
+  composeTool,
+  conditional,
+  parallel,
+  retry,
+  sequential,
+  timeout,
+  type ComposedTool,
+} from '../../src/tools/composition.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('tool composition utilities', () => {
+  it('executes tools sequentially', async () => {
+    const increment: ComposedTool<number, number> = {
+      name: 'increment',
+      description: 'Increment a number',
+      invoke: async (input) => input + 1,
+    };
+
+    const double: ComposedTool<number, number> = {
+      name: 'double',
+      description: 'Double a number',
+      invoke: async (input) => input * 2,
+    };
+
+    const composed = sequential<number>([increment, double]);
+    const result = await composed.invoke(3);
+
+    expect(result).toBe(8);
+  });
+
+  it('executes tools in parallel', async () => {
+    const stringify: ComposedTool<number, string> = {
+      name: 'stringify',
+      description: 'Convert to prefixed string',
+      invoke: async (input) => `value:${input}`,
+    };
+
+    const square: ComposedTool<number, number> = {
+      name: 'square',
+      description: 'Square a number',
+      invoke: async (input) => input * input,
+    };
+
+    const composed = parallel([stringify, square]);
+    const result = await composed.invoke(4);
+
+    expect(result).toEqual(['value:4', 16]);
+  });
+
+  it('routes execution conditionally', async () => {
+    const onTrue: ComposedTool<number, string> = {
+      name: 'on-true',
+      description: 'True branch',
+      invoke: async (input) => `true:${input}`,
+    };
+
+    const onFalse: ComposedTool<number, string> = {
+      name: 'on-false',
+      description: 'False branch',
+      invoke: async (input) => `false:${input}`,
+    };
+
+    const composed = conditional({
+      condition: async (input) => input > 10,
+      onTrue,
+      onFalse,
+    });
+
+    await expect(composed.invoke(11)).resolves.toBe('true:11');
+    await expect(composed.invoke(9)).resolves.toBe('false:9');
+  });
+
+  it('composes mixed steps with final result transform', async () => {
+    const increment: ComposedTool<number, number> = {
+      name: 'increment',
+      description: 'Increment',
+      invoke: async (input) => input + 1,
+    };
+
+    const halve: ComposedTool<number, number> = {
+      name: 'halve',
+      description: 'Halve',
+      invoke: async (input) => input / 2,
+    };
+
+    const double: ComposedTool<number, number> = {
+      name: 'double',
+      description: 'Double',
+      invoke: async (input) => input * 2,
+    };
+
+    const triple: ComposedTool<number, number> = {
+      name: 'triple',
+      description: 'Triple',
+      invoke: async (input) => input * 3,
+    };
+
+    const composed = composeTool<number, string>({
+      name: 'mixed-workflow',
+      steps: [
+        increment,
+        {
+          condition: (input) => input > 6,
+          onTrue: halve,
+          onFalse: increment,
+        },
+        [double, triple],
+      ],
+      transformResult: (value) => JSON.stringify(value),
+    });
+
+    const result = await composed.invoke(10);
+    expect(result).toBe('[11,16.5]');
+  });
+
+  it('retries failed tools until success', async () => {
+    let attempts = 0;
+
+    const flakyTool: ComposedTool<string, string> = {
+      name: 'flaky',
+      description: 'Fails twice then succeeds',
+      invoke: async (input) => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error('temporary failure');
+        }
+        return `ok:${input}`;
+      },
+    };
+
+    const composed = retry(flakyTool, {
+      maxAttempts: 3,
+      delay: 0,
+      backoff: 'linear',
+    });
+
+    const result = await composed.invoke('task');
+
+    expect(result).toBe('ok:task');
+    expect(attempts).toBe(3);
+  });
+
+  it('throws for invalid retry configuration', () => {
+    const tool: ComposedTool<string, string> = {
+      name: 'tool',
+      description: 'Test tool',
+      invoke: async (input) => input,
+    };
+
+    expect(() => retry(tool, { maxAttempts: 0 })).toThrow(
+      'Invalid retry options: maxAttempts must be an integer >= 1'
+    );
+  });
+
+  it('fails with a timeout error when execution exceeds limit', async () => {
+    vi.useFakeTimers();
+
+    const slowTool: ComposedTool<string, string> = {
+      name: 'slow',
+      description: 'Slow tool',
+      invoke: async (input) =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(`done:${input}`), 100);
+        }),
+    };
+
+    const composed = timeout(slowTool, 10);
+    const promise = composed.invoke('job');
+    const assertion = expect(promise).rejects.toThrow('Tool slow timed out after 10ms');
+
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+  });
+
+  it('returns cached values until ttl expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    let calls = 0;
+    const sourceTool: ComposedTool<string, string> = {
+      name: 'source',
+      description: 'Source tool',
+      invoke: async (input) => {
+        calls += 1;
+        return `${input}:${calls}`;
+      },
+    };
+
+    const composed = cache(sourceTool, 50);
+
+    const first = await composed.invoke('key');
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.040Z'));
+    const second = await composed.invoke('key');
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.060Z'));
+    const third = await composed.invoke('key');
+
+    expect(first).toBe('key:1');
+    expect(second).toBe('key:1');
+    expect(third).toBe('key:2');
+    expect(calls).toBe(2);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -22,8 +22,11 @@
   - `pnpm test --run` -> `147 passed | 16 skipped` files; `2084 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `bcdb705` refactor(st-09001): harden core tool composition typing
+  - `e8f3698` docs(st-09001): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #63 marked ready: https://github.com/TVScoundrel/agentforge/pull/63
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -25,6 +25,7 @@
 - [x] Commit completed checklist items as logical commits and push updates
   - `bcdb705` refactor(st-09001): harden core tool composition typing
   - `e8f3698` docs(st-09001): record validation and move story to in-review
+  - `fbf3c85` fix(st-09001): clear timeout handle after promise race
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #63 marked ready: https://github.com/TVScoundrel/agentforge/pull/63
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -7,15 +7,21 @@
 ### Checklist
 - [x] Create branch `fix/st-09001-core-tool-composition-contracts`
   - Created as `codex/fix/st-09001-core-tool-composition-contracts` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
-- [ ] Replace explicit `any`-based contracts in `packages/core/src/tools/composition.ts` with generic/`unknown`-based boundaries
-- [ ] Refactor composition helpers where needed to keep responsibilities isolated and readable
-- [ ] Add/update focused tests for composition flows (sequential, parallel, conditional, retry, timeout, cache)
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09001-core-tool-composition-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create draft PR with story ID in title
+  - PR #63: https://github.com/TVScoundrel/agentforge/pull/63
+- [x] Replace explicit `any`-based contracts in `packages/core/src/tools/composition.ts` with generic/`unknown`-based boundaries
+- [x] Refactor composition helpers where needed to keep responsibilities isolated and readable
+- [x] Add/update focused tests for composition flows (sequential, parallel, conditional, retry, timeout, cache)
+  - `pnpm test --run packages/core/tests/tools/composition.test.ts` -> 8 passed
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09001-core-tool-composition-contracts.md` (`13 -> 0`, overall `385 -> 372`)
+- [x] Add or update story documentation at `docs/st09001-core-tool-composition-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused composition tests in `packages/core/tests/tools/composition.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `147 passed | 16 skipped` files; `2084 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -12,7 +12,7 @@
 - [x] Replace explicit `any`-based contracts in `packages/core/src/tools/composition.ts` with generic/`unknown`-based boundaries
 - [x] Refactor composition helpers where needed to keep responsibilities isolated and readable
 - [x] Add/update focused tests for composition flows (sequential, parallel, conditional, retry, timeout, cache)
-  - `pnpm test --run packages/core/tests/tools/composition.test.ts` -> 8 passed
+  - `pnpm test --run packages/core/tests/tools/composition.test.ts` -> 9 passed
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09001-core-tool-composition-contracts.md` (`13 -> 0`, overall `385 -> 372`)
 - [x] Add or update story documentation at `docs/st09001-core-tool-composition-contracts.md` (or document why not required)

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -5,7 +5,8 @@
 **Branch:** `fix/st-09001-core-tool-composition-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09001-core-tool-composition-contracts`
+- [x] Create branch `fix/st-09001-core-tool-composition-contracts`
+  - Created as `codex/fix/st-09001-core-tool-composition-contracts` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
 - [ ] Replace explicit `any`-based contracts in `packages/core/src/tools/composition.ts` with generic/`unknown`-based boundaries
 - [ ] Refactor composition helpers where needed to keep responsibilities isolated and readable

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -826,7 +826,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-08004
-**Status:** In Progress
+**Status:** In Review (PR #63)
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/composition.ts` replaces broad `any`-based public contracts with generic input/output types (`unknown` where runtime-erased)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -826,6 +826,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-08004
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/composition.ts` replaces broad `any`-based public contracts with generic input/output types (`unknown` where runtime-erased)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -1,9 +1,9 @@
 # Feature Plan: SOLID Micro-Refactors and Type Boundary Hardening
 
 **Epic Range:** EP-09 through EP-09
-**Status:** In Progress
+**Status:** In Review
 **Last Updated:** 2026-03-12
-**Active Story:** ST-09001 (In Progress)
+**Active Story:** ST-09001 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -1,9 +1,9 @@
 # Feature Plan: SOLID Micro-Refactors and Type Boundary Hardening
 
 **Epic Range:** EP-09 through EP-09
-**Status:** Planned
+**Status:** In Progress
 **Last Updated:** 2026-03-12
-**Active Story:** ST-09001 (Ready)
+**Active Story:** ST-09001 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -20,16 +20,15 @@ _No stories currently ready_
 
 ## In Progress
 
-- **ST-09001: Harden Core Tool Composition Contracts** (EP-09, P1, 3h)
-  - Branch: `fix/st-09001-core-tool-composition-contracts`
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/core/src/tools/composition.ts` typed contract hardening + focused tests
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- **ST-09001: Harden Core Tool Composition Contracts** (EP-09, P1, 3h)
+  - PR: https://github.com/TVScoundrel/agentforge/pull/63
+  - Scope: `packages/core/src/tools/composition.ts` typed contract hardening + focused tests
 
 ---
 
@@ -101,4 +100,4 @@ _No stories currently blocked_
 - Epic 08 (Type Safety Hardening and `no-explicit-any` Debt Burn-Down) created in Fix Mode on 2026-03-06
 - ST-08001, ST-08002, ST-08003, and ST-08004 merged (PR #59, PR #60, PR #61, PR #62); Epic 08 complete
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) planned on 2026-03-12
-- ST-09001 moved to Ready; ST-09002 through ST-09005 queued in Backlog for daily execution
+- ST-09001 moved to In Review (PR #63); ST-09002 through ST-09005 remain queued in Backlog

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
@@ -14,16 +14,16 @@
 
 ## Ready
 
-- **ST-09001: Harden Core Tool Composition Contracts** (EP-09, P1, 3h)
-  - Branch: `fix/st-09001-core-tool-composition-contracts`
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/core/src/tools/composition.ts` typed contract hardening + focused tests
+_No stories currently ready_
 
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- **ST-09001: Harden Core Tool Composition Contracts** (EP-09, P1, 3h)
+  - Branch: `fix/st-09001-core-tool-composition-contracts`
+  - Dependencies: ST-08004 (complete)
+  - Scope: `packages/core/src/tools/composition.ts` typed contract hardening + focused tests
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09001: Harden Core Tool Composition Contracts

## What Changed
- Refactored `packages/core/src/tools/composition.ts` to replace broad `any` signatures with generic `ComposedTool<TInput, TOutput>` and runtime-erased `unknown` boundaries.
- Added focused helper utilities (`isConditionalStep`, `calculateRetryDelay`, `toError`) to separate orchestration flow from utility logic.
- Added retry-option validation guard to fail fast when `maxAttempts < 1`.
- Fixed timeout-resource handling by clearing scheduled timeout handles after `Promise.race` settles.
- Added focused tests in `packages/core/tests/tools/composition.test.ts` covering sequential, parallel, conditional, compose, retry, timeout, and cache behavior.
- Added story documentation at `docs/st09001-core-tool-composition-contracts.md` including warning deltas and validation evidence.
- Updated planning trackers/checklists and moved ST-09001 to In Review.

## Acceptance Criteria Coverage
- [x] `packages/core/src/tools/composition.ts` replaces broad `any`-based public contracts with generic input/output types (`unknown` where runtime-erased)
- [x] Composition helpers are split into clearer typed boundaries where needed (SRP-focused extraction)
- [x] Behavior remains backward compatible for existing call sites in `core` tests
- [x] Focused tests are added/updated for composition behavior and type-sensitive edge cases
- [x] Explicit-`any` warning deltas in touched files are reduced and recorded in story documentation
- [x] Story documentation added at `docs/st09001-core-tool-composition-contracts.md`

## Validation Performed
- `pnpm exec eslint packages/core/src/tools/composition.ts packages/core/tests/tools/composition.test.ts`
- `pnpm test --run packages/core/tests/tools/composition.test.ts` (9 passed)
- `pnpm lint:explicit-any:baseline`
  - `packages/**/src/**/*.ts`: `385 -> 372`
  - `core`: `189 -> 176`
- `pnpm test --run`
  - `147 passed | 16 skipped` files
  - `2084 passed | 286 skipped` tests
- `pnpm lint`
  - exit `0`; warnings only (`0` errors)

## Status
- Ready for review.
