### PR TITLE
ST-09010: Strengthen plan-execute agent routing typing

### DIFF
--- a/docs/st09010-plan-execute-routing-typing.md
+++ b/docs/st09010-plan-execute-routing-typing.md
@@ -1,0 +1,36 @@
+# ST-09010: Strengthen Plan-Execute Agent Routing Typing
+
+## Summary
+
+Tightened the plan-execute agent factory so its conditional routing and compile boundary no longer rely on explicit `any` casts, while preserving the existing planner, executor, replanner, finisher, and terminal error flows.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/patterns/src/plan-execute/agent.ts` | Replaced the route callback `as any` bridges with typed route maps, removed the compile-return cast, and dropped unused config/placeholder parameters exposed by the stricter boundary. |
+| `packages/patterns/tests/plan-execute/agent.test.ts` | Added focused routing coverage that proves failed executor steps can route through the replanner back to either the executor or the planner based on the replanning decision. |
+| `packages/patterns/tests/plan-execute/integration.test.ts` | Reused as the compiled-agent invocation coverage while keeping the existing end-to-end plan execution behavior intact. |
+
+## Explicit-`any` Delta
+
+- `packages/patterns/src/plan-execute/agent.ts`: `3 -> 0`
+- Workspace baseline: `292 -> 289`
+- `patterns`: `31 -> 28`
+
+## Validation Performed
+
+```bash
+pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit
+pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/tests/plan-execute/agent.test.ts
+pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/integration.test.ts
+pnpm lint:explicit-any:baseline
+```
+
+Focused test result:
+- `2` files passed
+- `8` tests passed
+
+## Status
+
+Implementation in progress on `codex/fix/st-09010-plan-execute-routing-typing`.

--- a/docs/st09010-plan-execute-routing-typing.md
+++ b/docs/st09010-plan-execute-routing-typing.md
@@ -25,12 +25,22 @@ pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit
 pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/tests/plan-execute/agent.test.ts
 pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/integration.test.ts
 pnpm lint:explicit-any:baseline
+pnpm test --run
+pnpm lint
 ```
 
 Focused test result:
 - `2` files passed
 - `8` tests passed
 
+Full-suite result:
+- `152` files passed, `16` skipped
+- `2119` tests passed, `286` skipped
+
+Lint result:
+- `pnpm lint` exited `0`
+- Existing workspace warnings remain outside this story's touched file set
+
 ## Status
 
-Implementation in progress on `codex/fix/st-09010-plan-execute-routing-typing`.
+Ready for review on `codex/fix/st-09010-plan-execute-routing-typing`.

--- a/packages/patterns/src/plan-execute/agent.ts
+++ b/packages/patterns/src/plan-execute/agent.ts
@@ -11,6 +11,20 @@ import { PlanExecuteState, type PlanExecuteStateType } from './state.js';
 import { createPlannerNode, createExecutorNode, createReplannerNode, createFinisherNode } from './nodes.js';
 import type { PlanExecuteAgentConfig, PlanExecuteRoute } from './types.js';
 
