### PR TITLE
ST-09008: Harden Parallel Workflow Builder Typing

### DIFF
--- a/docs/st09008-parallel-workflow-builder-typing.md
+++ b/docs/st09008-parallel-workflow-builder-typing.md
@@ -10,7 +10,7 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 |------|--------|
 | `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics, derived node state directly from the schema, and tightened parallel/aggregate node update contracts without a permissive index signature |
 | `packages/core/src/langgraph/builders/parallel.ts` | Removed `@ts-expect-error` node registration and `as any` edge wiring, using direct `START`/`END` edges and a localized `addNode()` interop cast instead |
-| `packages/core/src/langgraph/builders/parallel.ts` | Removed the unused `ParallelWorkflowOptions.name` field so the options surface matches actual builder behavior |
+| `packages/core/src/langgraph/builders/parallel.ts` | Kept `ParallelWorkflowOptions.name` as a deprecated compatibility-only no-op so the public API does not type-break before a major release |
 | `packages/core/tests/langgraph/builders/parallel.test.ts` | Added direct edge assertions for fan-out/fan-in wiring and `autoStartEnd: false`, while preserving duplicate-name and aggregate execution coverage |
 
 ## Explicit `any` Warning Delta
@@ -31,6 +31,7 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 - Parallel fan-out/fan-in runtime behavior is unchanged for both direct parallel execution and optional aggregation nodes.
 - `autoStartEnd` continues to control whether `START`/`END` edges are added automatically; the new tests now assert that wiring directly.
 - LangGraph still requires a widened node-action shape internally. That interop is now isolated to the `addNode()` call site instead of leaking into the exported builder API.
+- `ParallelWorkflowOptions.name` remains accepted for backward compatibility, but it is still a no-op and documented as deprecated for a future major release.
 
 ## Validation
 

--- a/docs/st09008-parallel-workflow-builder-typing.md
+++ b/docs/st09008-parallel-workflow-builder-typing.md
@@ -8,7 +8,7 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 
 | File | Change |
 |------|--------|
-| `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics, derived node state directly from the schema, and tightened parallel/aggregate node update contracts |
+| `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics, derived node state directly from the schema, and tightened parallel/aggregate node update contracts without a permissive index signature |
 | `packages/core/src/langgraph/builders/parallel.ts` | Removed `@ts-expect-error` node registration and `as any` edge wiring, using direct `START`/`END` edges and a localized `addNode()` interop cast instead |
 | `packages/core/src/langgraph/builders/parallel.ts` | Removed the unused `ParallelWorkflowOptions.name` field so the options surface matches actual builder behavior |
 | `packages/core/tests/langgraph/builders/parallel.test.ts` | Added direct edge assertions for fan-out/fan-in wiring and `autoStartEnd: false`, while preserving duplicate-name and aggregate execution coverage |
@@ -17,7 +17,7 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 
 ### Story scope hotspot
 
-- `packages/core/src/langgraph/builders/parallel.ts`: `11 -> 0` (`-11`)
+- `packages/core/src/langgraph/builders/parallel.ts`: `9 -> 0` (`-9`)
 
 ### Baseline gate snapshot
 

--- a/docs/st09008-parallel-workflow-builder-typing.md
+++ b/docs/st09008-parallel-workflow-builder-typing.md
@@ -8,8 +8,9 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 
 | File | Change |
 |------|--------|
-| `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics and tightened parallel/aggregate node update contracts |
+| `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics, derived node state directly from the schema, and tightened parallel/aggregate node update contracts |
 | `packages/core/src/langgraph/builders/parallel.ts` | Removed `@ts-expect-error` node registration and `as any` edge wiring, using direct `START`/`END` edges and a localized `addNode()` interop cast instead |
+| `packages/core/src/langgraph/builders/parallel.ts` | Removed the unused `ParallelWorkflowOptions.name` field so the options surface matches actual builder behavior |
 | `packages/core/tests/langgraph/builders/parallel.test.ts` | Added direct edge assertions for fan-out/fan-in wiring and `autoStartEnd: false`, while preserving duplicate-name and aggregate execution coverage |
 
 ## Explicit `any` Warning Delta

--- a/docs/st09008-parallel-workflow-builder-typing.md
+++ b/docs/st09008-parallel-workflow-builder-typing.md
@@ -37,6 +37,8 @@ Refined the parallel workflow builder to use LangGraph annotation types at the p
 - `pnpm exec eslint packages/core/src/langgraph/builders/parallel.ts packages/core/tests/langgraph/builders/parallel.test.ts`
 - `pnpm test --run packages/core/tests/langgraph/builders/parallel.test.ts` -> `8 passed`
 - `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `150 passed | 16 skipped` files; `2110 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
 
 ## Test Impact
 

--- a/docs/st09008-parallel-workflow-builder-typing.md
+++ b/docs/st09008-parallel-workflow-builder-typing.md
@@ -1,0 +1,43 @@
+# ST-09008: Harden Parallel Workflow Builder Typing
+
+## Summary
+
+Refined the parallel workflow builder to use LangGraph annotation types at the public boundary, remove avoidable `any` and `@ts-expect-error` usage, and keep the unavoidable LangGraph node-registration interop localized to a single typed seam.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/langgraph/builders/parallel.ts` | Replaced `any`-typed state schema input with `AnnotationRoot`/`StateDefinition`-driven generics and tightened parallel/aggregate node update contracts |
+| `packages/core/src/langgraph/builders/parallel.ts` | Removed `@ts-expect-error` node registration and `as any` edge wiring, using direct `START`/`END` edges and a localized `addNode()` interop cast instead |
+| `packages/core/tests/langgraph/builders/parallel.test.ts` | Added direct edge assertions for fan-out/fan-in wiring and `autoStartEnd: false`, while preserving duplicate-name and aggregate execution coverage |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/langgraph/builders/parallel.ts`: `11 -> 0` (`-11`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `304 -> 295` (`-9`)
+- `core` package: `128 -> 119` (`-9`)
+
+(After snapshot captured with `pnpm lint:explicit-any:baseline` on 2026-03-22.)
+
+## Compatibility Notes
+
+- Parallel fan-out/fan-in runtime behavior is unchanged for both direct parallel execution and optional aggregation nodes.
+- `autoStartEnd` continues to control whether `START`/`END` edges are added automatically; the new tests now assert that wiring directly.
+- LangGraph still requires a widened node-action shape internally. That interop is now isolated to the `addNode()` call site instead of leaking into the exported builder API.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/langgraph/builders/parallel.ts packages/core/tests/langgraph/builders/parallel.test.ts`
+- `pnpm test --run packages/core/tests/langgraph/builders/parallel.test.ts` -> `8 passed`
+- `pnpm lint:explicit-any:baseline`
+
+## Test Impact
+
+Expanded focused automated coverage for duplicate-node validation, aggregate fan-in wiring, and `autoStartEnd` edge behavior.

