### PR TITLE
ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types

### DIFF
--- a/docs/st09005-patterns-react-builder-typing.md
+++ b/docs/st09005-patterns-react-builder-typing.md
@@ -1,0 +1,46 @@
+# ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types
+
+## Summary
+
+Refactored the ReAct node helpers and shared agent-builder utility to remove broad `any`-based state boundaries while preserving existing ReAct loop behavior and shared workflow assembly semantics.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/patterns/src/react/nodes.ts` | Replaced ad hoc `any` casts with typed message/state helpers for conversation normalization, tool-call extraction, observation formatting, and scratchpad summaries |
+| `packages/patterns/src/shared/agent-builder.ts` | Reworked the shared builder contracts around config-derived state, update, node-name, and routing generics instead of `any`-typed node/state/condition boundaries |
+| `packages/patterns/tests/react/nodes.test.ts` | Added focused ReAct coverage for tool-message normalization, scratchpad context injection, and structured observation formatting while removing test-local `any` usage |
+| `packages/patterns/tests/shared/agent-builder.test.ts` | Added focused shared-builder coverage for mapped conditional routing and direct workflow termination via `END` |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspots
+
+- `packages/patterns/src/react/nodes.ts`: `10 -> 0` (`-10`)
+- `packages/patterns/src/shared/agent-builder.ts`: `9 -> 0` (`-9`)
+- `packages/patterns/tests/react/nodes.test.ts`: `4 -> 0` (`-4`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `324 -> 305` (`-19`)
+- `patterns` package: `50 -> 31` (`-19`)
+
+(After snapshot captured with `pnpm lint:explicit-any:baseline` on 2026-03-17.)
+
+## Compatibility Notes
+
+- ReAct reasoning, action, and observation nodes keep the same public shape and reducer-driven state updates.
+- Shared builder consumers still pass the same runtime config, but the exported node/condition/checkpointer contracts now preserve state and route types instead of collapsing to `any`.
+- Conditional routing behavior remains unchanged for both mapped branches and direct `END` termination.
+
+## Validation
+
+- `pnpm exec eslint packages/patterns/src/react/nodes.ts packages/patterns/src/shared/agent-builder.ts packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts`
+- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+- `pnpm test --run packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts` -> `13 passed`
+- `pnpm lint:explicit-any:baseline`
+
+## Test Impact
+
+Expanded focused automated coverage for ReAct message construction and shared builder conditional routing behavior.

--- a/docs/st09005-patterns-react-builder-typing.md
+++ b/docs/st09005-patterns-react-builder-typing.md
@@ -40,6 +40,8 @@ Refactored the ReAct node helpers and shared agent-builder utility to remove bro
 - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
 - `pnpm test --run packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts` -> `13 passed`
 - `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `149 passed | 16 skipped` files; `2102 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
 
 ## Test Impact
 

--- a/docs/st09005-patterns-react-builder-typing.md
+++ b/docs/st09005-patterns-react-builder-typing.md
@@ -8,8 +8,8 @@ Refactored the ReAct node helpers and shared agent-builder utility to remove bro
 
 | File | Change |
 |------|--------|
-| `packages/patterns/src/react/nodes.ts` | Replaced ad hoc `any` casts with typed message/state helpers for conversation normalization, tool-call extraction, observation formatting, and scratchpad summaries |
-| `packages/patterns/src/shared/agent-builder.ts` | Reworked the shared builder contracts around config-derived state, update, node-name, and routing generics instead of `any`-typed node/state/condition boundaries |
+| `packages/patterns/src/react/nodes.ts` | Replaced ad hoc `any` casts with typed message/state helpers for conversation normalization, tool-call extraction, observation formatting, scratchpad summaries, and invalid tool-message fallback handling |
+| `packages/patterns/src/shared/agent-builder.ts` | Reworked the shared builder contracts around config-derived state, update, node-name, and routing generics instead of `any`-typed node/state/condition boundaries while keeping the schema constructor type-checked |
 | `packages/patterns/tests/react/nodes.test.ts` | Added focused ReAct coverage for tool-message normalization, scratchpad context injection, and structured observation formatting while removing test-local `any` usage |
 | `packages/patterns/tests/shared/agent-builder.test.ts` | Added focused shared-builder coverage for mapped conditional routing and direct workflow termination via `END` |
 

--- a/packages/patterns/src/react/nodes.ts
+++ b/packages/patterns/src/react/nodes.ts
@@ -113,9 +113,7 @@ function formatObservationContent(observation: ToolResult): string {
     return `Error: ${observation.error}`;
   }
 
-  return typeof observation.result === 'string'
-    ? observation.result
-    : JSON.stringify(observation.result, null, 2);
+  return stringifyObservationResult(observation.result, 2);
 }
 
 function formatActionSummary(actions: ToolCall[]): string {
@@ -131,11 +129,18 @@ function formatObservationSummary(observations: ToolResult[]): string {
         return `Error: ${observation.error}`;
       }
 
-      return typeof observation.result === 'string'
-        ? observation.result
-        : JSON.stringify(observation.result);
+      return stringifyObservationResult(observation.result);
     })
     .join('; ');
+}
+
+function stringifyObservationResult(result: unknown, space?: number): string {
+  if (typeof result === 'string') {
+    return result;
+  }
+
+  const stringified = JSON.stringify(result, null, space);
+  return stringified ?? String(result);
 }
 
 function getLatestThought(thoughts: Thought[]): string {

--- a/packages/patterns/src/react/nodes.ts
+++ b/packages/patterns/src/react/nodes.ts
@@ -5,10 +5,23 @@
  */
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { HumanMessage, AIMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  HumanMessage,
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+  type BaseMessage,
+} from '@langchain/core/messages';
 import { type Tool, toLangChainTools } from '@agentforge/core';
-import type { ReActStateType, ToolCall, ToolResult } from './state.js';
-import { formatToolsForPrompt, formatScratchpad, formatThoughts } from './prompts.js';
+import type {
+  Message,
+  ReActStateType,
+  ScratchpadEntry,
+  Thought,
+  ToolCall,
+  ToolResult,
+} from './state.js';
+import { formatScratchpad } from './prompts.js';
 import {
   generateToolCallCacheKey,
   createPatternLogger,
@@ -20,6 +33,106 @@ import { handleNodeError } from '../shared/error-handling.js';
 const reasoningLogger = createPatternLogger('agentforge:patterns:react:reasoning');
 const actionLogger = createPatternLogger('agentforge:patterns:react:action');
 const observationLogger = createPatternLogger('agentforge:patterns:react:observation');
+
+type SupportedConversationMessage =
+  | HumanMessage
+  | AIMessage
+  | SystemMessage
+  | ToolMessage;
+
+type LlmToolCall = {
+  id?: string;
+  name: string;
+  args?: Record<string, unknown>;
+};
+
+type LlmResponseWithToolCalls = {
+  content: unknown;
+  tool_calls?: LlmToolCall[];
+};
+
+function normalizeConversationMessage(message: Message): SupportedConversationMessage {
+  switch (message.role) {
+    case 'user':
+      return new HumanMessage(message.content);
+    case 'assistant':
+      return new AIMessage(message.content);
+    case 'system':
+      return new SystemMessage(message.content);
+    case 'tool':
+      return new ToolMessage({
+        content: message.content,
+        tool_call_id: message.tool_call_id ?? '',
+        name: message.name,
+      });
+    default:
+      return new HumanMessage(message.content);
+  }
+}
+
+function buildReasoningMessages(
+  systemPrompt: string,
+  stateMessages: Message[],
+  scratchpad: ScratchpadEntry[]
+): BaseMessage[] {
+  const messages: BaseMessage[] = [
+    new SystemMessage(systemPrompt),
+    ...stateMessages.map(normalizeConversationMessage),
+  ];
+
+  if (scratchpad.length > 0) {
+    messages.push(new SystemMessage(`Previous steps:\n${formatScratchpad(scratchpad)}`));
+  }
+
+  return messages;
+}
+
+function extractToolCalls(response: LlmResponseWithToolCalls): ToolCall[] {
+  if (!response.tool_calls || response.tool_calls.length === 0) {
+    return [];
+  }
+
+  return response.tool_calls.map((toolCall) => ({
+    id: toolCall.id || `call_${Date.now()}_${Math.random()}`,
+    name: toolCall.name,
+    arguments: toolCall.args ?? {},
+    timestamp: Date.now(),
+  }));
+}
+
+function formatObservationContent(observation: ToolResult): string {
+  if (observation.error) {
+    return `Error: ${observation.error}`;
+  }
+
+  return typeof observation.result === 'string'
+    ? observation.result
+    : JSON.stringify(observation.result, null, 2);
+}
+
+function formatActionSummary(actions: ToolCall[]): string {
+  return actions
+    .map((action) => `${action.name}(${JSON.stringify(action.arguments)})`)
+    .join(', ');
+}
+
+function formatObservationSummary(observations: ToolResult[]): string {
+  return observations
+    .map((observation) => {
+      if (observation.error) {
+        return `Error: ${observation.error}`;
+      }
+
+      return typeof observation.result === 'string'
+        ? observation.result
+        : JSON.stringify(observation.result);
+    })
+    .join('; ');
+}
+
+function getLatestThought(thoughts: Thought[]): string {
+  return thoughts[thoughts.length - 1]?.content ?? '';
+}
 
 /**
  * Create a reasoning node that generates thoughts and decides on actions
@@ -35,68 +148,32 @@ export function createReasoningNode(
   tools: Tool[],
   systemPrompt: string,
   maxIterations: number,
-  verbose: boolean = false
+  _verbose: boolean = false
 ) {
   // Bind tools to the LLM
   const langchainTools = toLangChainTools(tools);
   const llmWithTools = llm.bindTools ? llm.bindTools(langchainTools) : llm;
 
   return async (state: ReActStateType) => {
-    const currentIteration = (state.iteration as number) || 0;
+    const currentIteration = state.iteration || 0;
     const startTime = Date.now();
 
     reasoningLogger.debug('Reasoning iteration started', {
       iteration: currentIteration + 1,
       maxIterations,
-      observationCount: (state.observations as any[])?.length || 0,
-      hasActions: !!(state.actions as any[])?.length
+      observationCount: state.observations.length,
+      hasActions: state.actions.length > 0
     });
 
     // Build messages for the LLM
-    const stateMessages = (state.messages as any[]) || [];
-    const messages = [
-      new SystemMessage(systemPrompt),
-      ...stateMessages.map((msg: any) => {
-        if (msg.role === 'user') return new HumanMessage(msg.content);
-        if (msg.role === 'assistant') return new AIMessage(msg.content);
-        if (msg.role === 'system') return new SystemMessage(msg.content);
-        if (msg.role === 'tool') {
-          // Properly handle tool messages with tool_call_id
-          return new ToolMessage({
-            content: msg.content,
-            tool_call_id: msg.tool_call_id,
-            name: msg.name,
-          });
-        }
-        return new HumanMessage(msg.content); // fallback
-      }),
-    ];
-
-    // Add context about current state
-    const scratchpad = (state.scratchpad as any[]) || [];
-    if (scratchpad.length > 0) {
-      const scratchpadText = formatScratchpad(scratchpad);
-      messages.push(new SystemMessage(`Previous steps:\n${scratchpadText}`));
-    }
+    const messages = buildReasoningMessages(systemPrompt, state.messages, state.scratchpad);
 
     // Invoke the LLM
     const response = await llmWithTools.invoke(messages);
 
     // Extract thought and tool calls
     const thought = typeof response.content === 'string' ? response.content : '';
-    const toolCalls: ToolCall[] = [];
-
-    // Check if the response has tool calls
-    if (response.tool_calls && response.tool_calls.length > 0) {
-      for (const toolCall of response.tool_calls) {
-        toolCalls.push({
-          id: toolCall.id || `call_${Date.now()}_${Math.random()}`,
-          name: toolCall.name,
-          arguments: toolCall.args || {},
-          timestamp: Date.now(),
-        });
-      }
-    }
+    const toolCalls = extractToolCalls(response as LlmResponseWithToolCalls);
 
     // Determine if we should continue
     const shouldContinue = toolCalls.length > 0 && currentIteration + 1 < maxIterations;
@@ -131,16 +208,16 @@ export function createReasoningNode(
  */
 export function createActionNode(
   tools: Tool[],
-  verbose: boolean = false,
+  _verbose: boolean = false,
   enableDeduplication: boolean = true
 ) {
   // Create a map for quick tool lookup
   const toolMap = new Map(tools.map((tool) => [tool.metadata.name, tool]));
 
   return async (state: ReActStateType) => {
-    const actions = (state.actions as ToolCall[]) || [];
-    const allObservations = (state.observations as ToolResult[]) || [];
-    const iteration = (state.iteration as number) || 0;
+    const actions = state.actions;
+    const allObservations = state.observations;
+    const iteration = state.iteration || 0;
     const startTime = Date.now();
 
     actionLogger.debug('Action node started', {
@@ -303,14 +380,14 @@ export function createActionNode(
  * @param returnIntermediateSteps - Whether to populate the scratchpad with intermediate steps
  */
 export function createObservationNode(
-  verbose: boolean = false,
+  _verbose: boolean = false,
   returnIntermediateSteps: boolean = false
 ) {
   return async (state: ReActStateType) => {
-    const observations = (state.observations as ToolResult[]) || [];
-    const thoughts = (state.thoughts as any[]) || [];
-    const actions = (state.actions as ToolCall[]) || [];
-    const iteration = (state.iteration as number) || 0;
+    const observations = state.observations;
+    const thoughts = state.thoughts;
+    const actions = state.actions;
+    const iteration = state.iteration || 0;
 
     observationLogger.debug('Processing observations', {
       observationCount: observations.length,
@@ -320,38 +397,22 @@ export function createObservationNode(
     // Get the most recent observations
     const recentObservations = observations.slice(-10);
     const latestActions = actions.slice(-10);
+    const actionNamesById = new Map(latestActions.map((action) => [action.id, action.name]));
 
     // Add observation results as messages
-    const observationMessages = recentObservations.map((obs: any) => {
-      const content = obs.error
-        ? `Error: ${obs.error}`
-        : typeof obs.result === 'string'
-        ? obs.result
-        : JSON.stringify(obs.result, null, 2);
-
-      return {
+    const observationMessages = recentObservations.map((observation) => ({
         role: 'tool' as const,
-        content,
-        name: latestActions.find((a: any) => a.id === obs.toolCallId)?.name,
-        tool_call_id: obs.toolCallId, // Include tool_call_id for proper ToolMessage construction
-      };
-    });
+        content: formatObservationContent(observation),
+        name: actionNamesById.get(observation.toolCallId),
+        tool_call_id: observation.toolCallId,
+      }));
 
     // Only populate scratchpad if returnIntermediateSteps is enabled
     const scratchpadEntries = returnIntermediateSteps ? [{
-      step: state.iteration as number,
-      thought: thoughts[thoughts.length - 1]?.content || '',
-      action: latestActions.map((a: any) => `${a.name}(${JSON.stringify(a.arguments)})`).join(', '),
-      observation: recentObservations
-        .map((obs: any) => {
-          if (obs.error) {
-            return `Error: ${obs.error}`;
-          }
-          return typeof obs.result === 'string'
-            ? obs.result
-            : JSON.stringify(obs.result);
-        })
-        .join('; '),
+      step: state.iteration,
+      thought: getLatestThought(thoughts),
+      action: formatActionSummary(latestActions),
+      observation: formatObservationSummary(recentObservations),
       timestamp: Date.now(),
     }] : [];
 
@@ -367,4 +428,3 @@ export function createObservationNode(
     };
   };
 }
-

--- a/packages/patterns/src/react/nodes.ts
+++ b/packages/patterns/src/react/nodes.ts
@@ -12,7 +12,7 @@ import {
   ToolMessage,
   type BaseMessage,
 } from '@langchain/core/messages';
-import { type Tool, toLangChainTools } from '@agentforge/core';
+import { type JsonValue, type Tool, toLangChainTools } from '@agentforge/core';
 import type {
   Message,
   ReActStateType,
@@ -33,6 +33,7 @@ import { handleNodeError } from '../shared/error-handling.js';
 const reasoningLogger = createPatternLogger('agentforge:patterns:react:reasoning');
 const actionLogger = createPatternLogger('agentforge:patterns:react:action');
 const observationLogger = createPatternLogger('agentforge:patterns:react:observation');
+type PatternLogger = typeof reasoningLogger;
 
 type SupportedConversationMessage =
   | HumanMessage
@@ -141,6 +142,17 @@ function getLatestThought(thoughts: Thought[]): string {
   return thoughts[thoughts.length - 1]?.content ?? '';
 }
 
+function debugIfVerbose(
+  logger: PatternLogger,
+  verbose: boolean,
+  message: string,
+  data?: JsonValue
+): void {
+  if (verbose) {
+    logger.debug(message, data);
+  }
+}
+
 /**
  * Create a reasoning node that generates thoughts and decides on actions
  *
@@ -155,7 +167,7 @@ export function createReasoningNode(
   tools: Tool[],
   systemPrompt: string,
   maxIterations: number,
-  _verbose: boolean = false
+  verbose: boolean = false
 ) {
   // Bind tools to the LLM
   const langchainTools = toLangChainTools(tools);
@@ -165,7 +177,7 @@ export function createReasoningNode(
     const currentIteration = state.iteration || 0;
     const startTime = Date.now();
 
-    reasoningLogger.debug('Reasoning iteration started', {
+    debugIfVerbose(reasoningLogger, verbose, 'Reasoning iteration started', {
       iteration: currentIteration + 1,
       maxIterations,
       observationCount: state.observations.length,
@@ -215,7 +227,7 @@ export function createReasoningNode(
  */
 export function createActionNode(
   tools: Tool[],
-  _verbose: boolean = false,
+  verbose: boolean = false,
   enableDeduplication: boolean = true
 ) {
   // Create a map for quick tool lookup
@@ -227,7 +239,7 @@ export function createActionNode(
     const iteration = state.iteration || 0;
     const startTime = Date.now();
 
-    actionLogger.debug('Action node started', {
+    debugIfVerbose(actionLogger, verbose, 'Action node started', {
       actionCount: actions.length,
       iteration,
       cacheEnabled: enableDeduplication
@@ -254,7 +266,7 @@ export function createActionNode(
       }
 
       if (cacheSize > 0) {
-        actionLogger.debug('Deduplication cache built', {
+        debugIfVerbose(actionLogger, verbose, 'Deduplication cache built', {
           cacheSize,
           totalObservations: allObservations.length
         });
@@ -270,7 +282,7 @@ export function createActionNode(
       // Skip actions that already have observations (already processed)
       const existingObservation = allObservations.find(obs => obs.toolCallId === action.id);
       if (existingObservation) {
-        actionLogger.debug('Skipping already-processed action', {
+        debugIfVerbose(actionLogger, verbose, 'Skipping already-processed action', {
           toolName: action.name,
           toolCallId: action.id,
           iteration
@@ -326,7 +338,7 @@ export function createActionNode(
 
         toolsExecuted++;
 
-        actionLogger.debug('Tool executed successfully', {
+        debugIfVerbose(actionLogger, verbose, 'Tool executed successfully', {
           toolName: action.name,
           executionTime,
           iteration
@@ -347,7 +359,7 @@ export function createActionNode(
         }
       } catch (error) {
         // Handle error with proper GraphInterrupt detection
-        const errorMessage = handleNodeError(error, `action:${action.name}`, false);
+        const errorMessage = handleNodeError(error, `action:${action.name}`, verbose);
 
         actionLogger.error('Tool execution failed', {
           toolName: action.name,
@@ -387,7 +399,7 @@ export function createActionNode(
  * @param returnIntermediateSteps - Whether to populate the scratchpad with intermediate steps
  */
 export function createObservationNode(
-  _verbose: boolean = false,
+  verbose: boolean = false,
   returnIntermediateSteps: boolean = false
 ) {
   return async (state: ReActStateType) => {
@@ -396,7 +408,7 @@ export function createObservationNode(
     const actions = state.actions;
     const iteration = state.iteration || 0;
 
-    observationLogger.debug('Processing observations', {
+    debugIfVerbose(observationLogger, verbose, 'Processing observations', {
       observationCount: observations.length,
       iteration
     });
@@ -423,7 +435,7 @@ export function createObservationNode(
       timestamp: Date.now(),
     }] : [];
 
-    observationLogger.debug('Observation node complete', {
+    debugIfVerbose(observationLogger, verbose, 'Observation node complete', {
       iteration,
       scratchpadUpdated: returnIntermediateSteps,
       messageCount: observationMessages.length

--- a/packages/patterns/src/react/nodes.ts
+++ b/packages/patterns/src/react/nodes.ts
@@ -60,9 +60,16 @@ function normalizeConversationMessage(message: Message): SupportedConversationMe
     case 'system':
       return new SystemMessage(message.content);
     case 'tool':
+      if (!message.tool_call_id) {
+        reasoningLogger.warn(
+          'Tool message missing tool_call_id; falling back to human message',
+          message.name ? { name: message.name } : undefined
+        );
+        return new HumanMessage(message.content);
+      }
       return new ToolMessage({
         content: message.content,
-        tool_call_id: message.tool_call_id ?? '',
+        tool_call_id: message.tool_call_id,
         name: message.name,
       });
     default:

--- a/packages/patterns/src/shared/agent-builder.ts
+++ b/packages/patterns/src/shared/agent-builder.ts
@@ -7,57 +7,87 @@
  * @module patterns/shared/agent-builder
  */
 
-import { StateGraph, END } from '@langchain/langgraph';
-import type { CompiledStateGraph } from '@langchain/langgraph';
+import { StateGraph, END, type BaseCheckpointSaver } from '@langchain/langgraph';
+import type { ExtractStateType, ExtractUpdateType } from '@langchain/langgraph';
+
+type AgentStateSchema = unknown;
+type AgentRoute = string;
+type AgentNodeOutput<TUpdate> = TUpdate extends object
+  ? TUpdate & Record<string, unknown>
+  : TUpdate;
+type AgentGraph<
+  TStateSchema,
+  TState,
+  TUpdate,
+  TNodeName extends string,
+> = ReturnType<StateGraph<TStateSchema, TState, TUpdate, TNodeName>['compile']>;
+
+export type AgentNodeFn<TState, TUpdate> = (
+  state: TState
+) => Promise<AgentNodeOutput<TUpdate>> | AgentNodeOutput<TUpdate>;
 
 /**
  * Node definition for agent builder
  */
-export interface NodeDefinition {
+export interface NodeDefinition<
+  TState,
+  TUpdate,
+  TNodeName extends string = string,
+> {
   /** Name of the node (must be unique within the graph) */
-  name: string;
+  name: TNodeName;
   /** Node function that processes state */
-  fn: (state: any) => Promise<any> | any;
+  fn: AgentNodeFn<TState, TUpdate>;
 }
 
 /**
  * Simple edge definition (unconditional edge)
  */
-export interface SimpleEdge {
+export interface SimpleEdge<TNodeName extends string = string> {
   /** Source node name */
-  from: string;
+  from: TNodeName;
   /** Target node name or END */
-  to: string | typeof END;
+  to: TNodeName | typeof END;
 }
 
 /**
  * Conditional edge definition (routing logic)
  */
-export interface ConditionalEdge {
+export interface ConditionalEdge<
+  TState,
+  TNodeName extends string = string,
+  TRoute extends string = AgentRoute,
+> {
   /** Source node name */
-  from: string;
+  from: TNodeName;
   /** Routing function that returns the next node name */
-  condition: (state: any) => string | typeof END | string[];
+  condition: (state: TState) => TRoute | typeof END | TRoute[];
   /** Optional mapping of condition results to node names */
-  mapping?: Record<string, string | typeof END>;
+  mapping?: Record<string, TNodeName | typeof END>;
 }
 
 /**
  * Configuration for building a LangGraph agent
  */
-export interface AgentBuilderConfig {
+export interface AgentBuilderConfig<
+  TStateSchema = AgentStateSchema,
+  TState = ExtractStateType<TStateSchema>,
+  TUpdate = ExtractUpdateType<TStateSchema, TState>,
+  TNodeName extends string = string,
+  TRoute extends string = AgentRoute,
+> {
   /** State annotation (created with createStateAnnotation) */
-  state: any;
+  state: TStateSchema;
   /** List of nodes to add to the graph */
-  nodes: NodeDefinition[];
+  nodes: Array<NodeDefinition<TState, TUpdate, TNodeName>>;
   /** Entry point node name (where the graph starts) */
-  entryPoint: string;
+  entryPoint: TNodeName;
   /** Simple edges (unconditional transitions) */
-  edges?: SimpleEdge[];
+  edges?: Array<SimpleEdge<TNodeName>>;
   /** Conditional edges (routing logic) */
-  conditionalEdges?: ConditionalEdge[];
+  conditionalEdges?: Array<ConditionalEdge<TState, TNodeName, TRoute>>;
   /** Optional checkpointer for persistence and human-in-the-loop */
-  checkpointer?: any;
+  checkpointer?: BaseCheckpointSaver | true;
 }
 
 /**
@@ -118,7 +148,15 @@ export interface AgentBuilderConfig {
  * });
  * ```
  */
