### PR TITLE
ST-09009: Tighten Ask-Human Interrupt Boundary

### DIFF
--- a/docs/st09009-ask-human-interrupt-boundary-hardening.md
+++ b/docs/st09009-ask-human-interrupt-boundary-hardening.md
@@ -24,12 +24,22 @@ Tightened the ask-human tool's LangGraph interrupt boundary so dynamic import, i
 pnpm exec tsc -p packages/tools/tsconfig.json --noEmit
 pnpm exec eslint packages/tools/src/agent/ask-human/tool.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human.test.ts
 pnpm test --run packages/tools/tests/agent/ask-human.test.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human-react.integration.test.ts packages/tools/tests/agent/ask-human-plan-execute.integration.test.ts
+pnpm test --run
+pnpm lint
 ```
 
 Focused test result:
 - `4` files passed
 - `32` tests passed
 
+Full-suite result:
+- `151` files passed, `16` skipped
+- `2114` tests passed, `286` skipped
+
+Lint result:
+- `pnpm lint` exited `0`
+- Existing workspace warnings remain outside this story's touched file set
+
 ## Status
 
-In progress on `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`.
+Ready for review on `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`.

--- a/docs/st09009-ask-human-interrupt-boundary-hardening.md
+++ b/docs/st09009-ask-human-interrupt-boundary-hardening.md
@@ -1,0 +1,35 @@
+# ST-09009: Ask-Human Interrupt Boundary Hardening
+
+## Summary
+
+Tightened the ask-human tool's LangGraph interrupt boundary so dynamic import, interrupt lookup, and resumed response handling no longer depend on explicit `any` casts.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/tools/src/agent/ask-human/tool.ts` | Added `unknown`-based LangGraph module guards, centralized interrupt loading, preserved clear dependency/version errors, and normalized resumed responses to keep `AskHumanOutput.response` strictly typed as `string`. |
+| `packages/tools/tests/agent/ask-human-boundary.test.ts` | Added focused interrupt-boundary tests for missing LangGraph handling, missing `interrupt` export compatibility, successful string resume behavior, and timeout/default-response fallback. |
+| `packages/tools/tests/agent/ask-human.test.ts` | Removed stale unused Vitest imports exposed while tightening the focused lint scope. |
+
+## Explicit-`any` Delta
+
+- `packages/tools/src/agent/ask-human/tool.ts`: `3 -> 0`
+- Workspace baseline: `295 -> 292`
+- `tools`: `70 -> 67`
+
+## Validation Performed
+
+```bash
+pnpm exec tsc -p packages/tools/tsconfig.json --noEmit
+pnpm exec eslint packages/tools/src/agent/ask-human/tool.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human.test.ts
+pnpm test --run packages/tools/tests/agent/ask-human.test.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human-react.integration.test.ts packages/tools/tests/agent/ask-human-plan-execute.integration.test.ts
+```
+
+Focused test result:
+- `4` files passed
+- `32` tests passed
+
+## Status
+
+In progress on `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`.