--- a/packages/core/examples/phase-2.2-demo.ts
+++ b/packages/core/examples/phase-2.2-demo.ts
@@ -72,7 +72,7 @@ console.log('Result:', sequentialResult);
 // Example 2: Parallel Workflow
 console.log('\n=== Example 2: Parallel Workflow ===\n');
 
-const parallelWorkflow = createParallelWorkflow<State>(AgentState, {
+const parallelWorkflow = createParallelWorkflow(AgentState, {
   parallel: [
     {
       name: 'fetch_news',
@@ -161,4 +161,3 @@ const result = await timedNode({ messages: [], data: {}, errors: [] });
 console.log('Result:', result);
 
 console.log('\n=== All examples completed! ===\n');
-

--- a/packages/core/src/langgraph/builders/parallel.ts
+++ b/packages/core/src/langgraph/builders/parallel.ts
@@ -62,6 +62,13 @@ export interface ParallelWorkflowOptions {
    * @default true
    */
   autoStartEnd?: boolean;
+
+  /**
+   * Compatibility-only no-op retained to avoid a public type break.
+   *
+   * @deprecated This option is currently unused and will be removed in a future major release.
+   */
+  name?: string;
 }
 
 /**

--- a/packages/core/src/langgraph/builders/parallel.ts
+++ b/packages/core/src/langgraph/builders/parallel.ts
@@ -11,12 +11,12 @@ import { StateGraph, END, START } from '@langchain/langgraph';
 import type { AnnotationRoot, StateDefinition, UpdateType } from '@langchain/langgraph';
 
 type ParallelWorkflowState<SD extends StateDefinition> = AnnotationRoot<SD>['State'];
-type ParallelNodeResult<State> = Partial<State> & Record<string, unknown>;
+type ParallelNodeResult<State> = Partial<State>;
 
 /**
  * Configuration for a parallel node
  */
-export interface ParallelNode<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
+export interface ParallelNode<State, Update = ParallelNodeResult<State>> {
   /**
    * Unique name for the node
    */
@@ -36,7 +36,7 @@ export interface ParallelNode<State, Update extends Record<string, unknown> = Pa
 /**
  * Configuration for an aggregation node that combines parallel results
  */
-export interface AggregateNode<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
+export interface AggregateNode<State, Update = ParallelNodeResult<State>> {
   /**
    * Name for the aggregation node
    */
@@ -67,7 +67,7 @@ export interface ParallelWorkflowOptions {
 /**
  * Configuration for a parallel workflow
  */
-export interface ParallelWorkflowConfig<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
+export interface ParallelWorkflowConfig<State, Update = ParallelNodeResult<State>> {
   /**
    * Nodes that execute in parallel
    */
@@ -108,7 +108,7 @@ export interface ParallelWorkflowConfig<State, Update extends Record<string, unk
  */
 export function createParallelWorkflow<
   SD extends StateDefinition = StateDefinition,
-  Update extends Record<string, unknown> = UpdateType<SD> & Record<string, unknown>
+  Update extends UpdateType<SD> = UpdateType<SD>
 >(
   stateSchema: AnnotationRoot<SD>,
   config: ParallelWorkflowConfig<ParallelWorkflowState<SD>, Update>,

--- a/packages/core/src/langgraph/builders/parallel.ts
+++ b/packages/core/src/langgraph/builders/parallel.ts
@@ -8,12 +8,14 @@
  */
 
 import { StateGraph, END, START } from '@langchain/langgraph';
-import type { StateGraphArgs } from '@langchain/langgraph';
+import type { AnnotationRoot, StateDefinition, UpdateType } from '@langchain/langgraph';
+
+type ParallelNodeResult<State> = Partial<State> & Record<string, unknown>;
 
 /**
  * Configuration for a parallel node
  */
-export interface ParallelNode<State> {
+export interface ParallelNode<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
   /**
    * Unique name for the node
    */
@@ -22,7 +24,7 @@ export interface ParallelNode<State> {
   /**
    * The node function that processes the state
    */
-  node: (state: State) => State | Promise<State> | Partial<State> | Promise<Partial<State>>;
+  node: (state: State) => Update | Promise<Update>;
 
   /**
    * Optional description of what this node does
@@ -33,7 +35,7 @@ export interface ParallelNode<State> {
 /**
  * Configuration for an aggregation node that combines parallel results
  */
-export interface AggregateNode<State> {
+export interface AggregateNode<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
   /**
    * Name for the aggregation node
    */
@@ -42,7 +44,7 @@ export interface AggregateNode<State> {
   /**
    * The aggregation function that combines results from parallel nodes
    */
-  node: (state: State) => State | Promise<State> | Partial<State> | Promise<Partial<State>>;
+  node: (state: State) => Update | Promise<Update>;
 
   /**
    * Optional description
@@ -69,16 +71,16 @@ export interface ParallelWorkflowOptions {
 /**
  * Configuration for a parallel workflow
  */
-export interface ParallelWorkflowConfig<State> {
+export interface ParallelWorkflowConfig<State, Update extends Record<string, unknown> = ParallelNodeResult<State>> {
   /**
    * Nodes that execute in parallel
    */
-  parallel: ParallelNode<State>[];
+  parallel: ParallelNode<State, Update>[];
 
   /**
    * Optional aggregation node that runs after all parallel nodes complete
    */
-  aggregate?: AggregateNode<State>;
+  aggregate?: AggregateNode<State, Update>;
 }
 
 /**
@@ -108,13 +110,17 @@ export interface ParallelWorkflowConfig<State> {
  * @param options - Optional configuration
  * @returns A configured StateGraph ready to compile
  */
-export function createParallelWorkflow<State>(
-  stateSchema: any,
-  config: ParallelWorkflowConfig<State>,
+export function createParallelWorkflow<
+  State,
+  SD extends StateDefinition = StateDefinition,
+  Update extends Record<string, unknown> = UpdateType<SD> & Record<string, unknown>
+>(
+  stateSchema: AnnotationRoot<SD>,
+  config: ParallelWorkflowConfig<State, Update>,
   options: ParallelWorkflowOptions = {}
-): StateGraph<State> {
+): StateGraph<AnnotationRoot<SD>, State, Update, string> {
   const { parallel, aggregate } = config;
-  const { autoStartEnd = true, name } = options;
+  const { autoStartEnd = true } = options;
 
   if (parallel.length === 0) {
     throw new Error('Parallel workflow must have at least one parallel node');
@@ -134,24 +140,25 @@ export function createParallelWorkflow<State>(
   }
 
   // Create the graph
-  const graph = new StateGraph<State>(stateSchema);
+  const graph = new StateGraph<AnnotationRoot<SD>, State, Update, string>(stateSchema);
+  type GraphNodeAction = Parameters<typeof graph.addNode>[1];
 
   // Add all parallel nodes
   for (const { name: nodeName, node } of parallel) {
-    // @ts-expect-error - LangGraph's complex generic types don't infer well here
-    graph.addNode(nodeName, node);
+    // LangGraph's addNode() overloads widen update objects internally. Keep that
+    // interop localized here rather than weakening the public workflow types.
+    graph.addNode(nodeName, node as unknown as GraphNodeAction);
   }
 
   // Add aggregation node if provided
   if (aggregate) {
-    // @ts-expect-error - LangGraph's complex generic types don't infer well here
-    graph.addNode(aggregate.name, aggregate.node);
+    graph.addNode(aggregate.name, aggregate.node as unknown as GraphNodeAction);
   }
 
   // Connect START to all parallel nodes (fan-out)
   if (autoStartEnd) {
     for (const { name: nodeName } of parallel) {
-      graph.addEdge(START as any, nodeName as any);
+      graph.addEdge(START, nodeName);
     }
   }
 
@@ -159,20 +166,19 @@ export function createParallelWorkflow<State>(
   if (aggregate) {
     // All parallel nodes connect to aggregation
     for (const { name: nodeName } of parallel) {
-      graph.addEdge(nodeName as any, aggregate.name as any);
+      graph.addEdge(nodeName, aggregate.name);
     }
 
     // Aggregation connects to END
     if (autoStartEnd) {
-      graph.addEdge(aggregate.name as any, END as any);
+      graph.addEdge(aggregate.name, END);
     }
   } else if (autoStartEnd) {
     // No aggregation, connect all parallel nodes to END
     for (const { name: nodeName } of parallel) {
-      graph.addEdge(nodeName as any, END as any);
+      graph.addEdge(nodeName, END);
     }
   }
 
   return graph;
 }
-

--- a/packages/core/src/langgraph/builders/parallel.ts
+++ b/packages/core/src/langgraph/builders/parallel.ts
@@ -10,6 +10,7 @@
 import { StateGraph, END, START } from '@langchain/langgraph';
 import type { AnnotationRoot, StateDefinition, UpdateType } from '@langchain/langgraph';
 
+type ParallelWorkflowState<SD extends StateDefinition> = AnnotationRoot<SD>['State'];
 type ParallelNodeResult<State> = Partial<State> & Record<string, unknown>;
 
 /**
@@ -61,11 +62,6 @@ export interface ParallelWorkflowOptions {
    * @default true
    */
   autoStartEnd?: boolean;
-
-  /**
-   * Custom name for the workflow (for debugging)
-   */
-  name?: string;
 }
 
 /**
@@ -111,14 +107,13 @@ export interface ParallelWorkflowConfig<State, Update extends Record<string, unk
  * @returns A configured StateGraph ready to compile
  */
 export function createParallelWorkflow<
-  State,
   SD extends StateDefinition = StateDefinition,
   Update extends Record<string, unknown> = UpdateType<SD> & Record<string, unknown>
 >(
   stateSchema: AnnotationRoot<SD>,
-  config: ParallelWorkflowConfig<State, Update>,
+  config: ParallelWorkflowConfig<ParallelWorkflowState<SD>, Update>,
   options: ParallelWorkflowOptions = {}
-): StateGraph<AnnotationRoot<SD>, State, Update, string> {
+): StateGraph<AnnotationRoot<SD>, ParallelWorkflowState<SD>, Update, string> {
   const { parallel, aggregate } = config;
   const { autoStartEnd = true } = options;
 
@@ -140,7 +135,7 @@ export function createParallelWorkflow<
   }
 
   // Create the graph
-  const graph = new StateGraph<AnnotationRoot<SD>, State, Update, string>(stateSchema);
+  const graph = new StateGraph<AnnotationRoot<SD>, ParallelWorkflowState<SD>, Update, string>(stateSchema);
   type GraphNodeAction = Parameters<typeof graph.addNode>[1];
 
   // Add all parallel nodes

--- a/packages/core/tests/langgraph/builders/parallel.test.ts
+++ b/packages/core/tests/langgraph/builders/parallel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Annotation } from '@langchain/langgraph';
+import { Annotation, END, START } from '@langchain/langgraph';
 import { createParallelWorkflow } from '../../../src/langgraph/builders/parallel';
 
 describe('Parallel Workflow Builder', () => {
@@ -23,21 +23,21 @@ describe('Parallel Workflow Builder', () => {
         parallel: [
           {
             name: 'task1',
-            node: async (state) => {
+            node: async (_state) => {
               await new Promise((resolve) => setTimeout(resolve, 10));
               return { results: ['task1'], count: 1 };
             },
           },
           {
             name: 'task2',
-            node: async (state) => {
+            node: async (_state) => {
               await new Promise((resolve) => setTimeout(resolve, 10));
               return { results: ['task2'], count: 1 };
             },
           },
           {
             name: 'task3',
-            node: async (state) => {
+            node: async (_state) => {
               await new Promise((resolve) => setTimeout(resolve, 10));
               return { results: ['task3'], count: 1 };
             },
@@ -64,16 +64,16 @@ describe('Parallel Workflow Builder', () => {
         parallel: [
           {
             name: 'fetch1',
-            node: (state) => ({ results: ['data1'], count: 1 }),
+            node: (_state) => ({ results: ['data1'], count: 1 }),
           },
           {
             name: 'fetch2',
-            node: (state) => ({ results: ['data2'], count: 1 }),
+            node: (_state) => ({ results: ['data2'], count: 1 }),
           },
         ],
         aggregate: {
           name: 'combine',
-          node: (state) => ({
+          node: (_state) => ({
             results: ['combined'],
             count: 1,
           }),
@@ -127,32 +127,63 @@ describe('Parallel Workflow Builder', () => {
       }).toThrow('Duplicate node name: task1');
     });
 
-    it('should work without autoStartEnd', async () => {
+    it('should wire fan-out and fan-in edges when autoStartEnd is enabled', () => {
+      const workflow = createParallelWorkflow<State>(TestState, {
+        parallel: [
+          {
+            name: 'task1',
+            node: (_state) => ({ results: ['task1'], count: 1 }),
+          },
+          {
+            name: 'task2',
+            node: (_state) => ({ results: ['task2'], count: 1 }),
+          },
+        ],
+        aggregate: {
+          name: 'combine',
+          node: (_state) => ({ results: ['combined'], count: 1 }),
+        },
+      });
+
+      expect(workflow.edges).toEqual(
+        new Set([
+          [START, 'task1'],
+          [START, 'task2'],
+          ['task1', 'combine'],
+          ['task2', 'combine'],
+          ['combine', END],
+        ])
+      );
+    });
+
+    it('should omit START and END edges when autoStartEnd is disabled', () => {
       const workflow = createParallelWorkflow<State>(
         TestState,
         {
           parallel: [
             {
               name: 'task1',
-              node: (state) => ({ results: ['task1'], count: 1 }),
+              node: (_state) => ({ results: ['task1'], count: 1 }),
             },
             {
               name: 'task2',
-              node: (state) => ({ results: ['task2'], count: 1 }),
+              node: (_state) => ({ results: ['task2'], count: 1 }),
             },
           ],
+          aggregate: {
+            name: 'combine',
+            node: (_state) => ({ results: ['combined'], count: 1 }),
+          },
         },
-        { autoStartEnd: true }
+        { autoStartEnd: false }
       );
 
-      const app = workflow.compile();
-      const result = await app.invoke({
-        results: [],
-        count: 0,
-      });
-
-      expect(result.results).toHaveLength(2);
-      expect(result.count).toBe(2);
+      expect(workflow.edges).toEqual(
+        new Set([
+          ['task1', 'combine'],
+          ['task2', 'combine'],
+        ])
+      );
     });
 
     it('should handle parallel nodes with different execution times', async () => {
@@ -160,14 +191,14 @@ describe('Parallel Workflow Builder', () => {
         parallel: [
           {
             name: 'fast',
-            node: async (state) => {
+            node: async (_state) => {
               await new Promise((resolve) => setTimeout(resolve, 5));
               return { results: ['fast'], count: 1 };
             },
           },
           {
             name: 'slow',
-            node: async (state) => {
+            node: async (_state) => {
               await new Promise((resolve) => setTimeout(resolve, 50));
               return { results: ['slow'], count: 1 };
             },
@@ -190,4 +221,3 @@ describe('Parallel Workflow Builder', () => {
     });
   });
 });
-

--- a/packages/core/tests/langgraph/builders/parallel.test.ts
+++ b/packages/core/tests/langgraph/builders/parallel.test.ts
@@ -14,12 +14,9 @@ describe('Parallel Workflow Builder', () => {
       default: () => 0,
     }),
   });
-
-  type State = typeof TestState.State;
-
   describe('createParallelWorkflow', () => {
     it('should execute multiple nodes in parallel', async () => {
-      const workflow = createParallelWorkflow<State>(TestState, {
+      const workflow = createParallelWorkflow(TestState, {
         parallel: [
           {
             name: 'task1',
@@ -60,7 +57,7 @@ describe('Parallel Workflow Builder', () => {
     });
 
     it('should support aggregation node after parallel execution', async () => {
-      const workflow = createParallelWorkflow<State>(TestState, {
+      const workflow = createParallelWorkflow(TestState, {
         parallel: [
           {
             name: 'fetch1',
@@ -95,7 +92,7 @@ describe('Parallel Workflow Builder', () => {
 
     it('should throw error for empty parallel node list', () => {
       expect(() => {
-        createParallelWorkflow<State>(TestState, {
+        createParallelWorkflow(TestState, {
           parallel: [],
         });
       }).toThrow('Parallel workflow must have at least one parallel node');
@@ -103,7 +100,7 @@ describe('Parallel Workflow Builder', () => {
 
     it('should throw error for duplicate node names in parallel nodes', () => {
       expect(() => {
-        createParallelWorkflow<State>(TestState, {
+        createParallelWorkflow(TestState, {
           parallel: [
             { name: 'duplicate', node: (state) => state },
             { name: 'duplicate', node: (state) => state },
@@ -114,7 +111,7 @@ describe('Parallel Workflow Builder', () => {
 
     it('should throw error if aggregate node name conflicts with parallel node', () => {
       expect(() => {
-        createParallelWorkflow<State>(TestState, {
+        createParallelWorkflow(TestState, {
           parallel: [
             { name: 'task1', node: (state) => state },
             { name: 'task2', node: (state) => state },
@@ -128,7 +125,7 @@ describe('Parallel Workflow Builder', () => {
     });
 
     it('should wire fan-out and fan-in edges when autoStartEnd is enabled', () => {
-      const workflow = createParallelWorkflow<State>(TestState, {
+      const workflow = createParallelWorkflow(TestState, {
         parallel: [
           {
             name: 'task1',
@@ -157,7 +154,7 @@ describe('Parallel Workflow Builder', () => {
     });
 
     it('should omit START and END edges when autoStartEnd is disabled', () => {
-      const workflow = createParallelWorkflow<State>(
+      const workflow = createParallelWorkflow(
         TestState,
         {
           parallel: [
@@ -187,7 +184,7 @@ describe('Parallel Workflow Builder', () => {
     });
 
     it('should handle parallel nodes with different execution times', async () => {
-      const workflow = createParallelWorkflow<State>(TestState, {
+      const workflow = createParallelWorkflow(TestState, {
         parallel: [
           {
             name: 'fast',

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -290,6 +290,7 @@
   - `cb664a3` refactor(st-09008): harden parallel workflow builder typing
   - `ff6ea5e` docs(st-09008): record parallel builder typing progress
   - `2fa17b8` docs(st-09008): record validation and move story to in-review
+  - `d4b2b18` fix(st-09008): derive parallel workflow state from schema
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #70 marked ready: https://github.com/TVScoundrel/agentforge/pull/70
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -286,8 +286,12 @@
   - `pnpm test --run` -> `150 passed | 16 skipped` files; `2110 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `cb664a3` refactor(st-09008): harden parallel workflow builder typing
+  - `ff6ea5e` docs(st-09008): record parallel builder typing progress
+  - `2fa17b8` docs(st-09008): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #70 marked ready: https://github.com/TVScoundrel/agentforge/pull/70
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -267,14 +267,21 @@
 **Branch:** `fix/st-09008-parallel-workflow-builder-typing`
 
 ### Checklist
-- [ ] Create branch `fix/st-09008-parallel-workflow-builder-typing`
-- [ ] Create draft PR with story ID in title
-- [ ] Remove avoidable `any` and `@ts-expect-error` usage from `packages/core/src/langgraph/builders/parallel.ts`
-- [ ] Preserve current fan-out/fan-in runtime behavior while tightening state schema, node registration, and edge wiring contracts
-- [ ] Add/update focused tests for duplicate-node validation, auto start/end wiring, and aggregate fan-in behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09008-parallel-workflow-builder-typing.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create branch `fix/st-09008-parallel-workflow-builder-typing`
+  - Created as `codex/fix/st-09008-parallel-workflow-builder-typing` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - Draft PR #70: https://github.com/TVScoundrel/agentforge/pull/70
+- [x] Remove avoidable `any` and `@ts-expect-error` usage from `packages/core/src/langgraph/builders/parallel.ts`
+  - Replaced `any` schema input with `AnnotationRoot`/`StateDefinition` generics and removed `@ts-expect-error`/`as any` edge wiring
+- [x] Preserve current fan-out/fan-in runtime behavior while tightening state schema, node registration, and edge wiring contracts
+  - Verified via focused typecheck/tests plus direct edge assertions for parallel fan-out, aggregate fan-in, and `autoStartEnd: false`
+- [x] Add/update focused tests for duplicate-node validation, auto start/end wiring, and aggregate fan-in behavior
+  - Updated `packages/core/tests/langgraph/builders/parallel.test.ts` to cover direct edge wiring and aggregate fan-in contracts
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - `packages/core/src/langgraph/builders/parallel.ts`: `11 -> 0`; baseline `304 -> 295`, `core 128 -> 119`
+- [x] Add or update story documentation at `docs/st09008-parallel-workflow-builder-typing.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Focused test coverage updated in `packages/core/tests/langgraph/builders/parallel.test.ts`
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -292,6 +292,7 @@
   - `2fa17b8` docs(st-09008): record validation and move story to in-review
   - `d4b2b18` fix(st-09008): derive parallel workflow state from schema
   - `182f525` fix(st-09008): tighten parallel update contracts
+  - `65a9c50` fix(st-09008): restore deprecated parallel name option
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #70 marked ready: https://github.com/TVScoundrel/agentforge/pull/70
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -282,8 +282,10 @@
 - [x] Add or update story documentation at `docs/st09008-parallel-workflow-builder-typing.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Focused test coverage updated in `packages/core/tests/langgraph/builders/parallel.test.ts`
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `150 passed | 16 skipped` files; `2110 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -291,6 +291,7 @@
   - `ff6ea5e` docs(st-09008): record parallel builder typing progress
   - `2fa17b8` docs(st-09008): record validation and move story to in-review
   - `d4b2b18` fix(st-09008): derive parallel workflow state from schema
+  - `182f525` fix(st-09008): tighten parallel update contracts
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #70 marked ready: https://github.com/TVScoundrel/agentforge/pull/70
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -264,7 +264,7 @@
 
 ## ST-09008: Harden Parallel Workflow Builder Typing
 
-**Branch:** `fix/st-09008-parallel-workflow-builder-typing`
+**Branch:** `codex/fix/st-09008-parallel-workflow-builder-typing`
 
 ### Checklist
 - [x] Create branch `fix/st-09008-parallel-workflow-builder-typing`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -278,7 +278,7 @@
 - [x] Add/update focused tests for duplicate-node validation, auto start/end wiring, and aggregate fan-in behavior
   - Updated `packages/core/tests/langgraph/builders/parallel.test.ts` to cover direct edge wiring and aggregate fan-in contracts
 - [x] Record explicit-`any` warning deltas for touched files in story docs
-  - `packages/core/src/langgraph/builders/parallel.ts`: `11 -> 0`; baseline `304 -> 295`, `core 128 -> 119`
+  - `packages/core/src/langgraph/builders/parallel.ts`: `9 -> 0`; baseline `304 -> 295`, `core 128 -> 119`
 - [x] Add or update story documentation at `docs/st09008-parallel-workflow-builder-typing.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Focused test coverage updated in `packages/core/tests/langgraph/builders/parallel.test.ts`

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -953,7 +953,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09007
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langgraph/builders/parallel.ts` removes avoidable `any` and `@ts-expect-error` usage around state schema, node registration, and edge wiring

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -953,7 +953,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09007
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langgraph/builders/parallel.ts` removes avoidable `any` and `@ts-expect-error` usage around state schema, node registration, and edge wiring

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-22
-**Active Story:** ST-09008 (Ready)
+**Active Story:** ST-09008 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -50,7 +50,7 @@ Recent improvement snapshot:
 - `ST-09003` removed `13` explicit-`any` warnings from `packages/core/src/langgraph/state.ts` and improved the `core` baseline from `161` to `148`.
 - `ST-09004` removed `20` explicit-`any` warnings from `packages/core/src/langgraph/observability/logger.ts` and `packages/core/src/monitoring/alerts.ts`, improving the `core` baseline from `148` to `128`.
 - `ST-09005` removed `19` explicit-`any` warnings from `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`, improving the workspace baseline from `324` to `305` and the `patterns` baseline from `50` to `31`.
-- `ST-09008` removed `9` explicit-`any` warnings from `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
+- `ST-09008` reduced explicit-`any` warnings in `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
 - The current baseline check now reports `295` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-22
-**Active Story:** ST-09008 (In Progress)
+**Active Story:** ST-09008 (In Review)
 
 ---
 
@@ -34,16 +34,15 @@
 
 Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-22):
 
-- Total: `304` warnings (`src/**`)
-- By package: `core 128`, `tools 70`, `testing 51`, `patterns 31`, `cli 24`
+- Total: `295` warnings (`src/**`)
+- By package: `core 119`, `tools 70`, `testing 51`, `patterns 31`, `cli 24`
 
 Top runtime hotspots informing this feature slice:
 
-1. `packages/core/src/langgraph/builders/parallel.ts` (9)
-2. `packages/tools/src/agent/ask-human/tool.ts` (8)
-3. `packages/patterns/src/plan-execute/agent.ts` (4)
-4. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `304`
-5. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
+1. `packages/tools/src/agent/ask-human/tool.ts` (8)
+2. `packages/patterns/src/plan-execute/agent.ts` (4)
+3. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `295`
+4. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
 
 Recent improvement snapshot:
 
@@ -51,7 +50,8 @@ Recent improvement snapshot:
 - `ST-09003` removed `13` explicit-`any` warnings from `packages/core/src/langgraph/state.ts` and improved the `core` baseline from `161` to `148`.
 - `ST-09004` removed `20` explicit-`any` warnings from `packages/core/src/langgraph/observability/logger.ts` and `packages/core/src/monitoring/alerts.ts`, improving the `core` baseline from `148` to `128`.
 - `ST-09005` removed `19` explicit-`any` warnings from `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`, improving the workspace baseline from `324` to `305` and the `patterns` baseline from `50` to `31`.
-- The current baseline check now reports `304` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
+- `ST-09008` removed `9` explicit-`any` warnings from `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
+- The current baseline check now reports `295` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -20,17 +20,17 @@ _No stories currently ready_
 
 ## In Progress
 
-- `ST-09008` - Harden Parallel Workflow Builder Typing
-  - Epic: `EP-09`
-  - Priority: `P1`
-  - Branch: `codex/fix/st-09008-parallel-workflow-builder-typing`
-  - Focus: remove avoidable `any`/`@ts-expect-error` usage from `packages/core/src/langgraph/builders/parallel.ts` without changing fan-out/fan-in behavior
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09008` - Harden Parallel Workflow Builder Typing
+  - Epic: `EP-09`
+  - PR: `#70`
+  - Branch: `codex/fix/st-09008-parallel-workflow-builder-typing`
+  - Validation: focused `tsc`/`eslint`/parallel builder tests plus full `pnpm test --run` and `pnpm lint`
 
 ---
 
@@ -50,7 +50,7 @@ _No stories currently blocked_
   - Rationale: `packages/patterns/src/plan-execute/agent.ts` still uses route and compile `as any` bridges
 - `ST-09011` - Tighten Explicit-`any` Baseline Caps
   - Depends on: `ST-09010`
-  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `304`
+  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `295`
 - `ST-09012` - Remove Package Export-Map Build Warnings
   - Depends on: `ST-09011`
   - Rationale: `skills`, `tools`, and `testing` package metadata still emit easy-to-fix `exports.types` ordering warnings during build
@@ -110,4 +110,4 @@ _No stories currently blocked_
 - ✅ ST-09006 complete - ReAct node modularization merged (PR #68, 2026-03-18)
 - ✅ ST-09007 complete - ReAct node test modularization merged (PR #69, 2026-03-20)
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded on 2026-03-22 with low-hanging follow-on stories ST-09008 through ST-09012
-- Current measured `no-explicit-any` baseline is `304` warnings (`cli 24`, `core 128`, `patterns 31`, `testing 51`, `tools 70`)
+- Current measured `no-explicit-any` baseline is `295` warnings (`cli 24`, `core 119`, `patterns 31`, `testing 51`, `tools 70`)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
@@ -14,17 +14,17 @@
 
 ## Ready
 
-- `ST-09008` - Harden Parallel Workflow Builder Typing
-  - Epic: `EP-09`
-  - Priority: `P1`
-  - Estimate: `3h`
-  - Rationale: `packages/core/src/langgraph/builders/parallel.ts` is still a high-value `any`/`@ts-expect-error` hotspot and is a clean next daily slice
+_No stories currently ready_
 
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09008` - Harden Parallel Workflow Builder Typing
+  - Epic: `EP-09`
+  - Priority: `P1`
+  - Branch: `codex/fix/st-09008-parallel-workflow-builder-typing`
+  - Focus: remove avoidable `any`/`@ts-expect-error` usage from `packages/core/src/langgraph/builders/parallel.ts` without changing fan-out/fan-in behavior
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09008 - Harden Parallel Workflow Builder Typing

## What Changed
- tightened `createParallelWorkflow()` around `AnnotationRoot`, `StateDefinition`, and `UpdateType`
- removed avoidable `any`, `@ts-expect-error`, and `START`/`END` edge casts from the parallel builder
- localized the remaining LangGraph `addNode()` interop to a single typed boundary assertion instead of leaking it into the public API
- expanded focused tests to assert duplicate-node validation, aggregate fan-in wiring, and `autoStartEnd: false`

## Acceptance Criteria Coverage
- `packages/core/src/langgraph/builders/parallel.ts` no longer uses avoidable `any` or `@ts-expect-error` for schema, node registration, or edge wiring
- builder behavior is preserved for parallel fan-out, optional aggregation fan-in, and `autoStartEnd` control
- focused tests cover duplicate-node validation, direct edge wiring, and aggregate fan-in behavior
- explicit-`any` warning delta is recorded in `docs/st09008-parallel-workflow-builder-typing.md`
- story documentation is included at `docs/st09008-parallel-workflow-builder-typing.md`

## Validation Performed
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec eslint packages/core/src/langgraph/builders/parallel.ts packages/core/tests/langgraph/builders/parallel.test.ts`
- `pnpm test --run packages/core/tests/langgraph/builders/parallel.test.ts` -> `8 passed`
- `pnpm lint:explicit-any:baseline` -> `295/496` warnings (`core 119/256`)
- `pnpm test --run` -> `150 passed | 16 skipped` files; `2110 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status
- Ready for review
