### PR TITLE
ST-09003: Strengthen LangGraph State Utility Typing

### DIFF
--- a/docs/st09003-langgraph-state-utility-typing.md
+++ b/docs/st09003-langgraph-state-utility-typing.md
@@ -1,0 +1,48 @@
+# ST-09003: Strengthen LangGraph State Utility Typing
+
+## Summary
+
+Refactored the LangGraph state utilities to remove explicit `any` usage from the exported state-channel helpers while preserving runtime behavior for default factories, reducer-driven channels, and state validation.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/langgraph/state.ts` | Replaced `any`-based `StateChannelConfig`, `createStateAnnotation()`, `validateState()`, and `mergeState()` contracts with config-derived state/update helper types |
+| `packages/core/src/langgraph/state.ts` | Added internal typed helpers for channel creation, object iteration, last-value semantics, and generic record writes so `Annotation.Root` inference is preserved without falling back to `StateDefinition` |
+| `packages/core/tests/langgraph/state.test.ts` | Added an inference-focused regression test for `annotation.State` and `annotation.Update` and removed explicit `any` usage from reducer coverage |
+| `packages/core/tests/langgraph/integration.test.ts` | Replaced explicit `any` reducer test fixtures with concrete event types and cleaned up unused node arguments in LangGraph integration coverage |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspots
+
+- `packages/core/src/langgraph/state.ts`: `13 -> 0` (`-13`)
+- `packages/core/tests/langgraph/state.test.ts`: `2 -> 0` (`-2`)
+- `packages/core/tests/langgraph/integration.test.ts`: `2 -> 0` (`-2`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `357 -> 344` (`-13`)
+- `core` package: `161 -> 148` (`-13`)
+
+(After snapshot captured with `pnpm lint:explicit-any:baseline` on 2026-03-13.)
+
+## Compatibility Notes
+
+- Runtime behavior remains unchanged for state defaults, reducer merges, and Zod-backed validation.
+- `createStateAnnotation()` now preserves config-derived `State` and `Update` inference without exposing `any` in the public helper surface.
+- `validateState()` and `mergeState()` return config-shaped state objects rather than untyped string-indexed records.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/langgraph/state.ts packages/core/tests/langgraph/state.test.ts packages/core/tests/langgraph/integration.test.ts`
+- `pnpm test --run packages/core/tests/langgraph/state.test.ts packages/core/tests/langgraph/integration.test.ts` -> `25 passed`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `147 passed | 16 skipped` files; `2088 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
+
+## Test Impact
+
+Expanded focused automated coverage for state inference alongside the existing default-factory, validation, and reducer-merge behavior tests.

--- a/packages/core/src/langgraph/state.ts
+++ b/packages/core/src/langgraph/state.ts
@@ -44,9 +44,22 @@ type StateChannelConfigLike = {
 
 type StateConfigMap = Record<string, StateChannelConfigLike>;
 
+type HasCustomUpdateType<TChannel extends StateChannelConfigLike> =
+  TChannel extends StateChannelConfig<infer TValue, infer TUpdate>
+    ? [TUpdate] extends [TValue]
+      ? [TValue] extends [TUpdate]
+        ? false
+        : true
+      : true
+    : false;
+
 type ValidStateChannel<TChannel extends StateChannelConfigLike> =
   TChannel extends StateChannelConfig<infer TValue, infer TUpdate>
-    ? TChannel & StateChannelConfig<TValue, TUpdate>
+    ? HasCustomUpdateType<TChannel> extends true
+      ? TChannel extends { reducer: (left: TValue, right: TUpdate) => TValue }
+        ? TChannel & StateChannelConfig<TValue, TUpdate>
+        : never
+      : TChannel & StateChannelConfig<TValue, TUpdate>
     : never;
 
 type ValidStateConfig<TConfig extends StateConfigMap> = {
@@ -60,9 +73,11 @@ type DeclaredChannelUpdate<TChannel extends StateChannelConfigLike> =
   TChannel extends StateChannelConfig<unknown, infer TUpdate> ? TUpdate : never;
 
 type ChannelUpdate<TChannel extends StateChannelConfigLike> =
-  TChannel extends { reducer: (left: never, right: never) => unknown }
+  HasCustomUpdateType<TChannel> extends true
     ? DeclaredChannelUpdate<TChannel>
-    : ChannelValue<TChannel>;
+    : TChannel extends { reducer: (left: never, right: never) => unknown }
+      ? DeclaredChannelUpdate<TChannel>
+      : ChannelValue<TChannel>;
 
 type StateShape<TConfig extends StateConfigMap> = {
   [K in keyof TConfig]: ChannelValue<TConfig[K]>;

--- a/packages/core/src/langgraph/state.ts
+++ b/packages/core/src/langgraph/state.ts
@@ -7,17 +7,17 @@
  * @module langgraph/state
  */
 
-import { Annotation, type AnnotationRoot, type StateDefinition } from '@langchain/langgraph';
-import { z, type ZodType, type ZodTypeDef } from 'zod';
+import { Annotation, type AnnotationRoot, type BaseChannel } from '@langchain/langgraph';
+import type { ZodType, ZodTypeDef } from 'zod';
 
 /**
  * State channel configuration with optional Zod schema validation
  */
-export interface StateChannelConfig<T = any, U = T> {
+export interface StateChannelConfig<T = unknown, U = T> {
   /**
    * Optional Zod schema for runtime validation
    */
-  schema?: ZodType<T, ZodTypeDef, any>;
+  schema?: ZodType<T, ZodTypeDef, unknown>;
 
   /**
    * Optional reducer function for aggregating updates
@@ -33,6 +33,124 @@ export interface StateChannelConfig<T = any, U = T> {
    * Description of this state channel (for documentation)
    */
   description?: string;
+}
+
+type StateChannelConfigLike = {
+  schema?: ZodType<unknown, ZodTypeDef, unknown>;
+  reducer?: (left: never, right: never) => unknown;
+  default?: () => unknown;
+  description?: string;
+};
+
+type StateConfigMap = Record<string, StateChannelConfigLike>;
+
+type ChannelValue<TChannel extends StateChannelConfigLike> =
+  TChannel extends StateChannelConfig<infer TValue, unknown> ? TValue : never;
+
+type DeclaredChannelUpdate<TChannel extends StateChannelConfigLike> =
+  TChannel extends StateChannelConfig<unknown, infer TUpdate> ? TUpdate : never;
+
+type ChannelUpdate<TChannel extends StateChannelConfigLike> =
+  TChannel extends { reducer: (left: never, right: never) => unknown }
+    ? DeclaredChannelUpdate<TChannel>
+    : ChannelValue<TChannel>;
+
+type StateShape<TConfig extends StateConfigMap> = {
+  [K in keyof TConfig]: ChannelValue<TConfig[K]>;
+};
+
+type StateUpdateShape<TConfig extends StateConfigMap> = {
+  [K in keyof TConfig]?: ChannelUpdate<TConfig[K]>;
+};
+
+type StateChannelDefinition<TChannel extends StateChannelConfigLike> = BaseChannel<
+  ChannelValue<TChannel>,
+  ChannelUpdate<TChannel>
+>;
+
+type StateAnnotationDefinition<TConfig extends StateConfigMap> = {
+  [K in keyof TConfig]: StateChannelDefinition<TConfig[K]>;
+};
+
+type DefaultedKeys<TConfig extends StateConfigMap> = {
+  [K in keyof TConfig]-?: TConfig[K] extends { default: () => ChannelValue<TConfig[K]> } ? K : never;
+}[keyof TConfig];
+
+type InputStateKeys<TConfig extends StateConfigMap, TState> = Extract<keyof TConfig, keyof TState>;
+
+type ValidatedState<
+  TConfig extends StateConfigMap,
+  TState extends Partial<Record<keyof TConfig, unknown>>,
+> = {
+  [K in InputStateKeys<TConfig, TState> | DefaultedKeys<TConfig>]: ChannelValue<TConfig[K]>;
+};
+
+function entriesOf<T extends Record<string, unknown>>(
+  value: T
+): Array<
+  {
+    [K in Extract<keyof T, string>]-?: [K, T[K]];
+  }[Extract<keyof T, string>]
+> {
+  return Object.entries(value) as Array<
+    {
+      [K in Extract<keyof T, string>]-?: [K, T[K]];
+    }[Extract<keyof T, string>]
+  >;
+}
+
+function keysOf<T extends Record<string, unknown>>(value: T): Array<Extract<keyof T, string>> {
+  return Object.keys(value) as Array<Extract<keyof T, string>>;
+}
+
+function hasOwnProperty<T extends object>(
+  value: T,
+  key: PropertyKey
+): key is Extract<keyof T, string | number | symbol> {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function useLatestValue<TValue>(_left: TValue, right: TValue): TValue {
+  return right;
+}
+
+function setStateValue<TConfig extends StateConfigMap, TKey extends keyof TConfig>(
+  target: Partial<StateShape<TConfig>>,
+  key: TKey,
+  value: StateShape<TConfig>[TKey]
+): void {
+  (target as Partial<Record<keyof TConfig, StateShape<TConfig>[keyof TConfig]>>)[key] = value;
+}
+
+function setStateDefinitionValue<TConfig extends StateConfigMap, TKey extends keyof TConfig>(
+  target: StateAnnotationDefinition<TConfig>,
+  key: TKey,
+  value: StateAnnotationDefinition<TConfig>[TKey]
+): void {
+  (target as Record<keyof TConfig, StateAnnotationDefinition<TConfig>[keyof TConfig]>)[key] = value;
+}
+
+function createChannel<TChannel extends StateChannelConfigLike>(
+  channelConfig: TChannel
+): StateChannelDefinition<TChannel> {
+  if (channelConfig.reducer) {
+    return Annotation<ChannelValue<TChannel>, ChannelUpdate<TChannel>>({
+      reducer: channelConfig.reducer as (
+        left: ChannelValue<TChannel>,
+        right: ChannelUpdate<TChannel>
+      ) => ChannelValue<TChannel>,
+      default: channelConfig.default as (() => ChannelValue<TChannel>) | undefined,
+    }) as StateChannelDefinition<TChannel>;
+  }
+
+  if (channelConfig.default) {
+    return Annotation<ChannelValue<TChannel>, ChannelValue<TChannel>>({
+      reducer: useLatestValue,
+      default: channelConfig.default as () => ChannelValue<TChannel>,
+    }) as StateChannelDefinition<TChannel>;
+  }
+
+  return Annotation<ChannelValue<TChannel>>() as StateChannelDefinition<TChannel>;
 }
 
 /**
@@ -66,32 +184,18 @@ export interface StateChannelConfig<T = any, U = T> {
  * ```
  */
 export function createStateAnnotation<