--- a/packages/tools/src/agent/ask-human/tool.ts
+++ b/packages/tools/src/agent/ask-human/tool.ts
@@ -158,7 +158,8 @@ export function createAskHumanTool() {
         response = interrupt(humanRequest);
         logger.debug('interrupt() returned successfully', {
           responseType: typeof response,
-          ...(typeof response === 'string' ? { response } : {}),
+          hasResponse: response != null,
+          ...(typeof response === 'string' ? { responseLength: response.length } : {}),
         });
       } catch (error) {
         logger.debug('interrupt() threw error (expected for GraphInterrupt)', {

--- a/packages/tools/src/agent/ask-human/tool.ts
+++ b/packages/tools/src/agent/ask-human/tool.ts
@@ -12,6 +12,80 @@ import { randomUUID } from 'crypto';
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
 const logger = createLogger('askHuman', { level: logLevel });
 
+type HumanInterruptRequest = Pick<
+  AskHumanInput,
+  'question' | 'context' | 'priority' | 'timeout' | 'defaultResponse' | 'suggestions'
+> & {
+  id: string;
+  createdAt: number;
+  status: 'pending';
+};
+
+type InterruptFunction = (value: HumanInterruptRequest) => unknown;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function resolveInterrupt(module: unknown): InterruptFunction | undefined {
+  if (!isRecord(module)) {
+    return undefined;
+  }
+
+  const candidate = module.interrupt;
+  return typeof candidate === 'function' ? candidate as InterruptFunction : undefined;
+}
+
+function isMissingLangGraphDependency(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes("Cannot find package '@langchain/langgraph'") ||
+    error.message.includes("Cannot find module '@langchain/langgraph'") ||
+    error.message.includes('Failed to resolve module specifier "@langchain/langgraph"')
+  );
+}
+
+async function loadInterrupt(): Promise<InterruptFunction> {
+  try {
+    const interrupt = resolveInterrupt(await import('@langchain/langgraph'));
+    if (!interrupt) {
+      throw new Error(
+        'interrupt function not found in @langchain/langgraph. ' +
+        'Make sure you are using a compatible version of LangGraph.'
+      );
+    }
+
+    return interrupt;
+  } catch (error) {
+    if (isMissingLangGraphDependency(error)) {
+      throw new Error(
+        'askHuman tool requires @langchain/langgraph to be installed. ' +
+        'Install it with: npm install @langchain/langgraph'
+      );
+    }
+
+    throw error;
+  }
+}
+
+function normalizeInterruptResponse(response: unknown): string {
+  if (response == null) {
+    return '';
+  }
+
+  if (typeof response === 'string') {
+    return response;
+  }
+
+  throw new Error(
+    'askHuman tool expected LangGraph interrupt() to resume with a string response. ' +
+    `Received ${typeof response}.`
+  );
+}
+
 /**
  * Create the askHuman tool
  * 
@@ -44,34 +118,13 @@ export function createAskHumanTool() {
     .category(ToolCategory.UTILITY)
     .schema(AskHumanInputSchema)
     .implement(async (input): Promise<AskHumanOutput> => {
-      // Type assertion after Zod validation
-      const validatedInput = input as AskHumanInput;
+      const validatedInput = AskHumanInputSchema.parse(input);
       const requestId = randomUUID();
       const requestedAt = Date.now();
-
-      // Import interrupt dynamically to avoid circular dependencies
-      // and to allow this tool to work even if LangGraph is not installed
-      let interrupt: ((value: any) => any) | undefined;
-      
-      try {
-        const langgraph = await import('@langchain/langgraph');
-        interrupt = (langgraph as any).interrupt;
-      } catch (error) {
-        throw new Error(
-          'askHuman tool requires @langchain/langgraph to be installed. ' +
-          'Install it with: npm install @langchain/langgraph'
-        );
-      }
-
-      if (!interrupt) {
-        throw new Error(
-          'interrupt function not found in @langchain/langgraph. ' +
-          'Make sure you are using a compatible version of LangGraph.'
-        );
-      }
+      const interrupt = await loadInterrupt();
 
       // Create the human request object
-      const humanRequest = {
+      const humanRequest: HumanInterruptRequest = {
         id: requestId,
         question: validatedInput.question,
         context: validatedInput.context,
@@ -80,7 +133,7 @@ export function createAskHumanTool() {
         timeout: validatedInput.timeout,
         defaultResponse: validatedInput.defaultResponse,
         suggestions: validatedInput.suggestions,
-        status: 'pending' as const,
+        status: 'pending',
       };
 
       // Use LangGraph's interrupt to pause execution
@@ -103,7 +156,10 @@ export function createAskHumanTool() {
       let response;
       try {
         response = interrupt(humanRequest);
-        logger.debug('interrupt() returned successfully', { response, responseType: typeof response });
+        logger.debug('interrupt() returned successfully', {
+          responseType: typeof response,
+          ...(typeof response === 'string' ? { response } : {}),
+        });
       } catch (error) {
         logger.debug('interrupt() threw error (expected for GraphInterrupt)', {
           ...(error && typeof error === 'object' && 'constructor' in error
@@ -123,7 +179,7 @@ export function createAskHumanTool() {
       // If timeout occurred and we have a default response, use it
       const finalResponse = timedOut && validatedInput.defaultResponse
         ? validatedInput.defaultResponse
-        : (response || '');
+        : normalizeInterruptResponse(response);
 
       return {
         response: finalResponse,

--- a/packages/tools/src/agent/ask-human/tool.ts
+++ b/packages/tools/src/agent/ask-human/tool.ts
@@ -153,7 +153,7 @@ export function createAskHumanTool() {
         },
       });
 
-      let response;
+      let response: unknown;
       try {
         response = interrupt(humanRequest);
         logger.debug('interrupt() returned successfully', {

--- a/packages/tools/src/agent/ask-human/tool.ts
+++ b/packages/tools/src/agent/ask-human/tool.ts
@@ -10,7 +10,7 @@ import { randomUUID } from 'crypto';
 // Create logger for askHuman tool
 // Log level can be controlled via LOG_LEVEL environment variable
 const logLevel = (process.env.LOG_LEVEL?.toLowerCase() as LogLevel) || LogLevel.INFO;
-const logger = createLogger('askHuman', { level: logLevel });
+const logger = createLogger('agentforge:tools:agent:ask-human', { level: logLevel });
 
 type HumanInterruptRequest = Pick<
   AskHumanInput,
@@ -177,9 +177,10 @@ export function createAskHumanTool() {
       const timedOut = validatedInput.timeout > 0 && duration >= validatedInput.timeout;
 
       // If timeout occurred and we have a default response, use it
-      const finalResponse = timedOut && validatedInput.defaultResponse
-        ? validatedInput.defaultResponse
-        : normalizeInterruptResponse(response);
+      const finalResponse =
+        timedOut && validatedInput.defaultResponse !== undefined
+          ? validatedInput.defaultResponse
+          : normalizeInterruptResponse(response);
 
       return {
         response: finalResponse,

--- a/packages/tools/tests/agent/ask-human-boundary.test.ts
+++ b/packages/tools/tests/agent/ask-human-boundary.test.ts
@@ -71,6 +71,21 @@ describe('askHuman Tool - interrupt boundary', () => {
     expect(result.metadata.timedOut).toBe(false);
   });
 
+  it('maps null interrupt resume values to an empty response string', async () => {
+    const interrupt = vi.fn().mockReturnValue(null);
+    vi.doMock('@langchain/langgraph', () => ({ interrupt }));
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    const result = await tool.invoke({
+      question: 'Should I continue?',
+    });
+
+    expect(result.response).toBe('');
+    expect(result.metadata.timedOut).toBe(false);
+  });
+
   it('uses the default response when the timeout elapses', async () => {
     const interrupt = vi.fn().mockReturnValue('late human answer');
     vi.doMock('@langchain/langgraph', () => ({ interrupt }));

--- a/packages/tools/tests/agent/ask-human-boundary.test.ts
+++ b/packages/tools/tests/agent/ask-human-boundary.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AskHumanInput } from '../../src/agent/ask-human/types.js';
+
+async function loadAskHumanToolModule() {
+  return import('../../src/agent/ask-human/tool.js');
+}
+
+describe('askHuman Tool - interrupt boundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock('@langchain/langgraph');
+  });
+
+  it('throws a clear error when LangGraph is not installed', async () => {
+    vi.doMock('@langchain/langgraph', () => ({
+      get interrupt() {
+        throw new Error("Cannot find package '@langchain/langgraph'");
+      },
+    }));
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    await expect(
+      tool.invoke({
+        question: 'Should I continue?',
+      })
+    ).rejects.toThrow(
+      'askHuman tool requires @langchain/langgraph to be installed. Install it with: npm install @langchain/langgraph'
+    );
+  });
+
+  it('throws a compatibility error when interrupt is unavailable', async () => {
+    vi.doMock('@langchain/langgraph', () => ({ interrupt: undefined }));
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    await expect(
+      tool.invoke({
+        question: 'Should I continue?',
+      })
+    ).rejects.toThrow(
+      'interrupt function not found in @langchain/langgraph. Make sure you are using a compatible version of LangGraph.'
+    );
+  });
+
+  it('returns the interrupt response when LangGraph resumes with a string', async () => {
+    const interrupt = vi.fn().mockReturnValue('Approved by human');
+    vi.doMock('@langchain/langgraph', () => ({ interrupt }));
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+    const input: AskHumanInput = {
+      question: 'Should I deploy?',
+      priority: 'high',
+      timeout: 0,
+    };
+
+    const result = await tool.invoke(input);
+
+    expect(interrupt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: 'Should I deploy?',
+        priority: 'high',
+        status: 'pending',
+      })
+    );
+    expect(result.response).toBe('Approved by human');
+    expect(result.metadata.timedOut).toBe(false);
+  });
+
+  it('uses the default response when the timeout elapses', async () => {
+    const interrupt = vi.fn().mockReturnValue('late human answer');
+    vi.doMock('@langchain/langgraph', () => ({ interrupt }));
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_500);
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    const result = await tool.invoke({
+      question: 'Approve deployment?',
+      timeout: 1_000,
+      defaultResponse: 'skip',
+    });
+
+    expect(result.response).toBe('skip');
+    expect(result.metadata.duration).toBe(1_500);
+    expect(result.metadata.timedOut).toBe(true);
+  });
+});

--- a/packages/tools/tests/agent/ask-human-boundary.test.ts
+++ b/packages/tools/tests/agent/ask-human-boundary.test.ts
@@ -91,4 +91,40 @@ describe('askHuman Tool - interrupt boundary', () => {
     expect(result.metadata.duration).toBe(1_500);
     expect(result.metadata.timedOut).toBe(true);
   });
+
+  it('honors an empty-string default response when the timeout elapses', async () => {
+    const interrupt = vi.fn().mockReturnValue('late human answer');
+    vi.doMock('@langchain/langgraph', () => ({ interrupt }));
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(5_000)
+      .mockReturnValueOnce(7_000);
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    const result = await tool.invoke({
+      question: 'Approve blank response?',
+      timeout: 1_000,
+      defaultResponse: '',
+    });
+
+    expect(result.response).toBe('');
+    expect(result.metadata.timedOut).toBe(true);
+  });
+
+  it('rejects non-string interrupt resume values with a compatibility error', async () => {
+    const interrupt = vi.fn().mockReturnValue({ answer: 'not-a-string' });
+    vi.doMock('@langchain/langgraph', () => ({ interrupt }));
+
+    const { createAskHumanTool } = await loadAskHumanToolModule();
+    const tool = createAskHumanTool();
+
+    await expect(
+      tool.invoke({
+        question: 'Should I continue?',
+      })
+    ).rejects.toThrow(
+      'askHuman tool expected LangGraph interrupt() to resume with a string response. Received object.'
+    );
+  });
 });

--- a/packages/tools/tests/agent/ask-human.test.ts
+++ b/packages/tools/tests/agent/ask-human.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createAskHumanTool, askHumanTool } from '../../src/agent/ask-human/tool.js';
 import type { AskHumanInput } from '../../src/agent/ask-human/types.js';
 
@@ -133,4 +133,3 @@ describe('askHuman Tool', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -306,25 +306,31 @@
 
 ### Checklist
 - [x] Create branch `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Remove avoidable `any` usage from `packages/tools/src/agent/ask-human/tool.ts` around dynamic LangGraph import and interrupt handling
 - [x] Preserve current ask-human runtime behavior while improving interrupt availability and compatibility checks
 - [x] Add/update focused tests for missing LangGraph dependency handling, interrupt responses, and timeout/default-response behavior
 - [x] Record explicit-`any` warning deltas for touched files in story docs
 - [x] Add or update story documentation at `docs/st09009-ask-human-interrupt-boundary-hardening.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [x] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
 - `fec8ad1` `fix(st-09009): harden ask-human interrupt boundary`
+- `d1f5dd2` `docs(st-09009): record ask-human boundary progress`
+- Draft PR #71: https://github.com/TVScoundrel/agentforge/pull/71
 - Focused validation passed:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/tools/src/agent/ask-human/tool.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human.test.ts`
   - `pnpm test --run packages/tools/tests/agent/ask-human.test.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human-react.integration.test.ts packages/tools/tests/agent/ask-human-plan-execute.integration.test.ts`
+- Full validation passed:
+  - `pnpm test --run` -> `151 passed | 16 skipped` files; `2114 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0` (warnings only)
+- PR #71 marked ready after final tracker/body refresh
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -322,6 +322,7 @@
 Implementation notes:
 - `fec8ad1` `fix(st-09009): harden ask-human interrupt boundary`
 - `d1f5dd2` `docs(st-09009): record ask-human boundary progress`
+- `fix(st-09009):` pending review-fix commit for logger namespace, timeout default handling, non-string resume regression, and Phase 9 status sync
 - Draft PR #71: https://github.com/TVScoundrel/agentforge/pull/71
 - Focused validation passed:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -324,6 +324,7 @@ Implementation notes:
 - `d1f5dd2` `docs(st-09009): record ask-human boundary progress`
 - `fix(st-09009):` pending review-fix commit for logger namespace, timeout default handling, non-string resume regression, and Phase 9 status sync
 - `fix(st-09009):` pending review-fix commit for typed interrupt response variable
+- `fix(st-09009):` pending review-fix commit for nullish interrupt resume coverage
 - Draft PR #71: https://github.com/TVScoundrel/agentforge/pull/71
 - Focused validation passed:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -302,22 +302,29 @@
 
 ## ST-09009: Tighten Ask-Human Interrupt Boundary
 
-**Branch:** `fix/st-09009-ask-human-interrupt-boundary-hardening`
+**Branch:** `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-09009-ask-human-interrupt-boundary-hardening`
+- [x] Create branch `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`
 - [ ] Create draft PR with story ID in title
-- [ ] Remove avoidable `any` usage from `packages/tools/src/agent/ask-human/tool.ts` around dynamic LangGraph import and interrupt handling
-- [ ] Preserve current ask-human runtime behavior while improving interrupt availability and compatibility checks
-- [ ] Add/update focused tests for missing LangGraph dependency handling, interrupt responses, and timeout/default-response behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09009-ask-human-interrupt-boundary-hardening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Remove avoidable `any` usage from `packages/tools/src/agent/ask-human/tool.ts` around dynamic LangGraph import and interrupt handling
+- [x] Preserve current ask-human runtime behavior while improving interrupt availability and compatibility checks
+- [x] Add/update focused tests for missing LangGraph dependency handling, interrupt responses, and timeout/default-response behavior
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09009-ask-human-interrupt-boundary-hardening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+- `fec8ad1` `fix(st-09009): harden ask-human interrupt boundary`
+- Focused validation passed:
+  - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/tools/src/agent/ask-human/tool.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human.test.ts`
+  - `pnpm test --run packages/tools/tests/agent/ask-human.test.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human-react.integration.test.ts packages/tools/tests/agent/ask-human-plan-execute.integration.test.ts`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -322,9 +322,9 @@
 Implementation notes:
 - `fec8ad1` `fix(st-09009): harden ask-human interrupt boundary`
 - `d1f5dd2` `docs(st-09009): record ask-human boundary progress`
-- `fix(st-09009):` pending review-fix commit for logger namespace, timeout default handling, non-string resume regression, and Phase 9 status sync
-- `fix(st-09009):` pending review-fix commit for typed interrupt response variable
-- `fix(st-09009):` pending review-fix commit for nullish interrupt resume coverage
+- `6d8ca5a` `fix(st-09009): tighten ask-human review fixes`
+- `f3b7e10` `fix(st-09009): type interrupt response boundary`
+- `300e610` `test(st-09009): cover nullish interrupt resumes`
 - Draft PR #71: https://github.com/TVScoundrel/agentforge/pull/71
 - Focused validation passed:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -323,6 +323,7 @@ Implementation notes:
 - `fec8ad1` `fix(st-09009): harden ask-human interrupt boundary`
 - `d1f5dd2` `docs(st-09009): record ask-human boundary progress`
 - `fix(st-09009):` pending review-fix commit for logger namespace, timeout default handling, non-string resume regression, and Phase 9 status sync
+- `fix(st-09009):` pending review-fix commit for typed interrupt response variable
 - Draft PR #71: https://github.com/TVScoundrel/agentforge/pull/71
 - Focused validation passed:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (In Progress) → ST-09010 (Backlog) → ST-09011 (Backlog) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (In Review) → ST-09010 (Backlog) → ST-09011 (Backlog) → ST-09012 (Backlog)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -970,7 +970,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09008
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/agent/ask-human/tool.ts` removes avoidable `any` usage around dynamic LangGraph import and interrupt handling

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -970,7 +970,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09008
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/agent/ask-human/tool.ts` removes avoidable `any` usage around dynamic LangGraph import and interrupt handling
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Ready) → ST-09009 (Backlog) → ST-09010 (Backlog) → ST-09011 (Backlog) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (In Progress) → ST-09010 (Backlog) → ST-09011 (Backlog) → ST-09012 (Backlog)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-22
-**Active Story:** ST-09009 (Ready)
+**Active Story:** ST-09009 (In Progress)
 
 ---
 
@@ -34,14 +34,14 @@
 
 Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-22):
 
-- Total: `295` warnings (`src/**`)
-- By package: `core 119`, `tools 70`, `testing 51`, `patterns 31`, `cli 24`
+- Total: `292` warnings (`src/**`)
+- By package: `core 119`, `tools 67`, `testing 51`, `patterns 31`, `cli 24`
 
 Top runtime hotspots informing this feature slice:
 
-1. `packages/tools/src/agent/ask-human/tool.ts` (8)
+1. `packages/tools/src/agent/ask-human/tool.ts` (5)
 2. `packages/patterns/src/plan-execute/agent.ts` (4)
-3. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `295`
+3. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `292`
 4. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
 
 Recent improvement snapshot:
@@ -51,7 +51,8 @@ Recent improvement snapshot:
 - `ST-09004` removed `20` explicit-`any` warnings from `packages/core/src/langgraph/observability/logger.ts` and `packages/core/src/monitoring/alerts.ts`, improving the `core` baseline from `148` to `128`.
 - `ST-09005` removed `19` explicit-`any` warnings from `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`, improving the workspace baseline from `324` to `305` and the `patterns` baseline from `50` to `31`.
 - `ST-09008` reduced explicit-`any` warnings in `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
-- The current baseline check now reports `295` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
+- `ST-09009` has reduced explicit-`any` warnings in `packages/tools/src/agent/ask-human/tool.ts` from `3` to `0` so far, improving the workspace baseline from `295` to `292` and the `tools` baseline from `70` to `67`.
+- The current baseline check now reports `292` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-22
-**Active Story:** ST-09009 (In Progress)
+**Active Story:** ST-09009 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,26 +4,27 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
 ---
 
-## Ready
+## In Progress
 
 - `ST-09009` - Tighten Ask-Human Interrupt Boundary
   - Epic: `EP-09`
   - Priority: `P1`
-  - Rationale: `packages/tools/src/agent/ask-human/tool.ts` still relies on broad interrupt import/response casts
+  - Branch: `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`
+  - Progress: ask-human interrupt loading/response normalization hardened; focused boundary tests added
 
 ---
 
-## In Progress
+## Ready
 
-_No stories currently in progress_
+_No stories currently ready_
 
 ---
 
@@ -46,7 +47,7 @@ _No stories currently blocked_
   - Rationale: `packages/patterns/src/plan-execute/agent.ts` still uses route and compile `as any` bridges
 - `ST-09011` - Tighten Explicit-`any` Baseline Caps
   - Depends on: `ST-09010`
-  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `295`
+  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `292`
 - `ST-09012` - Remove Package Export-Map Build Warnings
   - Depends on: `ST-09011`
   - Rationale: `skills`, `tools`, and `testing` package metadata still emit easy-to-fix `exports.types` ordering warnings during build
@@ -107,4 +108,4 @@ _No stories currently blocked_
 - ✅ ST-09007 complete - ReAct node test modularization merged (PR #69, 2026-03-20)
 - ✅ ST-09008 complete - parallel workflow builder typing hardened (PR #70, 2026-03-22)
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded on 2026-03-22 with low-hanging follow-on stories ST-09008 through ST-09012
-- Current measured `no-explicit-any` baseline is `295` warnings (`cli 24`, `core 119`, `patterns 31`, `testing 51`, `tools 70`)
+- Current measured `no-explicit-any` baseline is `292` warnings (`cli 24`, `core 119`, `patterns 31`, `testing 51`, `tools 67`)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,32 +5,32 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
 ---
 
-## In Progress
+## In Review
 
 - `ST-09009` - Tighten Ask-Human Interrupt Boundary
   - Epic: `EP-09`
   - Priority: `P1`
-  - Branch: `codex/fix/st-09009-ask-human-interrupt-boundary-hardening`
-  - Progress: ask-human interrupt loading/response normalization hardened; focused boundary tests added
+  - PR: `#71`
+  - Progress: ask-human interrupt loading/response normalization hardened; full suite and lint completed
+
+---
+
+## In Progress
+
+_No stories currently in progress_
 
 ---
 
 ## Ready
 
 _No stories currently ready_
-
----
-
-## In Review
-
-_No stories currently in review_
 
 ---
 


### PR DESCRIPTION
## Story
- `ST-09009` - Tighten Ask-Human Interrupt Boundary

## What Changed
- hardened `packages/tools/src/agent/ask-human/tool.ts` so LangGraph dynamic import, interrupt lookup, and resumed-response handling use `unknown`-based guards instead of explicit `any`
- preserved current ask-human behavior while making missing dependency and missing `interrupt` compatibility failures explicit
- kept `AskHumanOutput.response` strictly typed by normalizing nullish resumes and rejecting incompatible non-string resumes
- added focused boundary coverage in `packages/tools/tests/agent/ask-human-boundary.test.ts` for dependency handling, interrupt compatibility, direct string resumes, and timeout/default-response fallback
- recorded the warning delta and final validation results in `docs/st09009-ask-human-interrupt-boundary-hardening.md` and EP-09 trackers

## Acceptance Criteria Coverage
- [x] `packages/tools/src/agent/ask-human/tool.ts` removes avoidable `any` usage around dynamic LangGraph import and interrupt handling
- [x] Interrupt availability and compatibility checks produce clear errors without weakening the public `AskHumanOutput` contract
- [x] Focused tests are added or updated for missing LangGraph dependency handling, interrupt response handling, and timeout/default-response behavior
- [x] Explicit-`any` warning changes for touched files are recorded in story documentation
- [x] Add or update story documentation at `docs/st09009-ask-human-interrupt-boundary-hardening.md`

## Validation Performed
- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
- `pnpm exec eslint packages/tools/src/agent/ask-human/tool.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human.test.ts`
- `pnpm test --run packages/tools/tests/agent/ask-human.test.ts packages/tools/tests/agent/ask-human-boundary.test.ts packages/tools/tests/agent/ask-human-react.integration.test.ts packages/tools/tests/agent/ask-human-plan-execute.integration.test.ts`
- `pnpm lint:explicit-any:baseline` -> workspace `295 -> 292`, `tools 70 -> 67`
- `pnpm test --run` -> `151 passed | 16 skipped` files; `2114 passed | 286 skipped` tests
- `pnpm lint` -> exit `0` (warnings only)

## Status
- Ready for review