-export function buildAgent(config: AgentBuilderConfig): CompiledStateGraph<any, any> {
+export function buildAgent<
+  TStateSchema = AgentStateSchema,
+  TState = ExtractStateType<TStateSchema>,
+  TUpdate = ExtractUpdateType<TStateSchema, TState>,
+  TNodeName extends string = string,
+  TRoute extends string = AgentRoute,
+>(
+  config: AgentBuilderConfig<TStateSchema, TState, TUpdate, TNodeName, TRoute>
+): AgentGraph<TStateSchema, TState, TUpdate, TNodeName> {
   const {
     state,
     nodes,
@@ -129,15 +167,9 @@ export function buildAgent(config: AgentBuilderConfig): CompiledStateGraph<any, 
   } = config;
 
   // Create the workflow
-  const workflow = new StateGraph(state);
-  const dynamicWorkflow = workflow as unknown as {
-    addEdge: (from: string, to: string | typeof END) => void;
-    addConditionalEdges: (
-      from: string,
-      condition: (state: unknown) => string | typeof END | string[],
-      mapping?: Record<string, string | typeof END>
-    ) => void;
-  };
+  const workflow = new StateGraph<TStateSchema, TState, TUpdate, TNodeName>(
+    state as never
+  );
 
   // Add all nodes
   for (const { name, fn } of nodes) {
@@ -145,22 +177,22 @@ export function buildAgent(config: AgentBuilderConfig): CompiledStateGraph<any, 
   }
 
   // Set entry point
-  dynamicWorkflow.addEdge('__start__', entryPoint);
+  workflow.addEdge('__start__', entryPoint);
 
   // Add simple edges
   for (const edge of edges) {
-    dynamicWorkflow.addEdge(edge.from, edge.to);
+    workflow.addEdge(edge.from, edge.to);
   }
 
   // Add conditional edges
   for (const edge of conditionalEdges) {
     if (edge.mapping) {
-      dynamicWorkflow.addConditionalEdges(edge.from, edge.condition, edge.mapping);
+      workflow.addConditionalEdges(edge.from, edge.condition, edge.mapping);
     } else {
-      dynamicWorkflow.addConditionalEdges(edge.from, edge.condition);
+      workflow.addConditionalEdges(edge.from, edge.condition);
     }
   }
 
   // Compile with checkpointer if provided
-  return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
+  return workflow.compile(checkpointer ? { checkpointer } : undefined);
 }

--- a/packages/patterns/src/shared/agent-builder.ts
+++ b/packages/patterns/src/shared/agent-builder.ts
@@ -8,23 +8,34 @@
  */
 
 import { StateGraph, END, type BaseCheckpointSaver } from '@langchain/langgraph';
-import type { ExtractStateType, ExtractUpdateType } from '@langchain/langgraph';
+import type { ExtractStateType, ExtractUpdateType, StateDefinitionInit } from '@langchain/langgraph';
 
-type AgentStateSchema = unknown;
+type AgentStateSchema = StateDefinitionInit;
 type AgentRoute = string;
-type AgentNodeOutput<TUpdate> = TUpdate extends object
-  ? TUpdate & Record<string, unknown>
-  : TUpdate;
-type AgentGraph<
+type AgentState<TStateSchema extends AgentStateSchema> = ExtractStateType<TStateSchema>;
+type AgentUpdate<TStateSchema extends AgentStateSchema> = ExtractUpdateType<
   TStateSchema,
-  TState,
-  TUpdate,
+  AgentState<TStateSchema>
+>;
+type AgentGraph<
+  TStateSchema extends AgentStateSchema,
   TNodeName extends string,
-> = ReturnType<StateGraph<TStateSchema, TState, TUpdate, TNodeName>['compile']>;
+> = ReturnType<
+  StateGraph<TStateSchema, AgentState<TStateSchema>, AgentUpdate<TStateSchema>, TNodeName>['compile']
+>;
 
 export type AgentNodeFn<TState, TUpdate> = (
   state: TState
-) => Promise<AgentNodeOutput<TUpdate>> | AgentNodeOutput<TUpdate>;
+) => Promise<TUpdate> | TUpdate;
+
+type LangGraphNodeFn<TState, TUpdate> = (
+  state: TState
+) => Promise<TUpdate extends object ? TUpdate & Record<string, unknown> : TUpdate>
+  | (TUpdate extends object ? TUpdate & Record<string, unknown> : TUpdate);
+
+type StateGraphConstructor = new <TStateSchema extends AgentStateSchema>(
+  state: TStateSchema
+) => StateGraph<TStateSchema>;
 
 /**
  * Node definition for agent builder
@@ -70,22 +81,20 @@ export interface ConditionalEdge<
  * Configuration for building a LangGraph agent
  */
 export interface AgentBuilderConfig<