-  T extends Record<string, StateChannelConfig>
+  TConfig extends StateConfigMap
 >(
-  config: T
-): AnnotationRoot<StateDefinition> {
-  // Convert our config to LangGraph's StateDefinition format
-  const stateDefinition: StateDefinition = {};
+  config: TConfig
+): AnnotationRoot<StateAnnotationDefinition<TConfig>> {
+  const stateDefinition = {} as StateAnnotationDefinition<TConfig>;
 
-  for (const [key, channelConfig] of Object.entries(config)) {
-    if (channelConfig.reducer) {
-      // Use BinaryOperatorAggregate for channels with reducers
-      stateDefinition[key] = Annotation<any>({
-        reducer: channelConfig.reducer,
-        default: channelConfig.default,
-      });
-    } else if (channelConfig.default) {
-      // For simple channels with defaults, use a "last value wins" reducer
-      // This is necessary because LangGraph's Annotation() doesn't support
-      // defaults for LastValue channels - only for channels with reducers
-      stateDefinition[key] = Annotation<any>({
-        reducer: (_left: any, right: any) => right,
-        default: channelConfig.default,
-      });
-    } else {
-      // Use LastValue for simple channels without defaults
-      stateDefinition[key] = Annotation<any>();
-    }
+  for (const [key, channelConfig] of entriesOf(config)) {
+    setStateDefinitionValue(
+      stateDefinition,
+      key,
+      createChannel(channelConfig) as StateAnnotationDefinition<TConfig>[typeof key]
+    );
   }
 
   return Annotation.Root(stateDefinition);
@@ -118,26 +222,30 @@ export function createStateAnnotation<
  * );
  * ```
  */
-export function validateState<T extends Record<string, StateChannelConfig>>(
-  state: Record<string, any>,
-  config: T
-): Record<string, any> {
-  const validated: Record<string, any> = {};
+export function validateState<
+  TConfig extends StateConfigMap,
+  TState extends Partial<Record<keyof TConfig, unknown>>,
+>(state: TState, config: TConfig): ValidatedState<TConfig, TState> {
+  const validated = {} as Partial<StateShape<TConfig>>;
 
-  for (const [key, channelConfig] of Object.entries(config)) {
-    if (channelConfig.schema && key in state) {
+  for (const [key, channelConfig] of entriesOf(config)) {
+    if (channelConfig.schema && hasOwnProperty(state, key)) {
       // Validate with Zod schema
-      validated[key] = channelConfig.schema.parse(state[key]);
-    } else if (key in state) {
+      setStateValue(
+        validated,
+        key,
+        channelConfig.schema.parse(state[key]) as StateShape<TConfig>[typeof key]
+      );
+    } else if (hasOwnProperty(state, key)) {
       // No schema, pass through
-      validated[key] = state[key];
+      setStateValue(validated, key, state[key] as StateShape<TConfig>[typeof key]);
     } else if (channelConfig.default) {
       // Use default if key missing
-      validated[key] = channelConfig.default();
+      setStateValue(validated, key, channelConfig.default() as StateShape<TConfig>[typeof key]);
     }
   }
 
-  return validated;
+  return validated as ValidatedState<TConfig, TState>;
 }
 
 /**
@@ -164,25 +272,38 @@ export function validateState<T extends Record<string, StateChannelConfig>>(
  * // Result: { messages: ['a', 'b', 'c'] }
  * ```
  */
-export function mergeState<T extends Record<string, StateChannelConfig>>(
-  currentState: Record<string, any>,
-  update: Record<string, any>,
-  config: T
-): Record<string, any> {
+export function mergeState<TConfig extends StateConfigMap>(
+  currentState: Partial<StateShape<TConfig>>,
+  update: StateUpdateShape<TConfig>,
+  config: TConfig
+): Partial<StateShape<TConfig>> {
   const merged = { ...currentState };
 
-  for (const [key, value] of Object.entries(update)) {
+  for (const key of keysOf(update)) {
+    const value = update[key];
     const channelConfig = config[key];
+    const reducer = channelConfig?.reducer as
+      | ((
+          left: ChannelValue<typeof channelConfig>,
+          right: ChannelUpdate<typeof channelConfig>
+        ) => StateShape<TConfig>[typeof key])
+      | undefined;
 
-    if (channelConfig?.reducer && key in merged) {
+    if (reducer && hasOwnProperty(merged, key)) {
       // Apply reducer
-      merged[key] = channelConfig.reducer(merged[key], value);
+      setStateValue(
+        merged,
+        key,
+        reducer(
+          merged[key] as ChannelValue<typeof channelConfig>,
+          value as ChannelUpdate<typeof channelConfig>
+        )
+      );
     } else {
       // Simple replacement
-      merged[key] = value;
+      setStateValue(merged, key, value as StateShape<TConfig>[typeof key]);
     }
   }
 
   return merged;
 }
-

--- a/packages/core/src/langgraph/state.ts
+++ b/packages/core/src/langgraph/state.ts
@@ -44,6 +44,15 @@ type StateChannelConfigLike = {
 
 type StateConfigMap = Record<string, StateChannelConfigLike>;
 
+type ValidStateChannel<TChannel extends StateChannelConfigLike> =
+  TChannel extends StateChannelConfig<infer TValue, infer TUpdate>
+    ? TChannel & StateChannelConfig<TValue, TUpdate>
+    : never;
+
+type ValidStateConfig<TConfig extends StateConfigMap> = {
+  [K in keyof TConfig]: ValidStateChannel<TConfig[K]>;
+};
+
 type ChannelValue<TChannel extends StateChannelConfigLike> =
   TChannel extends StateChannelConfig<infer TValue, unknown> ? TValue : never;
 
@@ -186,7 +195,7 @@ function createChannel<TChannel extends StateChannelConfigLike>(
 export function createStateAnnotation<
   TConfig extends StateConfigMap
 >(
-  config: TConfig
+  config: TConfig & ValidStateConfig<TConfig>
 ): AnnotationRoot<StateAnnotationDefinition<TConfig>> {
   const stateDefinition = {} as StateAnnotationDefinition<TConfig>;
 
@@ -225,7 +234,7 @@ export function createStateAnnotation<
 export function validateState<
   TConfig extends StateConfigMap,
   TState extends Partial<Record<keyof TConfig, unknown>>,
->(state: TState, config: TConfig): ValidatedState<TConfig, TState> {
+>(state: TState, config: TConfig & ValidStateConfig<TConfig>): ValidatedState<TConfig, TState> {
   const validated = {} as Partial<StateShape<TConfig>>;
 
   for (const [key, channelConfig] of entriesOf(config)) {
@@ -275,7 +284,7 @@ export function validateState<
 export function mergeState<TConfig extends StateConfigMap>(
   currentState: Partial<StateShape<TConfig>>,
   update: StateUpdateShape<TConfig>,
-  config: TConfig
+  config: TConfig & ValidStateConfig<TConfig>
 ): Partial<StateShape<TConfig>> {
   const merged = { ...currentState };
 

--- a/packages/core/tests/langgraph/integration.test.ts
+++ b/packages/core/tests/langgraph/integration.test.ts
@@ -3,6 +3,11 @@ import { StateGraph } from '@langchain/langgraph';
 import { z } from 'zod';
 import { createStateAnnotation, validateState } from '../../src/langgraph/state.js';
 
+type IntegrationEvent = {
+  type: string;
+  timestamp: number;
+};
+
 describe('LangGraph Integration', () => {
   it('should work with StateGraph end-to-end', async () => {
     // Define state
@@ -22,12 +27,12 @@ describe('LangGraph Integration', () => {
     type State = typeof AgentState.State;
 
     // Define nodes
-    const node1 = (state: State) => ({
+    const node1 = (_state: State) => ({
       messages: ['node1'],
       stepCount: 1,
     });
 
-    const node2 = (state: State) => ({
+    const node2 = (_state: State) => ({
       messages: ['node2'],
       stepCount: 1,
     });
@@ -94,7 +99,7 @@ describe('LangGraph Integration', () => {
             timestamp: z.number(),
           })
         ),
-        reducer: (left: any[], right: any[]) => [...left, ...right],
+        reducer: (left: IntegrationEvent[], right: IntegrationEvent[]) => [...left, ...right],
         default: () => [],
       },
       counters: {
@@ -116,12 +121,12 @@ describe('LangGraph Integration', () => {
 
     type State = typeof AgentState.State;
 
-    const eventNode = (state: State) => ({
+    const eventNode = (_state: State) => ({
       events: [{ type: 'event1', timestamp: Date.now() }],
       counters: { event1: 1 },
     });
 
-    const anotherEventNode = (state: State) => ({
+    const anotherEventNode = (_state: State) => ({
       events: [{ type: 'event2', timestamp: Date.now() }],
       counters: { event2: 1, event1: 1 },
       metadata: { processed: true },
@@ -168,11 +173,11 @@ describe('LangGraph Integration', () => {
       return state.value > 5 ? 'high' : 'low';
     };
 
-    const highNode = (state: State) => ({
+    const highNode = (_state: State) => ({
       path: ['high'],
     });
 
-    const lowNode = (state: State) => ({
+    const lowNode = (_state: State) => ({
       path: ['low'],
     });
 
@@ -195,4 +200,3 @@ describe('LangGraph Integration', () => {
     expect(lowResult.path).toEqual(['low']);
   });
 });
-

--- a/packages/core/tests/langgraph/state.test.ts
+++ b/packages/core/tests/langgraph/state.test.ts
@@ -13,6 +13,10 @@ type EventRecord = {
   data: unknown;
 };
 
+type IncrementUpdate = {
+  delta: number;
+};
+
 describe('LangGraph State Utilities', () => {
   describe('createStateAnnotation', () => {
     it('should create annotation with simple channels', () => {
@@ -112,6 +116,27 @@ describe('LangGraph State Utilities', () => {
       expect(annotation.spec.events).toBeDefined();
       expect(initialState.count).toBe(1);
       expect(update.events).toHaveLength(1);
+    });
+
+    it('should preserve explicit update types for pre-typed reducer configs', () => {
+      const config: {
+        count: StateChannelConfig<number, IncrementUpdate>;
+      } = {
+        count: {
+          reducer: (left: number, right: IncrementUpdate) => left + right.delta,
+          default: () => 0,
+        },
+      };
+
+      const annotation = createStateAnnotation(config);
+      const update: typeof annotation.Update = {
+        count: { delta: 2 },
+      };
+
+      const merged = mergeState({ count: 3 }, update, config);
+
+      expect(annotation.spec.count).toBeDefined();
+      expect(merged.count).toBe(5);
     });
   });
 

--- a/packages/core/tests/langgraph/state.test.ts
+++ b/packages/core/tests/langgraph/state.test.ts
@@ -8,6 +8,11 @@ import {
   type StateChannelConfig,
 } from '../../src/langgraph/state.js';
 
+type EventRecord = {
+  type: string;
+  data: unknown;
+};
+
 describe('LangGraph State Utilities', () => {
   describe('createStateAnnotation', () => {
     it('should create annotation with simple channels', () => {
@@ -68,7 +73,7 @@ describe('LangGraph State Utilities', () => {
         // Reducer channel
         events: {
           schema: z.array(z.object({ type: z.string(), data: z.any() })),
-          reducer: (left: any[], right: any[]) => [...left, ...right],
+          reducer: (left: EventRecord[], right: EventRecord[]) => [...left, ...right],
           default: () => [],
         },
         // Simple channel with no schema
@@ -79,6 +84,34 @@ describe('LangGraph State Utilities', () => {
 
       expect(annotation).toBeDefined();
       expect(annotation.spec).toBeDefined();
+    });
+
+    it('should preserve inferred state and update shapes', () => {
+      const annotation = createStateAnnotation({
+        count: {
+          schema: z.number(),
+          default: () => 0,
+        },
+        events: {
+          schema: z.array(z.object({ type: z.string(), data: z.unknown() })),
+          reducer: (left: EventRecord[], right: EventRecord[]) => [...left, ...right],
+          default: () => [],
+        },
+      });
+
+      const initialState: typeof annotation.State = {
+        count: 1,
+        events: [{ type: 'created', data: { source: 'test' } }],
+      };
+
+      const update: typeof annotation.Update = {
+        count: 2,
+        events: [{ type: 'updated', data: { source: 'test' } }],
+      };
+
+      expect(annotation.spec.events).toBeDefined();
+      expect(initialState.count).toBe(1);
+      expect(update.events).toHaveLength(1);
     });
   });
 
@@ -283,7 +316,7 @@ describe('LangGraph State Utilities', () => {
 
       // Create a simple workflow
       const workflow = new StateGraph(State)
-        .addNode('start', (state) => {
+        .addNode('start', (_state) => {
           // Node doesn't set status or shouldContinue
           return { messages: ['Started'] };
         })
@@ -447,4 +480,3 @@ describe('LangGraph State Utilities', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -91,8 +91,12 @@
   - `pnpm test --run` -> `147 passed | 16 skipped` files; `2088 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `f533eeb` refactor(st-09003): harden langgraph state utility typing
+  - `abc515a` docs(st-09003): record state utility typing progress
+  - `a4effac` docs(st-09003): record state utility validation progress
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #65 marked ready: https://github.com/TVScoundrel/agentforge/pull/65
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -74,16 +74,23 @@
 **Branch:** `fix/st-09003-langgraph-state-utility-typing`
 
 ### Checklist
-- [ ] Create branch `fix/st-09003-langgraph-state-utility-typing`
-- [ ] Create draft PR with story ID in title
-- [ ] Reduce explicit `any` usage in `packages/core/src/langgraph/state.ts` for channel config and helper APIs
-- [ ] Preserve or improve generic inference for reducer/default/schema combinations
-- [ ] Add/update focused tests for state validation, default factories, and reducer merge behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09003-langgraph-state-utility-typing.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `fix/st-09003-langgraph-state-utility-typing`
+  - Created as `codex/fix/st-09003-langgraph-state-utility-typing` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #65: https://github.com/TVScoundrel/agentforge/pull/65
+- [x] Reduce explicit `any` usage in `packages/core/src/langgraph/state.ts` for channel config and helper APIs
+- [x] Preserve or improve generic inference for reducer/default/schema combinations
+- [x] Add/update focused tests for state validation, default factories, and reducer merge behavior
+  - `pnpm test --run packages/core/tests/langgraph/state.test.ts packages/core/tests/langgraph/integration.test.ts` -> `25 passed`
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09003-langgraph-state-utility-typing.md` (`state.ts 13 -> 0`; baseline `357 -> 344`)
+- [x] Add or update story documentation at `docs/st09003-langgraph-state-utility-typing.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused inference and reducer fixture updates in `packages/core/tests/langgraph/state.test.ts` and `packages/core/tests/langgraph/integration.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `147 passed | 16 skipped` files; `2088 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -95,6 +95,7 @@
   - `f533eeb` refactor(st-09003): harden langgraph state utility typing
   - `abc515a` docs(st-09003): record state utility typing progress
   - `a4effac` docs(st-09003): record state utility validation progress
+  - `f9d2eda` fix(st-09003): enforce state config compatibility
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #65 marked ready: https://github.com/TVScoundrel/agentforge/pull/65
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -96,6 +96,7 @@
   - `abc515a` docs(st-09003): record state utility typing progress
   - `a4effac` docs(st-09003): record state utility validation progress
   - `f9d2eda` fix(st-09003): enforce state config compatibility
+  - `a369e64` fix(st-09003): preserve declared reducer update types
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #65 marked ready: https://github.com/TVScoundrel/agentforge/pull/65
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -862,6 +862,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-08004
+**Status:** In Review (PR #65, 2026-03-13)
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langgraph/state.ts` removes avoidable explicit `any` from `StateChannelConfig`, `createStateAnnotation`, `validateState`, and `mergeState`
@@ -926,4 +927,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → [ST-09003, ST-09005 ready] → ST-09004
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → [ST-09003 in review, ST-09005 ready] → ST-09004

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-13
-**Active Story:** ST-09003 (Ready)
+**Active Story:** ST-09003 (In Review)
 
 ---
 
@@ -33,18 +33,19 @@
 
 Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-13):
 
-- Total: `357` warnings (`src/**`)
-- By package: `core 161`, `tools 70`, `testing 51`, `patterns 50`, `cli 25`
+- Total: `344` warnings (`src/**`)
+- By package: `core 148`, `tools 70`, `testing 51`, `patterns 50`, `cli 25`
 
 Top runtime hotspots informing this feature slice:
 
 1. `packages/core/src/langgraph/observability/logger.ts` (15)
-2. `packages/core/src/langgraph/state.ts` (13)
-3. `packages/patterns/src/react/nodes.ts` (10)
+2. `packages/patterns/src/react/nodes.ts` (10)
+3. `packages/core/src/langgraph/builders/parallel.ts` (9)
 4. `packages/patterns/src/shared/agent-builder.ts` (9)
 5. `packages/core/src/monitoring/alerts.ts` (5)
 
 `ST-09002` removed `15` explicit-`any` warnings from `packages/core/src/langchain/converter.ts` and improved the `core` baseline from `176` to `161`.
+`ST-09003` removed `13` explicit-`any` warnings from `packages/core/src/langgraph/state.ts` and improved the `core` baseline from `161` to `148`.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
+- **Ready:** 1 story
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
 
@@ -14,9 +14,6 @@
 
 ## Ready
 
-- **ST-09003: Strengthen LangGraph State Utility Typing** (EP-09, P2, 3h)
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/core/src/langgraph/state.ts` generics and reducer/default typing hardening
 - **ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types** (EP-09, P2, 4h)
   - Dependencies: ST-08004 (complete)
   - Scope: `packages/patterns/src/react/nodes.ts` + `packages/patterns/src/shared/agent-builder.ts`
@@ -31,7 +28,10 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+- **ST-09003: Strengthen LangGraph State Utility Typing** (EP-09, P2, 3h)
+  - PR: #65
+  - Dependencies: ST-08004 (complete)
+  - Scope: `packages/core/src/langgraph/state.ts` generics and reducer/default typing hardening
 
 ---
 
@@ -96,4 +96,4 @@ _No stories currently blocked_
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) planned on 2026-03-12
 - ✅ ST-09001 complete - core tool composition contracts hardened (merged 2026-03-12)
 - ✅ ST-09002 complete - LangChain converter boundary hardened (merged 2026-03-13)
-- ST-09003 and ST-09005 remain Ready; ST-09004 remains in Backlog pending ST-09003 completion
+- ST-09003 is in review (PR #65); ST-09005 remains Ready; ST-09004 remains in Backlog pending ST-09003 completion


### PR DESCRIPTION
## Story

- ST-09003: Strengthen LangGraph State Utility Typing

## What Changed

- replaced explicit `any` usage in `packages/core/src/langgraph/state.ts` with config-derived state and update helper types
- preserved `createStateAnnotation()` inference by building typed LangGraph channel definitions instead of falling back to a loose `StateDefinition`
- tightened `validateState()` and `mergeState()` around config-shaped state objects
- added focused inference coverage and removed explicit `any` fixtures from the touched LangGraph tests
- documented the warning delta and validation record in `docs/st09003-langgraph-state-utility-typing.md`

## Acceptance Criteria Coverage

- reduced explicit `any` usage in `packages/core/src/langgraph/state.ts` for channel config and helper APIs
- preserved generic inference for reducer, default, and schema-driven channel definitions
- updated focused tests for validation, default factories, reducer behavior, and inferred `State`/`Update` shapes
- recorded explicit-`any` warning deltas in the story doc

## Validation Performed

- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec eslint packages/core/src/langgraph/state.ts packages/core/tests/langgraph/state.test.ts packages/core/tests/langgraph/integration.test.ts`
- `pnpm test --run packages/core/tests/langgraph/state.test.ts packages/core/tests/langgraph/integration.test.ts` -> `25 passed`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run` -> `147 passed | 16 skipped` files; `2088 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status

- Ready for review
