### PR TITLE
ST-09011: Tighten explicit-any baseline caps

### DIFF
--- a/docs/st09011-explicit-any-baseline-tightening.md
+++ b/docs/st09011-explicit-any-baseline-tightening.md
@@ -9,9 +9,9 @@ Tightened the committed `@typescript-eslint/no-explicit-any` baseline caps so th
 | File | Change |
 |------|--------|
 | `scripts/no-explicit-any-baseline.json` | Updated the total `maxWarnings` cap from `496` to `289`, refreshed per-package caps to the current measured counts, and stamped the baseline snapshot date to `2026-03-23`. |
-| `planning/kanban-queue.md` | Moved ST-09011 into active execution while tightening the queue rationale around baseline enforcement. |
-| `planning/epics-and-stories.md` | Updated ST-09011 status and phase-chain sequencing to reflect active execution. |
-| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker while the baseline-tightening work is in progress. |
+| `planning/kanban-queue.md` | Moved ST-09011 from `Ready` to `In Review` and aligned the queue summary counts with the actual sections. |
+| `planning/epics-and-stories.md` | Updated ST-09011 status and phase-chain sequencing to reflect review-ready state. |
+| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker from `Ready` to `In Review` for the review-ready baseline-tightening work. |
 
 ## Baseline Cap Delta
 

--- a/docs/st09011-explicit-any-baseline-tightening.md
+++ b/docs/st09011-explicit-any-baseline-tightening.md
@@ -27,11 +27,21 @@ Tightened the committed `@typescript-eslint/no-explicit-any` baseline caps so th
 
 ```bash
 pnpm lint:explicit-any:baseline
+pnpm test --run
+pnpm lint
 ```
 
 Baseline result:
 - `289/289` warnings
 - `cli 24/24`, `core 119/119`, `patterns 28/28`, `skills 0/0`, `testing 51/51`, `tools 67/67`
+
+Full-suite result:
+- `152` files passed, `16` skipped
+- `2119` tests passed, `286` skipped
+
+Lint result:
+- `pnpm lint` exited `0`
+- Existing workspace warnings remain outside this story's touched baseline file
 
 ## Test Impact
 
@@ -39,4 +49,4 @@ No source runtime behavior changed. This story tightens a lint-baseline data fil
 
 ## Status
 
-Implementation in progress on `codex/chore/st-09011-explicit-any-baseline-tightening`.
+Ready for review on `codex/chore/st-09011-explicit-any-baseline-tightening`.

--- a/docs/st09011-explicit-any-baseline-tightening.md
+++ b/docs/st09011-explicit-any-baseline-tightening.md
@@ -1,0 +1,42 @@
+# ST-09011: Tighten Explicit-`any` Baseline Caps
+
+## Summary
+
+Tightened the committed `@typescript-eslint/no-explicit-any` baseline caps so the no-regression guard now reflects the current measured floor instead of stale historical allowance values.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `scripts/no-explicit-any-baseline.json` | Updated the total `maxWarnings` cap from `496` to `289`, refreshed per-package caps to the current measured counts, and stamped the baseline snapshot date to `2026-03-23`. |
+| `planning/kanban-queue.md` | Moved ST-09011 into active execution while tightening the queue rationale around baseline enforcement. |
+| `planning/epics-and-stories.md` | Updated ST-09011 status and phase-chain sequencing to reflect active execution. |
+| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker while the baseline-tightening work is in progress. |
+
+## Baseline Cap Delta
+
+- Total cap: `496 -> 289`
+- `core`: `256 -> 119`
+- `tools`: `82 -> 67`
+- `patterns`: `82 -> 28`
+- `testing`: `51 -> 51` (unchanged)
+- `cli`: `25 -> 24`
+- `skills`: `0 -> 0` (unchanged)
+
+## Validation Performed
+
+```bash
+pnpm lint:explicit-any:baseline
+```
+
+Baseline result:
+- `289/289` warnings
+- `cli 24/24`, `core 119/119`, `patterns 28/28`, `skills 0/0`, `testing 51/51`, `tools 67/67`
+
+## Test Impact
+
+No source runtime behavior changed. This story tightens a lint-baseline data file and validates it with the existing baseline command instead of adding new automated tests.
+
+## Status
+
+Implementation in progress on `codex/chore/st-09011-explicit-any-baseline-tightening`.

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -402,6 +402,7 @@ Implementation notes:
 - Full validation passed:
   - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0` (warnings only)
+- PR #73 marked ready after final tracker/body refresh
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -376,21 +376,26 @@ Implementation notes:
 
 ## ST-09011: Tighten Explicit-`any` Baseline Caps
 
-**Branch:** `chore/st-09011-explicit-any-baseline-tightening`
+**Branch:** `codex/chore/st-09011-explicit-any-baseline-tightening`
 
 ### Checklist
-- [ ] Create branch `chore/st-09011-explicit-any-baseline-tightening`
+- [x] Create branch `codex/chore/st-09011-explicit-any-baseline-tightening`
 - [ ] Create draft PR with story ID in title
-- [ ] Update `scripts/no-explicit-any-baseline.json` to the current improved total and per-package warning caps
-- [ ] Verify `pnpm lint:explicit-any:baseline` passes locally with the tightened counts and record the command output
-- [ ] Record before/after baseline cap values and rationale in story docs
-- [ ] Add or update story documentation at `docs/st09011-explicit-any-baseline-tightening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Update `scripts/no-explicit-any-baseline.json` to the current improved total and per-package warning caps
+- [x] Verify `pnpm lint:explicit-any:baseline` passes locally with the tightened counts and record the command output
+- [x] Record before/after baseline cap values and rationale in story docs
+- [x] Add or update story documentation at `docs/st09011-explicit-any-baseline-tightening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+- Focused validation passed:
+  - `pnpm lint:explicit-any:baseline` -> `289/289` warnings
+  - Per-package caps: `cli 24/24`, `core 119/119`, `patterns 28/28`, `skills 0/0`, `testing 51/51`, `tools 67/67`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -380,22 +380,28 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `codex/chore/st-09011-explicit-any-baseline-tightening`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Update `scripts/no-explicit-any-baseline.json` to the current improved total and per-package warning caps
 - [x] Verify `pnpm lint:explicit-any:baseline` passes locally with the tightened counts and record the command output
 - [x] Record before/after baseline cap values and rationale in story docs
 - [x] Add or update story documentation at `docs/st09011-explicit-any-baseline-tightening.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
