### PR TITLE
ST-09012: Remove package export-map build warnings

### DIFF
--- a/docs/st09012-package-export-map-warning-cleanup.md
+++ b/docs/st09012-package-export-map-warning-cleanup.md
@@ -11,9 +11,9 @@ Cleaned up package export-map condition ordering in the published `@agentforge/s
 | `packages/skills/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, matching Node package condition precedence and eliminating the build warning. |
 | `packages/tools/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime entrypoints while removing the metadata warning. |
 | `packages/testing/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime/test entrypoints while removing the metadata warning. |
-| `planning/kanban-queue.md` | Moved ST-09012 from `Ready` to `In Progress` during execution. |
-| `planning/epics-and-stories.md` | Updated ST-09012 status from `Ready` to `In Progress`. |
-| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker from `Ready` to `In Progress`. |
+| `planning/kanban-queue.md` | Moved ST-09012 from `Ready` to `In Review` during execution. |
+| `planning/epics-and-stories.md` | Updated ST-09012 status from `Ready` to `In Review`. |
+| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker from `Ready` to `In Review`. |
 
 ## Warning Removed
 

--- a/docs/st09012-package-export-map-warning-cleanup.md
+++ b/docs/st09012-package-export-map-warning-cleanup.md
@@ -1,0 +1,74 @@
+# ST-09012: Remove Package Export-Map Build Warnings
+
+## Summary
+
+Cleaned up package export-map condition ordering in the published `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing` manifests so routine builds no longer emit the avoidable `"types" condition will never be used` warning.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/skills/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, matching Node package condition precedence and eliminating the build warning. |
+| `packages/tools/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime entrypoints while removing the metadata warning. |
+| `packages/testing/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime/test entrypoints while removing the metadata warning. |
+| `planning/kanban-queue.md` | Moved ST-09012 from `Ready` to `In Progress` during execution. |
+| `planning/epics-and-stories.md` | Updated ST-09012 status from `Ready` to `In Progress`. |
+| `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker from `Ready` to `In Progress`. |
+
+## Warning Removed
+
+The same warning was present in all three touched packages before this change:
+
+```text
+The condition "types" here will never be used as it comes after both "import" and "require"
+```
+
+Reordering the condition keys removes that warning without changing the resolved file targets:
+
+- `types` still resolves to `./dist/index.d.ts`
+- `import` still resolves to `./dist/index.js`
+- `require` still resolves to `./dist/index.cjs`
+
+## Validation Performed
+
+```bash
+pnpm --filter @agentforge/skills build
+pnpm --filter @agentforge/tools build
+pnpm --filter @agentforge/testing build
+node <temp>/runtime.cjs
+node <temp>/runtime.mjs
+pnpm exec tsc --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck --noEmit <temp>/index.ts
+vitest run --config <temp>/vitest.config.ts
+```
+
+Focused validation results:
+
+- The `exports.types` warning no longer appears in the builds for `@agentforge/skills`, `@agentforge/tools`, or `@agentforge/testing`.
+- CJS and ESM package entrypoint smoke checks passed for `@agentforge/skills` and `@agentforge/tools`.
+- TypeScript entrypoint resolution passed for `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing`.
+- A disposable Vitest smoke test passed for `@agentforge/testing`, which is the correct runtime context for that package.
+
+## Test Impact
+
+No repository source runtime logic changed. This story only adjusts package metadata ordering, so focused build and consumer-entrypoint smoke checks provide the meaningful regression coverage rather than new committed tests.
+
+## Full Validation
+
+```bash
+pnpm test --run
+pnpm lint
+```
+
+Full-suite result:
+
+- `152` files passed, `16` skipped
+- `2119` tests passed, `286` skipped
+
+Lint result:
+
+- `pnpm lint` exited `0`
+- Existing workspace warnings remain outside this story's touched package metadata files
+
+## Status
+
+Ready for review on `codex/fix/st-09012-package-export-map-warning-cleanup`.

--- a/docs/st09012-package-export-map-warning-cleanup.md
+++ b/docs/st09012-package-export-map-warning-cleanup.md
@@ -8,9 +8,9 @@ Cleaned up package export-map condition ordering in the published `@agentforge/s
 
 | File | Change |
 |------|--------|
