### PR TITLE
ST-09002: Tighten LangChain Converter Runtime Boundary

### DIFF
--- a/docs/st09002-langchain-converter-boundary-hardening.md
+++ b/docs/st09002-langchain-converter-boundary-hardening.md
@@ -1,0 +1,42 @@
+# ST-09002: Tighten LangChain Converter Runtime Boundary
+
+## Summary
+
+Refactored the LangChain converter boundary to replace explicit `any` contracts with generic or runtime-erased types, while splitting output serialization and JSON-schema extraction into focused helpers.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/langchain/converter.ts` | Replaced exported `any`-based converter signatures with generic tool inputs and a runtime-erased multi-tool boundary |
+| `packages/core/src/langchain/converter.ts` | Extracted `serializeToolResult()` to isolate LangChain stringification from tool invocation |
+| `packages/core/src/langchain/converter.ts` | Extracted schema guards and `extractToolSchema()` so JSON-schema unwrapping is separated from public API functions |
+| `packages/core/tests/langchain/converter.test.ts` | Added focused serialization edge-case coverage for array and `null` outputs while preserving existing object/string/primitive/schema assertions |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/langchain/converter.ts`: `15 -> 0` (`-15`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `372 -> 357` (`-15`)
+- `core` package: `176 -> 161` (`-15`)
+
+(After snapshot captured with `pnpm lint:explicit-any:baseline` on 2026-03-13.)
+
+## Compatibility Notes
+
+- Public API behavior remains unchanged for `toLangChainTool`, `toLangChainTools`, `getToolJsonSchema`, and `getToolDescription`.
+- LangChain-facing tool outputs still resolve to strings, with arrays and objects serialized as formatted JSON and primitives stringified directly.
+
+## Validation
+
+- `pnpm exec eslint packages/core/src/langchain/converter.ts packages/core/tests/langchain/converter.test.ts`
+- `pnpm test --run packages/core/tests/langchain/converter.test.ts` -> `14 passed`
+- `pnpm lint:explicit-any:baseline`
+
+## Test Impact
+
+Expanded focused automated coverage for converter serialization boundaries and retained the existing schema/metadata assertions.

--- a/docs/st09002-langchain-converter-boundary-hardening.md
+++ b/docs/st09002-langchain-converter-boundary-hardening.md
@@ -36,6 +36,8 @@ Refactored the LangChain converter boundary to replace explicit `any` contracts 
 - `pnpm exec eslint packages/core/src/langchain/converter.ts packages/core/tests/langchain/converter.test.ts`
 - `pnpm test --run packages/core/tests/langchain/converter.test.ts` -> `14 passed`
 - `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `147 passed | 16 skipped` files; `2087 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
 
 ## Test Impact
 

--- a/packages/core/src/langchain/converter.ts
+++ b/packages/core/src/langchain/converter.ts
@@ -12,8 +12,60 @@
  */
 
 import { DynamicStructuredTool } from '@langchain/core/tools';
+import type { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import type { Tool } from '../tools/types.js';
+import type { Tool, ToolMetadata } from '../tools/types.js';
+
+type RuntimeSchema<TInput = unknown> = z.ZodSchema<TInput>;
+type JsonSchemaObject = Record<string, unknown>;
+
+interface LangChainConvertibleTool<TInput = unknown, TOutput = unknown> {
+  metadata: ToolMetadata;
+  schema: RuntimeSchema<TInput>;
+  invoke(input: TInput): Promise<TOutput>;
+}
+
+function serializeToolResult(result: unknown): string {
+  if (typeof result === 'string') {
+    return result;
+  }
+
+  if (typeof result === 'object' && result !== null) {
+    return JSON.stringify(result, null, 2);
+  }
+
+  return String(result);
+}
+
+function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJsonSchemaDefinitionMap(
+  value: unknown
+): value is Record<string, JsonSchemaObject> {
+  if (!isJsonSchemaObject(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(isJsonSchemaObject);
+}
+
+function extractToolSchema(jsonSchema: unknown): JsonSchemaObject {
+  if (!isJsonSchemaObject(jsonSchema)) {
+    return {};
+  }
+
+  const ref = jsonSchema.$ref;
+  const definitions = jsonSchema.definitions;
+
+  if (typeof ref !== 'string' || !isJsonSchemaDefinitionMap(definitions)) {
+    return jsonSchema;
+  }
+
+  const refName = ref.replace('#/definitions/', '');
+  return definitions[refName] ?? jsonSchema;
+}
 
 /**
  * Convert an AgentForge tool to a LangChain DynamicStructuredTool
@@ -47,30 +99,14 @@ import type { Tool } from '../tools/types.js';
  * });
  * ```
  */
-export function toLangChainTool(
-  tool: Tool<any, any>
-): DynamicStructuredTool<any> {
-  return new DynamicStructuredTool<any>({
+export function toLangChainTool<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>
+): DynamicStructuredTool<RuntimeSchema<TInput>, TInput, TInput, string> {
+  return new DynamicStructuredTool<RuntimeSchema<TInput>, TInput, TInput, string>({
     name: tool.metadata.name,
     description: tool.metadata.description,
-    schema: tool.schema as any,
-    func: async (input: any) => {
-      const result = await tool.invoke(input);
-
-      // LangChain tools must return strings
-      // Convert result to string if it's not already
-      if (typeof result === 'string') {
-        return result;
-      }
-
-      // For objects/arrays, return JSON string
-      if (typeof result === 'object' && result !== null) {
-        return JSON.stringify(result, null, 2);
-      }
-
-      // For primitives, convert to string
-      return String(result);
-    },
+    schema: tool.schema,
+    func: async (input) => serializeToolResult(await tool.invoke(input)),
   });
 }
 
@@ -92,8 +128,8 @@ export function toLangChainTool(
  * ```
  */
 export function toLangChainTools(
-  tools: Tool<any, any>[]
-): DynamicStructuredTool<any>[] {
+  tools: readonly LangChainConvertibleTool[]
+): DynamicStructuredTool[] {
   return tools.map(toLangChainTool);
 }
 
@@ -111,19 +147,15 @@ export function toLangChainTools(
  * console.log(JSON.stringify(schema, null, 2));
  * ```
  */
-export function getToolJsonSchema(tool: Tool<any, any>): Record<string, any> {
+export function getToolJsonSchema<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>
+): JsonSchemaObject {
   const jsonSchema = zodToJsonSchema(tool.schema, {
     name: tool.metadata.name,
     $refStrategy: 'none', // Don't use $ref for nested schemas
-  }) as any; // Type assertion needed because zod-to-json-schema types are incomplete
+  });
 
-  // If the schema has a $ref and definitions, extract the actual schema
-  if (jsonSchema.$ref && jsonSchema.definitions) {
-    const refName = jsonSchema.$ref.replace('#/definitions/', '');
-    return jsonSchema.definitions[refName] || jsonSchema;
-  }
-
-  return jsonSchema;
+  return extractToolSchema(jsonSchema);
 }
 
 /**
@@ -146,7 +178,9 @@ export function getToolJsonSchema(tool: Tool<any, any>): Record<string, any> {
  * // ...
  * ```
  */
-export function getToolDescription(tool: Tool<any, any>): string {
+export function getToolDescription<TInput, TOutput>(
+  tool: Tool<TInput, TOutput>
+): string {
   const { metadata } = tool;
   const parts: string[] = [];
 
@@ -186,4 +220,3 @@ export function getToolDescription(tool: Tool<any, any>): string {
   
   return parts.join('\n');
 }
-

--- a/packages/core/tests/langchain/converter.test.ts
+++ b/packages/core/tests/langchain/converter.test.ts
@@ -78,6 +78,30 @@ describe('LangChain Integration', () => {
       expect(result).toBe('Hello, Alice!');
     });
 
+    it('should convert array results to JSON strings', async () => {
+      const tool = toolBuilder()
+        .name('list-users')
+        .description('List users')
+        .category(ToolCategory.UTILITY)
+        .schema(z.object({
+          team: z.string().describe('Team name'),
+        }))
+        .implement(async ({ team }) => [
+          { id: 1, team },
+          { id: 2, team },
+        ])
+        .build();
+
+      const langchainTool = toLangChainTool(tool);
+      const result = await langchainTool.invoke({ team: 'core' });
+
+      expect(typeof result).toBe('string');
+      expect(JSON.parse(result)).toEqual([
+        { id: 1, team: 'core' },
+        { id: 2, team: 'core' },
+      ]);
+    });
+
     it('should convert primitive results to strings', async () => {
       const tool = toolBuilder()
         .name('is-even')
@@ -93,6 +117,23 @@ describe('LangChain Integration', () => {
       const result = await langchainTool.invoke({ n: 4 });
       
       expect(result).toBe('true');
+    });
+
+    it('should stringify null results', async () => {
+      const tool = toolBuilder()
+        .name('lookup-optional')
+        .description('Return null when no value exists')
+        .category(ToolCategory.UTILITY)
+        .schema(z.object({
+          id: z.string().describe('Lookup identifier'),
+        }))
+        .implement(async () => null)
+        .build();
+
+      const langchainTool = toLangChainTool(tool);
+      const result = await langchainTool.invoke({ id: 'missing' });
+
+      expect(result).toBe('null');
     });
 
     it('should preserve tool schema', () => {
@@ -269,4 +310,3 @@ describe('LangChain Integration', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -58,8 +58,12 @@
   - `pnpm test --run` -> `147 passed | 16 skipped` files; `2087 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `e33273d` refactor(st-09002): harden langchain converter boundary
+  - `9297d86` docs(st-09002): record converter boundary progress
+  - `b7d145f` docs(st-09002): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #64 marked ready: https://github.com/TVScoundrel/agentforge/pull/64
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -43,15 +43,21 @@
 ### Checklist
 - [x] Create branch `fix/st-09002-langchain-converter-boundary-hardening`
   - Created as `codex/fix/st-09002-langchain-converter-boundary-hardening` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
-- [ ] Replace avoidable explicit `any` usage in `packages/core/src/langchain/converter.ts` with generic/`unknown` + narrowing
-- [ ] Separate schema-conversion and output-serialization responsibilities for clearer module boundaries
-- [ ] Add/update focused tests for converter behavior and output serialization edge cases
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09002-langchain-converter-boundary-hardening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create draft PR with story ID in title
+  - PR #64: https://github.com/TVScoundrel/agentforge/pull/64
+- [x] Replace avoidable explicit `any` usage in `packages/core/src/langchain/converter.ts` with generic/`unknown` + narrowing
+- [x] Separate schema-conversion and output-serialization responsibilities for clearer module boundaries
+- [x] Add/update focused tests for converter behavior and output serialization edge cases
+  - `pnpm test --run packages/core/tests/langchain/converter.test.ts` -> `14 passed`
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09002-langchain-converter-boundary-hardening.md` (`15 -> 0`, overall `372 -> 357`)
+- [x] Add or update story documentation at `docs/st09002-langchain-converter-boundary-hardening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused converter serialization tests in `packages/core/tests/langchain/converter.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `147 passed | 16 skipped` files; `2087 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -41,7 +41,8 @@
 **Branch:** `fix/st-09002-langchain-converter-boundary-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-09002-langchain-converter-boundary-hardening`
+- [x] Create branch `fix/st-09002-langchain-converter-boundary-hardening`
+  - Created as `codex/fix/st-09002-langchain-converter-boundary-hardening` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
 - [ ] Replace avoidable explicit `any` usage in `packages/core/src/langchain/converter.ts` with generic/`unknown` + narrowing
 - [ ] Separate schema-conversion and output-serialization responsibilities for clearer module boundaries

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -844,7 +844,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-08004
-**Status:** In Progress (2026-03-13)
+**Status:** In Review (PR #64, 2026-03-13)
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langchain/converter.ts` removes avoidable explicit `any` from exported signatures in favor of generics/`unknown` + narrowing

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -844,6 +844,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-08004
+**Status:** In Progress (2026-03-13)
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langchain/converter.ts` removes avoidable explicit `any` from exported signatures in favor of generics/`unknown` + narrowing

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-13
-**Active Story:** ST-09002 (In Progress)
+**Active Story:** ST-09002 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-03-12
-**Active Story:** ST-09002 (Ready)
+**Last Updated:** 2026-03-13
+**Active Story:** ST-09002 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
@@ -14,9 +14,6 @@
 
 ## Ready
 
-- **ST-09002: Tighten LangChain Converter Runtime Boundary** (EP-09, P1, 3h)
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/core/src/langchain/converter.ts` boundary hardening and SRP split
 - **ST-09003: Strengthen LangGraph State Utility Typing** (EP-09, P2, 3h)
   - Dependencies: ST-08004 (complete)
   - Scope: `packages/core/src/langgraph/state.ts` generics and reducer/default typing hardening
@@ -28,7 +25,9 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- **ST-09002: Tighten LangChain Converter Runtime Boundary** (EP-09, P1, 3h)
+  - Dependencies: ST-08004 (complete)
+  - Scope: `packages/core/src/langchain/converter.ts` boundary hardening and SRP split
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
 
@@ -25,15 +25,15 @@
 
 ## In Progress
 
-- **ST-09002: Tighten LangChain Converter Runtime Boundary** (EP-09, P1, 3h)
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/core/src/langchain/converter.ts` boundary hardening and SRP split
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- **ST-09002: Tighten LangChain Converter Runtime Boundary** (EP-09, P1, 3h)
+  - Dependencies: ST-08004 (complete)
+  - Scope: `packages/core/src/langchain/converter.ts` boundary hardening and SRP split
 
 ---
 


### PR DESCRIPTION
## Story
ST-09002: Tighten LangChain Converter Runtime Boundary

## What Changed
- replaced explicit `any` usage in `packages/core/src/langchain/converter.ts` with generic or runtime-erased boundaries
- extracted focused helpers for LangChain output serialization and JSON-schema extraction
- added converter edge-case tests for array and `null` result serialization
- recorded warning-delta and validation notes in `docs/st09002-langchain-converter-boundary-hardening.md`
- moved ST-09002 to `In Review` in the planning trackers

## Acceptance Criteria Coverage
- removed avoidable explicit `any` from exported converter signatures and internal helpers
- separated schema conversion and output stringification responsibilities for clearer SRP boundaries
- preserved public API behavior for `toLangChainTool`, `toLangChainTools`, `getToolJsonSchema`, and `getToolDescription`
- focused tests cover object, primitive, string, array, and `null` serialization plus schema extraction behavior
- explicit-`any` deltas are recorded in the story doc
- story documentation added at `docs/st09002-langchain-converter-boundary-hardening.md`

## Validation Performed
- `pnpm exec eslint packages/core/src/langchain/converter.ts packages/core/tests/langchain/converter.test.ts`
- `pnpm test --run packages/core/tests/langchain/converter.test.ts` -> `14 passed`
- `pnpm lint:explicit-any:baseline` -> `357/496` warnings overall, `core 161/256`
- `pnpm test --run` -> `147 passed | 16 skipped` files; `2087 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status
Ready for review.