-  TStateSchema = AgentStateSchema,
-  TState = ExtractStateType<TStateSchema>,
-  TUpdate = ExtractUpdateType<TStateSchema, TState>,
+  TStateSchema extends AgentStateSchema = AgentStateSchema,
   TNodeName extends string = string,
   TRoute extends string = AgentRoute,
 > {
   /** State annotation (created with createStateAnnotation) */
   state: TStateSchema;
   /** List of nodes to add to the graph */
-  nodes: Array<NodeDefinition<TState, TUpdate, TNodeName>>;
+  nodes: Array<NodeDefinition<AgentState<TStateSchema>, AgentUpdate<TStateSchema>, TNodeName>>;
   /** Entry point node name (where the graph starts) */
   entryPoint: TNodeName;
   /** Simple edges (unconditional transitions) */
   edges?: Array<SimpleEdge<TNodeName>>;
   /** Conditional edges (routing logic) */
-  conditionalEdges?: Array<ConditionalEdge<TState, TNodeName, TRoute>>;
+  conditionalEdges?: Array<ConditionalEdge<AgentState<TStateSchema>, TNodeName, TRoute>>;
   /** Optional checkpointer for persistence and human-in-the-loop */
   checkpointer?: BaseCheckpointSaver | true;
 }
@@ -149,14 +158,12 @@ export interface AgentBuilderConfig<
  * ```
  */
 export function buildAgent<
-  TStateSchema = AgentStateSchema,
-  TState = ExtractStateType<TStateSchema>,
-  TUpdate = ExtractUpdateType<TStateSchema, TState>,
+  TStateSchema extends AgentStateSchema = AgentStateSchema,
   TNodeName extends string = string,
   TRoute extends string = AgentRoute,
 >(
-  config: AgentBuilderConfig<TStateSchema, TState, TUpdate, TNodeName, TRoute>
-): AgentGraph<TStateSchema, TState, TUpdate, TNodeName> {
+  config: AgentBuilderConfig<TStateSchema, TNodeName, TRoute>
+): AgentGraph<TStateSchema, TNodeName> {
   const {
     state,
     nodes,
@@ -167,32 +174,47 @@ export function buildAgent<
   } = config;
 
   // Create the workflow
-  const workflow = new StateGraph<TStateSchema, TState, TUpdate, TNodeName>(
-    state as never
-  );
+  const StateGraphCtor = StateGraph as unknown as StateGraphConstructor;
+  const workflow = new StateGraphCtor(state);
+  const dynamicWorkflow = workflow as unknown as {
+    addNode: (
+      name: TNodeName,
+      fn: LangGraphNodeFn<AgentState<TStateSchema>, AgentUpdate<TStateSchema>>
+    ) => void;
+    addEdge: (from: TNodeName | '__start__', to: TNodeName | typeof END) => void;
+    addConditionalEdges: (
+      from: TNodeName,
+      condition: (state: AgentState<TStateSchema>) => TRoute | typeof END | TRoute[],
+      mapping?: Record<string, TNodeName | typeof END>
+    ) => void;
+    compile: (config?: { checkpointer?: BaseCheckpointSaver | true }) => unknown;
+  };
 
   // Add all nodes
   for (const { name, fn } of nodes) {
-    workflow.addNode(name, fn);
+    dynamicWorkflow.addNode(name, fn as LangGraphNodeFn<AgentState<TStateSchema>, AgentUpdate<TStateSchema>>);
   }
 
   // Set entry point
-  workflow.addEdge('__start__', entryPoint);
+  dynamicWorkflow.addEdge('__start__', entryPoint);
 
   // Add simple edges
   for (const edge of edges) {
-    workflow.addEdge(edge.from, edge.to);
+    dynamicWorkflow.addEdge(edge.from, edge.to);
   }
 
   // Add conditional edges
   for (const edge of conditionalEdges) {
     if (edge.mapping) {
-      workflow.addConditionalEdges(edge.from, edge.condition, edge.mapping);
+      dynamicWorkflow.addConditionalEdges(edge.from, edge.condition, edge.mapping);
     } else {
-      workflow.addConditionalEdges(edge.from, edge.condition);
+      dynamicWorkflow.addConditionalEdges(edge.from, edge.condition);
     }
   }
 
   // Compile with checkpointer if provided
-  return workflow.compile(checkpointer ? { checkpointer } : undefined);
+  return dynamicWorkflow.compile(checkpointer ? { checkpointer } : undefined) as unknown as AgentGraph<
+    TStateSchema,
+    TNodeName
+  >;
 }

--- a/packages/patterns/src/shared/agent-builder.ts
+++ b/packages/patterns/src/shared/agent-builder.ts
@@ -74,7 +74,7 @@ export interface ConditionalEdge<
   /** Routing function that returns the next node name */
   condition: (state: TState) => TRoute | typeof END | TRoute[];
   /** Optional mapping of condition results to node names */
-  mapping?: Record<string, TNodeName | typeof END>;
+  mapping?: Partial<Record<TRoute, TNodeName | typeof END>>;
 }
 
 /**
@@ -185,7 +185,7 @@ export function buildAgent<
     addConditionalEdges: (
       from: TNodeName,
       condition: (state: AgentState<TStateSchema>) => TRoute | typeof END | TRoute[],
-      mapping?: Record<string, TNodeName | typeof END>
+      mapping?: Partial<Record<TRoute, TNodeName | typeof END>>
     ) => void;
     compile: (config?: { checkpointer?: BaseCheckpointSaver | true }) => unknown;
   };

--- a/packages/patterns/tests/react/nodes.test.ts
+++ b/packages/patterns/tests/react/nodes.test.ts
@@ -5,13 +5,22 @@ import {
   createObservationNode,
 } from '../../src/react/nodes.js';
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { createMockLLM } from '@agentforge/testing';
-import { AIMessage } from '@langchain/core/messages';
+import { AIMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { z } from 'zod';
 import type { ReActStateType } from '../../src/react/state.js';
 
+type MockReasoningResponse = {
+  content: string;
+  tool_calls?: Array<{
+    id?: string;
+    name: string;
+    args?: Record<string, unknown>;
+  }>;
+};
+
 // Helper to create mock LLM with custom response
-function createMockChatModel(mockResponse?: any) {
+function createMockChatModel(mockResponse?: MockReasoningResponse): BaseChatModel {
   const response = mockResponse || {
     content: 'I need to use a tool',
     tool_calls: [
@@ -23,9 +32,11 @@ function createMockChatModel(mockResponse?: any) {
     ],
   };
 
-  return createMockLLM({
-    responseGenerator: () => new AIMessage(response),
-  });
+  const invoke = vi.fn().mockResolvedValue(new AIMessage(response));
+  return {
+    bindTools: vi.fn().mockReturnThis(),
+    invoke,
+  } as unknown as BaseChatModel;
 }
 
 describe('ReAct Nodes', () => {
@@ -40,7 +51,7 @@ describe('ReAct Nodes', () => {
 
   describe('createReasoningNode', () => {
     it('should generate thoughts and tool calls', async () => {
-      const mockLLM = createMockChatModel() as any;
+      const mockLLM = createMockChatModel();
       const reasoningNode = createReasoningNode(mockLLM, [testTool], 'System prompt', 10, false);
 
       const initialState: ReActStateType = {
@@ -66,7 +77,7 @@ describe('ReAct Nodes', () => {
       const mockLLM = createMockChatModel({
         content: 'Final answer',
         tool_calls: [],
-      }) as any;
+      });
 
       const reasoningNode = createReasoningNode(mockLLM, [testTool], 'System prompt', 10, false);
 
@@ -88,7 +99,7 @@ describe('ReAct Nodes', () => {
     });
 
     it('should respect max iterations', async () => {
-      const mockLLM = createMockChatModel() as any;
+      const mockLLM = createMockChatModel();
       const reasoningNode = createReasoningNode(mockLLM, [testTool], 'System prompt', 5, false);
 
       const initialState: ReActStateType = {
@@ -105,6 +116,50 @@ describe('ReAct Nodes', () => {
       const result = await reasoningNode(initialState);
 
       expect(result.shouldContinue).toBe(false);
+    });
+
+    it('should normalize tool messages and append scratchpad context', async () => {
+      const invoke = vi.fn().mockResolvedValue(new AIMessage('Final answer'));
+      const mockLLM = {
+        bindTools: vi.fn().mockReturnThis(),
+        invoke,
+      } as unknown as BaseChatModel;
+
+      const reasoningNode = createReasoningNode(mockLLM, [testTool], 'System prompt', 10, false);
+
+      await reasoningNode({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          {
+            role: 'tool',
+            content: 'Tool output',
+            name: 'test-tool',
+            tool_call_id: 'call_123',
+          },
+        ],
+        thoughts: [],
+        actions: [],
+        observations: [],
+        scratchpad: [
+          {
+            step: 1,
+            thought: 'Need more context',
+            action: 'test-tool({"input":"hello"})',
+            observation: 'Tool output',
+          },
+        ],
+        iteration: 0,
+        shouldContinue: true,
+        response: undefined,
+      });
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+
+      const [messages] = invoke.mock.calls[0] as [unknown[]];
+      expect(messages[2]).toBeInstanceOf(ToolMessage);
+      expect((messages[2] as ToolMessage).tool_call_id).toBe('call_123');
+      expect(messages[3]).toBeInstanceOf(SystemMessage);
+      expect(String((messages[3] as SystemMessage).content)).toContain('Previous steps');
     });
   });
 
@@ -312,6 +367,37 @@ describe('ReAct Nodes', () => {
       expect(result.scratchpad![0].observation).toContain('Error: Tool failed');
       expect(result.messages![0].content).toContain('Error: Tool failed');
     });
+
+    it('should stringify structured observations and preserve tool names', async () => {
+      const observationNode = createObservationNode(false, true);
+
+      const result = await observationNode({
+        messages: [],
+        thoughts: [{ content: 'Inspect the structured result' }],
+        actions: [
+          {
+            id: 'call_json',
+            name: 'test-tool',
+            arguments: { input: 'json' },
+            timestamp: Date.now(),
+          },
+        ],
+        observations: [
+          {
+            toolCallId: 'call_json',
+            result: { ok: true, count: 2 },
+            timestamp: Date.now(),
+          },
+        ],
+        scratchpad: [],
+        iteration: 1,
+        shouldContinue: true,
+        response: undefined,
+      });
+
+      expect(result.messages?.[0].name).toBe('test-tool');
+      expect(result.messages?.[0].content).toContain('"ok": true');
+      expect(result.scratchpad?.[0].observation).toContain('"count":2');
+    });
   });
 });
-

--- a/packages/patterns/tests/react/nodes.test.ts
+++ b/packages/patterns/tests/react/nodes.test.ts
@@ -432,5 +432,36 @@ describe('ReAct Nodes', () => {
       expect(result.messages?.[0].content).toContain('"ok": true');
       expect(result.scratchpad?.[0].observation).toContain('"count":2');
     });
+
+    it('should preserve undefined observation results as strings in messages and scratchpad', async () => {
+      const observationNode = createObservationNode(false, true);
+
+      const result = await observationNode({
+        messages: [],
+        thoughts: [{ content: 'Inspect missing tool output' }],
+        actions: [
+          {
+            id: 'call_undefined',
+            name: 'test-tool',
+            arguments: { input: 'undefined' },
+            timestamp: Date.now(),
+          },
+        ],
+        observations: [
+          {
+            toolCallId: 'call_undefined',
+            result: undefined,
+            timestamp: Date.now(),
+          },
+        ],
+        scratchpad: [],
+        iteration: 1,
+        shouldContinue: true,
+        response: undefined,
+      });
+
+      expect(result.messages?.[0].content).toBe('undefined');
+      expect(result.scratchpad?.[0].observation).toContain('undefined');
+    });
   });
 });

--- a/packages/patterns/tests/react/nodes.test.ts
+++ b/packages/patterns/tests/react/nodes.test.ts
@@ -161,6 +161,39 @@ describe('ReAct Nodes', () => {
       expect(messages[3]).toBeInstanceOf(SystemMessage);
       expect(String((messages[3] as SystemMessage).content)).toContain('Previous steps');
     });
+
+    it('should fall back to a human message when tool_call_id is missing', async () => {
+      const invoke = vi.fn().mockResolvedValue(new AIMessage('Final answer'));
+      const mockLLM = {
+        bindTools: vi.fn().mockReturnThis(),
+        invoke,
+      } as unknown as BaseChatModel;
+
+      const reasoningNode = createReasoningNode(mockLLM, [testTool], 'System prompt', 10, false);
+
+      await reasoningNode({
+        messages: [
+          {
+            role: 'tool',
+            content: 'Detached tool output',
+            name: 'test-tool',
+          },
+        ],
+        thoughts: [],
+        actions: [],
+        observations: [],
+        scratchpad: [],
+        iteration: 0,
+        shouldContinue: true,
+        response: undefined,
+      });
+
+      const [messages] = invoke.mock.calls[0] as [unknown[]];
+      expect(messages[1]).not.toBeInstanceOf(ToolMessage);
+      expect((messages[1] as AIMessage | SystemMessage | ToolMessage | { content: string }).content).toBe(
+        'Detached tool output'
+      );
+    });
   });
 
   describe('createActionNode', () => {

--- a/packages/patterns/tests/shared/agent-builder.test.ts
+++ b/packages/patterns/tests/shared/agent-builder.test.ts
@@ -30,6 +30,16 @@ const TestAgentState = createStateAnnotation({
 
 type TestAgentStateType = typeof TestAgentState.State;
 
+const validRouteMapping = {
+  continue: 'step',
+  end: END,
+} satisfies Partial<Record<TestAgentStateType['routeTo'], 'step' | typeof END>>;
+
+// @ts-expect-error invalid route keys should be rejected by ConditionalEdge.mapping
+const invalidRouteMapping = {
+  continnue: 'step',
+} satisfies Partial<Record<TestAgentStateType['routeTo'], 'step' | typeof END>>;
+
 describe('buildAgent', () => {
   it('should follow mapped conditional routes through the configured nodes', async () => {
     const agent = buildAgent({
@@ -62,13 +72,12 @@ describe('buildAgent', () => {
         {
           from: 'decide',
           condition: (state: TestAgentStateType) => state.routeTo,
-          mapping: {
-            continue: 'step',
-            end: END,
-          },
+          mapping: validRouteMapping,
         },
       ],
     });
+
+    expect(invalidRouteMapping).toBeDefined();
 
     const result = await agent.invoke({
       routeTo: 'continue',

--- a/packages/patterns/tests/shared/agent-builder.test.ts
+++ b/packages/patterns/tests/shared/agent-builder.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { END } from '@langchain/langgraph';
+import { createStateAnnotation, type StateChannelConfig } from '@agentforge/core';
+import { z } from 'zod';
+import { buildAgent } from '../../src/shared/agent-builder.js';
+
+const TestAgentState = createStateAnnotation({
+  routeTo: {
+    schema: z.enum(['continue', 'end']),
+    default: () => 'continue',
+    description: 'Desired route for the workflow',
+  } satisfies StateChannelConfig<'continue' | 'end'>,
+  history: {
+    schema: z.array(z.string()),
+    reducer: (left: string[], right: string[]) => [...left, ...right],
+    default: () => [],
+    description: 'Workflow execution history',
+  } satisfies StateChannelConfig<string[], string[]>,
+  count: {
+    schema: z.number().int().nonnegative(),
+    default: () => 0,
+    description: 'Counter incremented by the workflow',
+  } satisfies StateChannelConfig<number>,
+  done: {
+    schema: z.boolean(),
+    default: () => false,
+    description: 'Completion flag',
+  } satisfies StateChannelConfig<boolean>,
+});
+
+type TestAgentStateType = typeof TestAgentState.State;
+
+describe('buildAgent', () => {
+  it('should follow mapped conditional routes through the configured nodes', async () => {
+    const agent = buildAgent({
+      state: TestAgentState,
+      nodes: [
+        {
+          name: 'decide',
+          fn: (state: TestAgentStateType) => ({
+            history: [`decide:${state.routeTo}`],
+          }),
+        },
+        {
+          name: 'step',
+          fn: () => ({
+            history: ['step'],
+            count: 1,
+          }),
+        },
+        {
+          name: 'finish',
+          fn: () => ({
+            history: ['finish'],
+            done: true,
+          }),
+        },
+      ],
+      entryPoint: 'decide',
+      edges: [{ from: 'step', to: 'finish' }],
+      conditionalEdges: [
+        {
+          from: 'decide',
+          condition: (state: TestAgentStateType) => state.routeTo,
+          mapping: {
+            continue: 'step',
+            end: END,
+          },
+        },
+      ],
+    });
+
+    const result = await agent.invoke({
+      routeTo: 'continue',
+      history: [],
+      count: 0,
+      done: false,
+    });
+
+    expect(result.history).toEqual(['decide:continue', 'step', 'finish']);
+    expect(result.count).toBe(1);
+    expect(result.done).toBe(true);
+  });
+
+  it('should allow conditional routes to end the workflow directly', async () => {
+    const agent = buildAgent({
+      state: TestAgentState,
+      nodes: [
+        {
+          name: 'decide',
+          fn: (state: TestAgentStateType) => ({
+            history: [`decide:${state.routeTo}`],
+          }),
+        },
+        {
+          name: 'finish',
+          fn: () => ({
+            history: ['finish'],
+            done: true,
+          }),
+        },
+      ],
+      entryPoint: 'decide',
+      conditionalEdges: [
+        {
+          from: 'decide',
+          condition: (state: TestAgentStateType) => state.routeTo,
+          mapping: {
+            continue: 'finish',
+            end: END,
+          },
+        },
+      ],
+    });
+
+    const result = await agent.invoke({
+      routeTo: 'end',
+      history: [],
+      count: 0,
+      done: false,
+    });
+
+    expect(result.history).toEqual(['decide:end']);
+    expect(result.count).toBe(0);
+    expect(result.done).toBe(false);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -171,6 +171,7 @@
   - `119eec6` refactor(st-09005): harden react node and builder typing
   - `1a2353a` docs(st-09005): record react builder typing progress
   - `d608445` docs(st-09005): record validation and move story to in-review
+  - `f02d050` fix(st-09005): tighten builder schema and tool message validation
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #67 marked ready: https://github.com/TVScoundrel/agentforge/pull/67
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -174,6 +174,7 @@
   - `f02d050` fix(st-09005): tighten builder schema and tool message validation
   - `7b7d14f` chore(st-09005): append review-fix commit record
   - `5952ef7` fix(st-09005): restore verbose debug gating
+  - `bedc74a` fix(st-09005): tighten conditional route mapping types
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #67 marked ready: https://github.com/TVScoundrel/agentforge/pull/67
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -175,6 +175,7 @@
   - `7b7d14f` chore(st-09005): append review-fix commit record
   - `5952ef7` fix(st-09005): restore verbose debug gating
   - `bedc74a` fix(st-09005): tighten conditional route mapping types
+  - `2bb0250` fix(st-09005): normalize undefined observation results
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #67 marked ready: https://github.com/TVScoundrel/agentforge/pull/67
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -172,6 +172,8 @@
   - `1a2353a` docs(st-09005): record react builder typing progress
   - `d608445` docs(st-09005): record validation and move story to in-review
   - `f02d050` fix(st-09005): tighten builder schema and tool message validation
+  - `7b7d14f` chore(st-09005): append review-fix commit record
+  - `5952ef7` fix(st-09005): restore verbose debug gating
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #67 marked ready: https://github.com/TVScoundrel/agentforge/pull/67
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -150,14 +150,19 @@
 **Branch:** `fix/st-09005-patterns-react-builder-typing`
 
 ### Checklist
-- [ ] Create branch `fix/st-09005-patterns-react-builder-typing`
-- [ ] Create draft PR with story ID in title
-- [ ] Reduce explicit `any` usage in `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`
-- [ ] Extract focused helper(s) for message normalization/state access where it improves SRP and readability
-- [ ] Add/update focused tests for conditional routing and tool-message construction behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09005-patterns-react-builder-typing.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create branch `fix/st-09005-patterns-react-builder-typing`
+  - Created as `codex/fix/st-09005-patterns-react-builder-typing` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #67: https://github.com/TVScoundrel/agentforge/pull/67
+- [x] Reduce explicit `any` usage in `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`
+- [x] Extract focused helper(s) for message normalization/state access where it improves SRP and readability
+- [x] Add/update focused tests for conditional routing and tool-message construction behavior
+  - `pnpm test --run packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts` -> `13 passed`
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09005-patterns-react-builder-typing.md` (`nodes.ts 10 -> 0`, `agent-builder.ts 9 -> 0`, baseline `324 -> 305`)
+- [x] Add or update story documentation at `docs/st09005-patterns-react-builder-typing.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused coverage in `packages/patterns/tests/react/nodes.test.ts` and `packages/patterns/tests/shared/agent-builder.test.ts`
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -163,8 +163,10 @@
 - [x] Add or update story documentation at `docs/st09005-patterns-react-builder-typing.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Added focused coverage in `packages/patterns/tests/react/nodes.test.ts` and `packages/patterns/tests/shared/agent-builder.test.ts`
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `149 passed | 16 skipped` files; `2102 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -167,6 +167,10 @@
   - `pnpm test --run` -> `149 passed | 16 skipped` files; `2102 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `119eec6` refactor(st-09005): harden react node and builder typing