-| `packages/skills/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, matching Node package condition precedence and eliminating the build warning. |
-| `packages/tools/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime entrypoints while removing the metadata warning. |
-| `packages/testing/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime/test entrypoints while removing the metadata warning. |
+| `packages/skills/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, so TypeScript and related tooling can select the declaration entrypoint before the runtime conditions, eliminating the build warning. |
+| `packages/tools/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime entrypoints while ensuring TypeScript/tooling sees the declaration entrypoint first. |
+| `packages/testing/package.json` | Reordered the root export conditions to put `types` before `import` and `require`, preserving the same runtime/test entrypoints while ensuring TypeScript/tooling sees the declaration entrypoint first. |
 | `planning/kanban-queue.md` | Moved ST-09012 from `Ready` to `In Review` during execution. |
 | `planning/epics-and-stories.md` | Updated ST-09012 status from `Ready` to `In Review`. |
 | `planning/features/09-solid-micro-refactors-feature-plan.md` | Updated the EP-09 active-story marker from `Ready` to `In Review`. |

--- a/docs/st09012-package-export-map-warning-cleanup.md
+++ b/docs/st09012-package-export-map-warning-cleanup.md
@@ -38,7 +38,7 @@ pnpm --filter @agentforge/testing build
 node <temp>/runtime.cjs
 node <temp>/runtime.mjs
 pnpm exec tsc --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck --noEmit <temp>/index.ts
-vitest run --config <temp>/vitest.config.ts
+pnpm exec vitest run --config <temp>/vitest.config.ts
 ```
 
 Focused validation results:

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -413,18 +413,31 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `codex/fix/st-09012-package-export-map-warning-cleanup`
-- [ ] Create draft PR with story ID in title
-- [ ] Remove the current `exports.types` ordering build warnings from `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json`
-- [ ] Preserve published import/require/types resolution behavior for the touched packages
-- [ ] Add/update focused validation for package builds and smoke-level resolution checks
-- [ ] Record removed warnings and package-metadata rationale in story docs
-- [ ] Add or update story documentation at `docs/st09012-package-export-map-warning-cleanup.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create draft PR with story ID in title
+- [x] Remove the current `exports.types` ordering build warnings from `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json`
+- [x] Preserve published import/require/types resolution behavior for the touched packages
+- [x] Add/update focused validation for package builds and smoke-level resolution checks
+- [x] Record removed warnings and package-metadata rationale in story docs
+- [x] Add or update story documentation at `docs/st09012-package-export-map-warning-cleanup.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
 - Branch created from `main` on 2026-03-23: `codex/fix/st-09012-package-export-map-warning-cleanup`
+- Draft PR #74: https://github.com/TVScoundrel/agentforge/pull/74
+- Focused validation passed:
+  - `pnpm --filter @agentforge/skills build`
+  - `pnpm --filter @agentforge/tools build`
+  - `pnpm --filter @agentforge/testing build`
+  - CJS/ESM smoke imports passed for `@agentforge/skills` and `@agentforge/tools`
+  - `pnpm exec tsc --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck --noEmit <temp>/index.ts`
+  - disposable Vitest smoke test passed for `@agentforge/testing`
+- Test impact: no committed automated tests were added because this story only changes package metadata ordering; focused build and consumer-entrypoint smoke checks cover the regression surface more directly than repository test additions
+- Full validation passed:
+  - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0` (warnings only)
+- PR #74 marked ready after final tracker/body refresh

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -441,3 +441,4 @@ Implementation notes:
   - `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0` (warnings only)
 - PR #74 marked ready after final tracker/body refresh
+- Review fix: `75e4935` `docs(st-09012): align review-state tracker wording`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -443,3 +443,4 @@ Implementation notes:
 - PR #74 marked ready after final tracker/body refresh
 - Review fix: `75e4935` `docs(st-09012): align review-state tracker wording`
 - Review fix: pending terminology clarification for `types` resolution wording
+- Review fix: pending `pnpm exec vitest` wording alignment in story doc validation list

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -412,7 +412,7 @@ Implementation notes:
 **Branch:** `codex/fix/st-09012-package-export-map-warning-cleanup`
 
 ### Checklist
-- [ ] Create branch `codex/fix/st-09012-package-export-map-warning-cleanup`
+- [x] Create branch `codex/fix/st-09012-package-export-map-warning-cleanup`
 - [ ] Create draft PR with story ID in title
 - [ ] Remove the current `exports.types` ordering build warnings from `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json`
 - [ ] Preserve published import/require/types resolution behavior for the touched packages
@@ -425,3 +425,6 @@ Implementation notes:
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+- Branch created from `main` on 2026-03-23: `codex/fix/st-09012-package-export-map-warning-cleanup`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -442,3 +442,4 @@ Implementation notes:
   - `pnpm lint` -> exit `0` (warnings only)
 - PR #74 marked ready after final tracker/body refresh
 - Review fix: `75e4935` `docs(st-09012): align review-state tracker wording`
+- Review fix: pending terminology clarification for `types` resolution wording

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1021,7 +1021,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09011
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` no longer emit the current `"types" condition will never be used` build warnings

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1021,7 +1021,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09011
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` no longer emit the current `"types" condition will never be used` build warnings

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1051,4 +1051,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Ready)
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (In Review)

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09012 (Ready)
+**Active Story:** ST-09012 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-23
-**Active Story:** ST-09012 (In Progress)
+**Active Story:** ST-09012 (In Review)
 
 ---
 
@@ -40,7 +40,6 @@ Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit
 Top runtime hotspots informing this feature slice:
 
 1. `packages/patterns/src/plan-execute/types.ts` still carries an easy two-warning `Tool<any, any>[]` boundary in the active EP-09 area
-2. `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` still emit `exports.types` ordering warnings during `pnpm build`
 
 Recent improvement snapshot:
 
@@ -52,6 +51,7 @@ Recent improvement snapshot:
 - `ST-09009` has reduced explicit-`any` warnings in `packages/tools/src/agent/ask-human/tool.ts` from `3` to `0` so far, improving the workspace baseline from `295` to `292` and the `tools` baseline from `70` to `67`.
 - `ST-09010` has reduced explicit-`any` warnings in `packages/patterns/src/plan-execute/agent.ts` from `3` to `0`, improving the workspace baseline from `292` to `289` and the `patterns` baseline from `31` to `28`.
 - `ST-09011` tightened the committed explicit-`any` baseline caps from `496` to the current measured `289`, aligning the no-regression gate with the post-EP-09 warning floor.
+- `ST-09012` removed the remaining `exports.types` ordering warnings from `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing`, quieting the routine build output without changing published entrypoint targets.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,16 +20,16 @@ _No stories currently ready_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09012` - Remove Package Export-Map Build Warnings
+  - Epic: `EP-09`
+  - Priority: `P2`
+  - Rationale: export-map cleanup is implemented and validated, and is ready for review before concluding the EP-09 follow-on cleanup slice
 
 ---
 
 ## In Progress
 