+- `40e6417` `chore(st-09011): tighten explicit-any baseline caps`
+- Draft PR #73: https://github.com/TVScoundrel/agentforge/pull/73
 - Focused validation passed:
   - `pnpm lint:explicit-any:baseline` -> `289/289` warnings
   - Per-package caps: `cli 24/24`, `core 119/119`, `patterns 28/28`, `skills 0/0`, `testing 51/51`, `tools 67/67`
+- Test impact: no new automated tests were added because this story only tightens the existing lint-baseline data file; coverage comes from the baseline command plus full-suite/lint verification
+- Full validation passed:
+  - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0` (warnings only)
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1004,7 +1004,7 @@
 **Priority:** P1 (High)
 **Estimate:** 2 hours
 **Dependencies:** ST-09010
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `scripts/no-explicit-any-baseline.json` is updated to the current post-EP-09 warning totals and per-package caps
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (In Progress) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (In Review) → ST-09012 (Backlog)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1004,7 +1004,7 @@
 **Priority:** P1 (High)
 **Estimate:** 2 hours
 **Dependencies:** ST-09010
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `scripts/no-explicit-any-baseline.json` is updated to the current post-EP-09 warning totals and per-package caps
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Ready) → ST-09012 (Backlog)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (In Progress) → ST-09012 (Backlog)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09011 (In Progress)
+**Active Story:** ST-09011 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09011 (Ready)
+**Active Story:** ST-09011 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
@@ -14,10 +14,7 @@
 
 ## Ready
 
-- `ST-09011` - Tighten Explicit-`any` Baseline Caps
-  - Epic: `EP-09`
-  - Priority: `P1`
-  - Rationale: the committed baseline still allows `496` warnings while the current measured count is `289`
+_No stories currently ready_
 
 ---
 
@@ -29,7 +26,10 @@ _No stories currently in review_
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09011` - Tighten Explicit-`any` Baseline Caps
+  - Epic: `EP-09`
+  - Priority: `P1`
+  - Rationale: aligning the committed `no-explicit-any` guard with the measured `289` warning floor so regressions fail immediately
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -8,7 +8,7 @@
 - **In Progress:** 0 stories
 - **In Review:** 1 story
 - **Blocked:** 0 stories
-- **Backlog:** 3 stories
+- **Backlog:** 1 story
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
 
@@ -20,16 +20,16 @@ _No stories currently ready_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09011` - Tighten Explicit-`any` Baseline Caps
+  - Epic: `EP-09`
+  - Priority: `P1`
+  - Rationale: the committed baseline now matches the measured `289` warning floor and is ready for review before unblocking the export-map cleanup story
 
 ---
 
 ## In Progress
 
-- `ST-09011` - Tighten Explicit-`any` Baseline Caps
-  - Epic: `EP-09`
-  - Priority: `P1`
-  - Rationale: aligning the committed `no-explicit-any` guard with the measured `289` warning floor so regressions fail immediately
+_No stories currently in progress_
 
 ---
 

--- a/scripts/no-explicit-any-baseline.json
+++ b/scripts/no-explicit-any-baseline.json
@@ -1,14 +1,14 @@
 {
   "ruleId": "@typescript-eslint/no-explicit-any",
   "target": "packages/**/src/**/*.ts",
-  "generatedAt": "2026-03-06",
-  "maxWarnings": 496,
+  "generatedAt": "2026-03-23",
+  "maxWarnings": 289,
   "byPackage": {
-    "core": 256,
-    "tools": 82,
-    "patterns": 82,
+    "core": 119,
+    "tools": 67,
+    "patterns": 28,
     "testing": 51,
-    "cli": 25,
+    "cli": 24,
     "skills": 0
   }
 }


### PR DESCRIPTION
## Story
- ST-09011: Tighten Explicit-`any` Baseline Caps

## What Changed
- tightened `scripts/no-explicit-any-baseline.json` to the current measured warning floor instead of the stale historical cap
- reduced the total baseline from `496` to `289`
- updated package caps to `core 119`, `tools 67`, `patterns 28`, `testing 51`, `cli 24`, `skills 0`
- recorded the cap delta, validation evidence, and no-runtime-change scope in `docs/st09011-explicit-any-baseline-tightening.md`
- moved ST-09011 to `In Review` in the EP-09 planning trackers

## Acceptance Criteria Coverage
- `scripts/no-explicit-any-baseline.json` now reflects the current post-EP-09 warning totals and per-package caps
- `pnpm lint:explicit-any:baseline` passes locally with the tightened counts (`289/289`)
- story docs record before/after cap values and the command output used to derive them
- no source runtime files changed as part of this baseline-tightening story
- story documentation was added at `docs/st09011-explicit-any-baseline-tightening.md`

## Validation Performed
- `pnpm lint:explicit-any:baseline` -> `289/289` warnings
- `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
- `pnpm lint` -> exit `0` (warnings only)

## Status
Ready for review.