+  - `1a2353a` docs(st-09005): record react builder typing progress
+  - `d608445` docs(st-09005): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #67 marked ready: https://github.com/TVScoundrel/agentforge/pull/67
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -898,6 +898,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-08004
+**Status:** In Progress (PR #67, 2026-03-17)
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts` reduce explicit `any` in state/message/condition handling
@@ -928,4 +929,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged); ST-09005 ready in parallel
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (In Progress)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -898,7 +898,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-08004
-**Status:** In Progress (PR #67, 2026-03-17)
+**Status:** In Review (PR #67, 2026-03-17)
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts` reduce explicit `any` in state/message/condition handling
@@ -929,4 +929,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (In Progress)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (In Review)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-17
-**Active Story:** ST-09005 (In Progress)
+**Active Story:** ST-09005 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-17
-**Active Story:** ST-09005 (Ready)
+**Active Story:** ST-09005 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,17 +20,17 @@ _No stories currently ready_
 
 ## In Progress
 
-- **ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types** (EP-09, P2, 4h)
-  - Dependencies: ST-08004 (complete)
-  - Branch: `codex/fix/st-09005-patterns-react-builder-typing`
-  - PR #67 (Draft): https://github.com/TVScoundrel/agentforge/pull/67
-  - Scope: `packages/patterns/src/react/nodes.ts` + `packages/patterns/src/shared/agent-builder.ts`
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- **ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types** (EP-09, P2, 4h)
+  - Dependencies: ST-08004 (complete)
+  - Branch: `codex/fix/st-09005-patterns-react-builder-typing`
+  - PR #67: https://github.com/TVScoundrel/agentforge/pull/67
+  - Scope: `packages/patterns/src/react/nodes.ts` + `packages/patterns/src/shared/agent-builder.ts`
 
 ---
 
@@ -95,4 +95,4 @@ _No stories currently in backlog_
 - ✅ ST-09002 complete - LangChain converter boundary hardened (merged 2026-03-13)
 - ✅ ST-09003 complete - LangGraph state utility typing strengthened (merged 2026-03-13)
 - ✅ ST-09004 complete - observability payload contracts hardened (merged 2026-03-17)
-- ST-09005 is in progress on PR #67
+- ST-09005 is in review on PR #67

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,15 +14,17 @@
 
 ## Ready
 
-- **ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types** (EP-09, P2, 4h)
-  - Dependencies: ST-08004 (complete)
-  - Scope: `packages/patterns/src/react/nodes.ts` + `packages/patterns/src/shared/agent-builder.ts`
+_No stories currently ready_
 
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- **ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types** (EP-09, P2, 4h)
+  - Dependencies: ST-08004 (complete)
+  - Branch: `codex/fix/st-09005-patterns-react-builder-typing`
+  - PR #67 (Draft): https://github.com/TVScoundrel/agentforge/pull/67
+  - Scope: `packages/patterns/src/react/nodes.ts` + `packages/patterns/src/shared/agent-builder.ts`
 
 ---
 
@@ -93,4 +95,4 @@ _No stories currently in backlog_
 - ✅ ST-09002 complete - LangChain converter boundary hardened (merged 2026-03-13)
 - ✅ ST-09003 complete - LangGraph state utility typing strengthened (merged 2026-03-13)
 - ✅ ST-09004 complete - observability payload contracts hardened (merged 2026-03-17)
-- ST-09005 remains Ready
+- ST-09005 is in progress on PR #67


### PR DESCRIPTION
## Story
- ST-09005: Harden Patterns ReAct Node and Shared Agent Builder Types

## What Changed
- Replaced broad `any`-driven state/message casts in `packages/patterns/src/react/nodes.ts` with focused helpers for conversation normalization, tool-call extraction, observation formatting, and scratchpad summaries.
- Reworked `packages/patterns/src/shared/agent-builder.ts` around config-derived state, update, route, and node-name generics instead of `any`-typed node and condition contracts.
- Added focused coverage for ReAct tool-message construction and shared-builder conditional routing in `packages/patterns/tests/react/nodes.test.ts` and `packages/patterns/tests/shared/agent-builder.test.ts`.
- Recorded the warning delta and compatibility notes in `docs/st09005-patterns-react-builder-typing.md`.

## Acceptance Criteria Coverage
- Reduced explicit `any` usage in `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts` to `0` warnings each.
- Extracted focused helpers for message normalization, observation formatting, and scratchpad summary generation to simplify the ReAct node flow.
- Preserved runtime behavior for ReAct loops and shared builder routing while tightening exported typing boundaries.
- Added focused tests for conditional routing, tool-message construction, and structured observation formatting.
- Recorded warning deltas in the story doc, including the overall baseline improvement from `324` to `305`.

## Validation Performed
- `pnpm exec eslint packages/patterns/src/react/nodes.ts packages/patterns/src/shared/agent-builder.ts packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts`
- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
- `pnpm test --run packages/patterns/tests/react/nodes.test.ts packages/patterns/tests/shared/agent-builder.test.ts` -> `13 passed`
- `pnpm lint:explicit-any:baseline` -> overall `324 -> 305`, `patterns 50 -> 31`
- `pnpm test --run` -> `149 passed | 16 skipped` files; `2102 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status
- Ready for review