-- `ST-09012` - Remove Package Export-Map Build Warnings
-  - Epic: `EP-09`
-  - Priority: `P2`
-  - Rationale: export-map cleanup is active to remove the remaining easy package metadata warnings from routine builds
+_No stories currently in progress_
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,10 +14,7 @@
 
 ## Ready
 
-- `ST-09012` - Remove Package Export-Map Build Warnings
-  - Epic: `EP-09`
-  - Priority: `P2`
-  - Rationale: baseline tightening is merged, so the remaining low-effort release-quality cleanup can move straight into execution
+_No stories currently ready_
 
 ---
 
@@ -29,7 +26,10 @@ _No stories currently in review_
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09012` - Remove Package Export-Map Build Warnings
+  - Epic: `EP-09`
+  - Priority: `P2`
+  - Rationale: export-map cleanup is active to remove the remaining easy package metadata warnings from routine builds
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09012: Remove Package Export-Map Build Warnings

## What Changed
- reordered the root `exports` condition keys in `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing` so `types` is evaluated before `import` and `require`
- removed the repeated `"types" condition will never be used` build warning from those three published package manifests without changing the resolved entrypoint files
- recorded the focused packaging validation and moved ST-09012 to `In Review` in the EP-09 planning trackers

## Acceptance Criteria Coverage
- [x] `packages/skills/package.json`, `packages/tools/package.json`, and `packages/testing/package.json` no longer emit the current `"types" condition will never be used` build warnings
- [x] Export-map cleanup preserves published import/require/types resolution for consumers
- [x] Focused validation covers package builds and a smoke-level resolution check for the touched packages
- [x] Story docs capture the exact warnings removed and any package-metadata rationale
- [x] Added story documentation at `docs/st09012-package-export-map-warning-cleanup.md`

## Validation Performed
```bash
pnpm --filter @agentforge/skills build
pnpm --filter @agentforge/tools build
pnpm --filter @agentforge/testing build
pnpm test --run
pnpm lint
```

Focused smoke validation:
- CJS and ESM imports passed for `@agentforge/skills` and `@agentforge/tools`
- `pnpm exec tsc --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck --noEmit <temp>/index.ts`
- disposable Vitest smoke test passed for `@agentforge/testing`

Full validation results:
- `pnpm test --run` -> `152 passed | 16 skipped` files; `2119 passed | 286 skipped` tests
- `pnpm lint` -> exit `0` (warnings only)

## Status
Ready for review