+const executorRouteMap = {
+  execute: 'executor',
+  replan: 'replanner',
+  finish: 'finisher',
+  error: END,
+} as const satisfies Record<PlanExecuteRoute, 'executor' | 'replanner' | 'finisher' | typeof END>;
+
+const replannerRouteMap = {
+  replan: 'planner',
+  execute: 'executor',
+  error: END,
+  finish: END,
+} as const satisfies Record<PlanExecuteRoute, 'planner' | 'executor' | typeof END>;
+
 /**
  * Create a Plan-and-Execute agent
  *
@@ -76,7 +90,6 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
     executor,
     replanner,
     maxIterations = 5,
-    verbose = false,
     checkpointer,
   } = config;
 
@@ -88,7 +101,7 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
   // Create a no-op replanner if not configured
   const replannerNode = replanner
     ? createReplannerNode(replanner)
-    : async (state: PlanExecuteStateType) => ({ status: 'executing' as const });
+    : async () => ({ status: 'executing' as const });
 
   // Create the graph
   const workflow = new StateGraph(PlanExecuteState)
@@ -156,13 +169,8 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
   // Add conditional edges from executor
   workflow.addConditionalEdges(
     'executor',
-    routeAfterExecutor as any,
-    {
-      execute: 'executor', // Loop back to execute next step
-      replan: 'replanner',
-      finish: 'finisher',
-      error: END,
-    }
+    routeAfterExecutor,
+    executorRouteMap
   );
 
   // Add edge from finisher to END
@@ -171,15 +179,10 @@ export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
   // Add conditional edges from replanner
   workflow.addConditionalEdges(
     'replanner',
-    routeAfterReplanner as any,
-    {
-      replan: 'planner',
-      execute: 'executor',
-      error: END,
-      finish: END,
-    }
+    routeAfterReplanner,
+    replannerRouteMap
   );
 
   // Compile with checkpointer if provided
-  return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
+  return workflow.compile(checkpointer ? { checkpointer } : undefined);
 }

--- a/packages/patterns/tests/plan-execute/agent.test.ts
+++ b/packages/patterns/tests/plan-execute/agent.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { createMockLLM } from '@agentforge/testing';
+import { z } from 'zod';
+import { createPlanExecuteAgent } from '../../src/plan-execute/agent.js';
+
+const failingTool = toolBuilder()
+  .name('failing-tool')
+  .description('Always fails during execution')
+  .category(ToolCategory.UTILITY)
+  .schema(z.object({}))
+  .implement(async () => {
+    throw new Error('tool failed');
+  })
+  .build();
+
+const successTool = toolBuilder()
+  .name('success-tool')
+  .description('Returns a successful fallback result')
+  .category(ToolCategory.UTILITY)
+  .schema(z.object({}))
+  .implement(async () => 'recovered')
+  .build();
+
+function createPlanResponse(goal: string, steps: Array<{ id: string; description: string; tool?: string }>): string {
+  return JSON.stringify({
+    goal,
+    steps,
+    confidence: 0.95,
+  });
+}
+
+describe('Plan-Execute Agent Routing', () => {
+  it('routes from replanner back to executor when replanning is declined', async () => {
+    const planner = createMockLLM({
+      responses: [
+        createPlanResponse('Recover from failure', [
+          { id: 'step-fail', description: 'Fail once', tool: 'failing-tool' },
+          { id: 'step-success', description: 'Recover', tool: 'success-tool' },
+        ]),
+      ],
+    });
+
+    const replanner = createMockLLM({
+      responses: [
+        JSON.stringify({
+          shouldReplan: false,
+          reason: 'Continue with the current plan',
+        }),
+      ],
+    });
+
+    const agent = createPlanExecuteAgent({
+      planner: { model: planner },
+      executor: { tools: [failingTool, successTool] },
+      replanner: { model: replanner },
+    });
+
+    const result = await agent.invoke({ input: 'recover after one failed step' });
+
+    expect(planner.getCallCount()).toBe(1);
+    expect(replanner.getCallCount()).toBe(1);
+    expect(result.status).toBe('completed');
+    expect(result.pastSteps).toHaveLength(2);
+    expect(result.pastSteps[0]?.success).toBe(false);
+    expect(result.pastSteps[1]?.success).toBe(true);
+    expect(result.pastSteps[1]?.result).toBe('recovered');
+  });
+
+  it('routes from replanner back to planner when replanning is requested', async () => {
+    const planner = createMockLLM({
+      responses: [
+        createPlanResponse('Original goal', [
+          { id: 'step-fail', description: 'Fail once', tool: 'failing-tool' },
+          { id: 'step-stale', description: 'Stale follow-up', tool: 'success-tool' },
+        ]),
+        createPlanResponse('Retry with fallback', [
+          { id: 'step-retry', description: 'Retry with fallback', tool: 'success-tool' },
+        ]),
+      ],
+    });
+
+    const replanner = createMockLLM({
+      responses: [
+        JSON.stringify({
+          shouldReplan: true,
+          reason: 'The first attempt failed',
+          newGoal: 'Retry with fallback',
+        }),
+      ],
+    });
+
+    const agent = createPlanExecuteAgent({
+      planner: { model: planner },
+      executor: { tools: [failingTool, successTool] },
+      replanner: { model: replanner },
+      maxIterations: 3,
+    });
+
+    const result = await agent.invoke({ input: 'recover by replanning' });
+
+    expect(planner.getCallCount()).toBe(2);
+    expect(replanner.getCallCount()).toBe(1);
+    expect(result.status).toBe('completed');
+    expect(result.plan?.goal).toBe('Retry with fallback');
+    expect(result.pastSteps).toHaveLength(2);
+    expect(result.pastSteps[0]?.step.id).toBe('step-fail');
+    expect(result.pastSteps[0]?.success).toBe(false);
+    expect(result.pastSteps[1]?.step.id).toBe('step-retry');
+    expect(result.pastSteps[1]?.success).toBe(true);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -344,25 +344,30 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09010-plan-execute-routing-typing`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Remove avoidable `as any` usage from `packages/patterns/src/plan-execute/agent.ts` around route callbacks and compile return handling
 - [x] Preserve current planner/executor/replanner/finisher routing behavior while tightening route typing
 - [x] Add/update focused tests for executor/replanner route decisions and compiled agent invocation behavior
 - [x] Record explicit-`any` warning deltas for touched files in story docs
 - [x] Add or update story documentation at `docs/st09010-plan-execute-routing-typing.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
+- `12b06fe` `refactor(st-09010): tighten plan-execute routing typing`
+- Draft PR #72: https://github.com/TVScoundrel/agentforge/pull/72
 - Focused validation passed:
   - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/tests/plan-execute/agent.test.ts`
   - `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/integration.test.ts`
   - `pnpm lint:explicit-any:baseline`
+- Full validation passed:
+  - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0` (warnings only)
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -340,22 +340,29 @@ Implementation notes:
 
 ## ST-09010: Strengthen Plan-Execute Agent Routing Typing
 
-**Branch:** `fix/st-09010-plan-execute-routing-typing`
+**Branch:** `codex/fix/st-09010-plan-execute-routing-typing`
 
 ### Checklist
-- [ ] Create branch `fix/st-09010-plan-execute-routing-typing`
+- [x] Create branch `fix/st-09010-plan-execute-routing-typing`
 - [ ] Create draft PR with story ID in title
-- [ ] Remove avoidable `as any` usage from `packages/patterns/src/plan-execute/agent.ts` around route callbacks and compile return handling
-- [ ] Preserve current planner/executor/replanner/finisher routing behavior while tightening route typing
-- [ ] Add/update focused tests for executor/replanner route decisions and compiled agent invocation behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09010-plan-execute-routing-typing.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Remove avoidable `as any` usage from `packages/patterns/src/plan-execute/agent.ts` around route callbacks and compile return handling
+- [x] Preserve current planner/executor/replanner/finisher routing behavior while tightening route typing
+- [x] Add/update focused tests for executor/replanner route decisions and compiled agent invocation behavior
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09010-plan-execute-routing-typing.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+- Focused validation passed:
+  - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/tests/plan-execute/agent.test.ts`
+  - `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/integration.test.ts`
+  - `pnpm lint:explicit-any:baseline`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -368,6 +368,7 @@ Implementation notes:
 - Full validation passed:
   - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0` (warnings only)
+- PR #72 marked ready after final tracker/body refresh
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -343,7 +343,7 @@ Implementation notes:
 **Branch:** `codex/fix/st-09010-plan-execute-routing-typing`
 
 ### Checklist
-- [x] Create branch `fix/st-09010-plan-execute-routing-typing`
+- [x] Create branch `codex/fix/st-09010-plan-execute-routing-typing`
 - [x] Create draft PR with story ID in title
 - [x] Remove avoidable `as any` usage from `packages/patterns/src/plan-execute/agent.ts` around route callbacks and compile return handling
 - [x] Preserve current planner/executor/replanner/finisher routing behavior while tightening route typing
@@ -369,6 +369,7 @@ Implementation notes:
   - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0` (warnings only)
 - PR #72 marked ready after final tracker/body refresh
+- Review fix applied after PR feedback
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -987,7 +987,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09009
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/plan-execute/agent.ts` removes avoidable `as any` usage in conditional routing and compile return handling
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (In Progress) → ST-09011 (Backlog) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (In Review) → ST-09011 (Backlog) → ST-09012 (Backlog)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -987,7 +987,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09009
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/plan-execute/agent.ts` removes avoidable `as any` usage in conditional routing and compile return handling
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Ready) → ST-09011 (Backlog) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (In Progress) → ST-09011 (Backlog) → ST-09012 (Backlog)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09010 (Ready)
+**Active Story:** ST-09010 (In Progress)
 
 ---
 
@@ -40,7 +40,7 @@ Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit
 Top runtime hotspots informing this feature slice:
 
 1. `packages/tools/src/agent/ask-human/tool.ts` (5)
-2. `packages/patterns/src/plan-execute/agent.ts` (4)
+2. `packages/patterns/src/plan-execute/agent.ts` (3)
 3. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `292`
 4. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
 
@@ -52,6 +52,7 @@ Recent improvement snapshot:
 - `ST-09005` removed `19` explicit-`any` warnings from `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`, improving the workspace baseline from `324` to `305` and the `patterns` baseline from `50` to `31`.
 - `ST-09008` reduced explicit-`any` warnings in `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
 - `ST-09009` has reduced explicit-`any` warnings in `packages/tools/src/agent/ask-human/tool.ts` from `3` to `0` so far, improving the workspace baseline from `295` to `292` and the `tools` baseline from `70` to `67`.
+- `ST-09010` has reduced explicit-`any` warnings in `packages/patterns/src/plan-execute/agent.ts` from `3` to `0` so far, improving the workspace baseline from `292` to `289` and the `patterns` baseline from `31` to `28`.
 - The current baseline check now reports `292` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09010 (In Progress)
+**Active Story:** ST-09010 (In Review)
 
 ---
 
@@ -32,17 +32,16 @@
 
 ## Current Hotspot Snapshot
 
-Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-22):
+Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-23):
 
-- Total: `292` warnings (`src/**`)
-- By package: `core 119`, `tools 67`, `testing 51`, `patterns 31`, `cli 24`
+- Total: `289` warnings (`src/**`)
+- By package: `core 119`, `tools 67`, `testing 51`, `patterns 28`, `cli 24`
 
 Top runtime hotspots informing this feature slice:
 
-1. `packages/tools/src/agent/ask-human/tool.ts` (5)
-2. `packages/patterns/src/plan-execute/agent.ts` (3)
-3. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `292`
-4. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
+1. `scripts/no-explicit-any-baseline.json` still allows the pre-EP-09 cap of `496` total warnings despite the current `289`
+2. `packages/patterns/src/plan-execute/types.ts` still carries an easy two-warning `Tool<any, any>[]` boundary in the active EP-09 area
+3. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
 
 Recent improvement snapshot:
 
@@ -52,8 +51,8 @@ Recent improvement snapshot:
 - `ST-09005` removed `19` explicit-`any` warnings from `packages/patterns/src/react/nodes.ts` and `packages/patterns/src/shared/agent-builder.ts`, improving the workspace baseline from `324` to `305` and the `patterns` baseline from `50` to `31`.
 - `ST-09008` reduced explicit-`any` warnings in `packages/core/src/langgraph/builders/parallel.ts`, improving the workspace baseline from `304` to `295` and the `core` baseline from `128` to `119`.
 - `ST-09009` has reduced explicit-`any` warnings in `packages/tools/src/agent/ask-human/tool.ts` from `3` to `0` so far, improving the workspace baseline from `295` to `292` and the `tools` baseline from `70` to `67`.
-- `ST-09010` has reduced explicit-`any` warnings in `packages/patterns/src/plan-execute/agent.ts` from `3` to `0` so far, improving the workspace baseline from `292` to `289` and the `patterns` baseline from `31` to `28`.
-- The current baseline check now reports `292` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
+- `ST-09010` has reduced explicit-`any` warnings in `packages/patterns/src/plan-execute/agent.ts` from `3` to `0`, improving the workspace baseline from `292` to `289` and the `patterns` baseline from `31` to `28`.
+- The current baseline check now reports `289` warnings total and `cli 24`, so the committed caps are stale and worth tightening in a follow-up story.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
@@ -14,10 +14,7 @@
 
 ## Ready
 
-- `ST-09010` - Strengthen Plan-Execute Agent Routing Typing
-  - Epic: `EP-09`
-  - Priority: `P2`
-  - Rationale: `packages/patterns/src/plan-execute/agent.ts` still uses route and compile `as any` bridges
+_No stories currently ready_
 
 ---
 
@@ -29,7 +26,10 @@ _No stories currently in review_
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09010` - Strengthen Plan-Execute Agent Routing Typing
+  - Epic: `EP-09`
+  - Priority: `P2`
+  - Rationale: replacing route/compile `as any` bridges in `packages/patterns/src/plan-execute/agent.ts` with typed LangGraph wiring and focused route coverage
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
 
@@ -20,16 +20,16 @@ _No stories currently ready_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09010` - Strengthen Plan-Execute Agent Routing Typing
+  - Epic: `EP-09`
+  - Priority: `P2`
+  - Rationale: `packages/patterns/src/plan-execute/agent.ts` now uses typed route maps and focused replanner route coverage instead of route/compile `as any` bridges
 
 ---
 
 ## In Progress
 
-- `ST-09010` - Strengthen Plan-Execute Agent Routing Typing
-  - Epic: `EP-09`
-  - Priority: `P2`
-  - Rationale: replacing route/compile `as any` bridges in `packages/patterns/src/plan-execute/agent.ts` with typed LangGraph wiring and focused route coverage
+_No stories currently in progress_
 
 ---
 
@@ -43,7 +43,7 @@ _No stories currently blocked_
 
 - `ST-09011` - Tighten Explicit-`any` Baseline Caps
   - Depends on: `ST-09010`
-  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `292`
+  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `289`
 - `ST-09012` - Remove Package Export-Map Build Warnings
   - Depends on: `ST-09011`
   - Rationale: `skills`, `tools`, and `testing` package metadata still emit easy-to-fix `exports.types` ordering warnings during build


### PR DESCRIPTION
## Story
- ST-09010: Strengthen Plan-Execute Agent Routing Typing

## What Changed
- removed avoidable `as any` usage from `packages/patterns/src/plan-execute/agent.ts` around conditional route callbacks and compile return handling
- replaced inline route wiring with typed route maps that preserve planner, executor, replanner, finisher, and terminal error transitions
- added focused route-flow tests in `packages/patterns/tests/plan-execute/agent.test.ts` for both replanner outcomes while keeping compiled-agent invocation coverage in the existing integration suite
- recorded warning deltas, validation, and tracker updates in `docs/st09010-plan-execute-routing-typing.md` and the EP-09 planning files

## Acceptance Criteria Coverage
- `packages/patterns/src/plan-execute/agent.ts` no longer uses avoidable `as any` for route wiring or compile return handling
- route typing still supports planner, executor, replanner, finisher, and terminal error flows with behavior preserved by focused route tests
- focused tests now cover executor -> replanner -> executor and executor -> replanner -> planner flows, and compiled agent invocation remains covered by integration tests
- explicit-`any` warning deltas are documented in `docs/st09010-plan-execute-routing-typing.md`
- story-specific documentation was added at `docs/st09010-plan-execute-routing-typing.md`

## Validation Performed
- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
- `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/tests/plan-execute/agent.test.ts`
- `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/integration.test.ts`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
- `pnpm lint` -> exit `0` (warnings only)

## Status
Ready for review.
