### PR TITLE
ST-09014: Tighten plan-execute shared type boundaries

### DIFF
--- a/docs/st09014-plan-execute-shared-type-boundaries.md
+++ b/docs/st09014-plan-execute-shared-type-boundaries.md
@@ -35,11 +35,13 @@ Tightened the shared plan-execute contracts so the exported executor/agent confi
 - Tool execution still works with the existing `toolBuilder()` output. The runtime erasure is now expressed explicitly via the exported `PlanExecuteTool` contract instead of `any`.
 - Step arguments and completed-step results remain runtime-flexible because the Zod schemas still accept arbitrary values; the TypeScript surface is now `unknown`-based instead of `any`-based.
 - The new `contracts.typecheck.ts` file keeps the plan-execute config inference under the normal patterns package `typecheck` command, without relying on test-only files.
+- `ExecutorConfig.model`, `ExecutorConfig.parallel`, and `ReplannerConfig.replanThreshold` remain in the public config surface for now, but the runtime nodes explicitly warn that those options are currently unsupported and ignored.
 
 ## Validation
 
 - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
 - `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts`
+- `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/nodes.test.ts`
 - `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/integration.test.ts` -> `19 passed`
 - `pnpm lint:explicit-any:baseline`
 - `pnpm test --run` -> `152 passed | 16 skipped` files; `2126 passed | 286 skipped` tests

--- a/docs/st09014-plan-execute-shared-type-boundaries.md
+++ b/docs/st09014-plan-execute-shared-type-boundaries.md
@@ -40,7 +40,6 @@ Tightened the shared plan-execute contracts so the exported executor/agent confi
 ## Validation
 
 - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
-- `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts`
 - `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/nodes.test.ts`
 - `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/integration.test.ts` -> `19 passed`
 - `pnpm lint:explicit-any:baseline`

--- a/docs/st09014-plan-execute-shared-type-boundaries.md
+++ b/docs/st09014-plan-execute-shared-type-boundaries.md
@@ -1,0 +1,47 @@
+# ST-09014: Tighten Plan-Execute Shared Type Boundaries
+
+## Summary
+
+Tightened the shared plan-execute contracts so the exported executor/agent config no longer depends on `Tool<any, any>[]`, and replaced the open-ended step argument/result schema helpers with `unknown`-based aliases that preserve current runtime validation behavior.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/patterns/src/plan-execute/types.ts` | Replaced the broad `Tool<any, any>[]` executor boundary with a plan-execute-specific runtime tool contract and generic executor/agent config typing |
+| `packages/patterns/src/plan-execute/schemas.ts` | Introduced shared `PlanStepArguments`/`PlanStepResult` aliases and changed the step argument/result schemas from `z.any()`-based typing to `z.unknown()`-based contracts |
+| `packages/patterns/src/plan-execute/nodes.ts` | Localized the runtime tool invocation widening to a single helper and removed the executor’s `result: any` boundary |
+| `packages/patterns/src/plan-execute/agent.ts` | Preserved tool-list inference through `createPlanExecuteAgent(...)` while keeping the runtime execution path erased and compatible |
+| `packages/patterns/src/plan-execute/contracts.typecheck.ts` | Added a source-included type-level regression file that locks in concrete tool preservation through `ExecutorConfig` and `PlanExecuteAgentConfig` |
+| `packages/patterns/tests/plan-execute/state.test.ts` | Added focused coverage proving nested step arguments and flexible completed-step results still validate after the schema helper tightening |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/patterns/src/plan-execute/types.ts`: `1 -> 0` (`-1`)
+- `packages/patterns/src/plan-execute/nodes.ts`: `1 -> 0` (`-1`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `289 -> 278` (`-11`)
+- `patterns` package: `28 -> 25` (`-3`)
+
+(Captured with `pnpm lint:explicit-any:baseline` on 2026-03-24.)
+
+## Compatibility Notes
+
+- Planner, executor, replanner, and finisher runtime behavior is unchanged; only the shared type surfaces and schema helper typings were narrowed.
+- Tool execution still works with the existing `toolBuilder()` output. The runtime erasure is now expressed explicitly via the exported `PlanExecuteTool` contract instead of `any`.
+- Step arguments and completed-step results remain runtime-flexible because the Zod schemas still accept arbitrary values; the TypeScript surface is now `unknown`-based instead of `any`-based.
+- The new `contracts.typecheck.ts` file keeps the plan-execute config inference under the normal patterns package `typecheck` command, without relying on test-only files.
+
+## Validation
+
+- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts`
+- `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/integration.test.ts` -> `19 passed`
+
+## Test Impact
+
+Expanded focused automated coverage for type-driven plan-execute configuration and schema compatibility. Full-suite and lint validation remain pending until the story is finalized.

--- a/docs/st09014-plan-execute-shared-type-boundaries.md
+++ b/docs/st09014-plan-execute-shared-type-boundaries.md
@@ -41,7 +41,10 @@ Tightened the shared plan-execute contracts so the exported executor/agent confi
 - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
 - `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts`
 - `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/integration.test.ts` -> `19 passed`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run` -> `152 passed | 16 skipped` files; `2126 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
 
 ## Test Impact
 
-Expanded focused automated coverage for type-driven plan-execute configuration and schema compatibility. Full-suite and lint validation remain pending until the story is finalized.
+Expanded focused automated coverage for type-driven plan-execute configuration and schema compatibility. The story also passed full-suite and workspace lint validation before review handoff.

--- a/packages/patterns/src/plan-execute/agent.ts
+++ b/packages/patterns/src/plan-execute/agent.ts
@@ -9,7 +9,7 @@
 import { StateGraph, END } from '@langchain/langgraph';
 import { PlanExecuteState, type PlanExecuteStateType } from './state.js';
 import { createPlannerNode, createExecutorNode, createReplannerNode, createFinisherNode } from './nodes.js';
-import type { PlanExecuteAgentConfig, PlanExecuteRoute } from './types.js';
+import type { PlanExecuteAgentConfig, PlanExecuteRoute, PlanExecuteTool } from './types.js';
 
 const executorRouteMap = {
   execute: 'executor',
@@ -84,7 +84,9 @@ const replannerRouteMap = {
  * );
  * ```
  */
-export function createPlanExecuteAgent(config: PlanExecuteAgentConfig) {
+export function createPlanExecuteAgent<TTool extends PlanExecuteTool = PlanExecuteTool>(
+  config: PlanExecuteAgentConfig<TTool>
+) {
   const {
     planner,
     executor,

--- a/packages/patterns/src/plan-execute/agent.ts
+++ b/packages/patterns/src/plan-execute/agent.ts
@@ -46,12 +46,10 @@ const replannerRouteMap = {
  *     maxSteps: 5
  *   },
  *   executor: {
- *     tools: [searchTool, calculatorTool],
- *     parallel: false
+ *     tools: [searchTool, calculatorTool]
  *   },
  *   replanner: {
- *     model: new ChatOpenAI({ model: 'gpt-4' }),
- *     replanThreshold: 0.7
+ *     model: new ChatOpenAI({ model: 'gpt-4' })
  *   }
  * });
  *

--- a/packages/patterns/src/plan-execute/contracts.typecheck.ts
+++ b/packages/patterns/src/plan-execute/contracts.typecheck.ts
@@ -1,0 +1,38 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { ToolCategory, toolBuilder } from '@agentforge/core';
+import { z } from 'zod';
+import { createPlanExecuteAgent } from './agent.js';
+import type { ExecutorConfig, PlanExecuteAgentConfig } from './types.js';
+
+type Equal<TLeft, TRight> =
+  (<T>() => T extends TLeft ? 1 : 2) extends
+    (<T>() => T extends TRight ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+const searchTool = toolBuilder()
+  .name('search-tool')
+  .description('Search for documents')
+  .category(ToolCategory.WEB)
+  .schema(z.object({ query: z.string() }))
+  .implement(async ({ query }) => `result:${query}`)
+  .build();
+
+const executorConfig = {
+  tools: [searchTool],
+} satisfies ExecutorConfig<typeof searchTool>;
+
+const preservesConcreteTool: Expect<
+  Equal<(typeof executorConfig.tools)[number], typeof searchTool>
+> = true;
+void preservesConcreteTool;
+
+declare const model: BaseChatModel;
+
+const agentConfig = {
+  planner: { model },
+  executor: executorConfig,
+} satisfies PlanExecuteAgentConfig<typeof searchTool>;
+
+createPlanExecuteAgent(agentConfig);

--- a/packages/patterns/src/plan-execute/contracts.typecheck.ts
+++ b/packages/patterns/src/plan-execute/contracts.typecheck.ts
@@ -15,7 +15,7 @@ const searchTool = toolBuilder()
   .name('search-tool')
   .description('Search for documents')
   .category(ToolCategory.WEB)
-  .schema(z.object({ query: z.string() }))
+  .schema(z.object({ query: z.string().describe('Search query to execute') }))
   .implement(async ({ query }) => `result:${query}`)
   .build();
 

--- a/packages/patterns/src/plan-execute/index.ts
+++ b/packages/patterns/src/plan-execute/index.ts
@@ -30,6 +30,7 @@ export type {
   ExecutorConfig,
   ReplannerConfig,
   PlanExecuteAgentConfig,
+  PlanExecuteTool,
   PlanExecuteNode,
   PlanExecuteRoute,
   PlanExecuteRouter,
@@ -43,7 +44,9 @@ export {
   ReplanDecisionSchema,
   ExecutionStatusSchema,
   type PlanStep,
+  type PlanStepArguments,
   type CompletedStep,
+  type PlanStepResult,
   type Plan,
   type ReplanDecision,
   type ExecutionStatus,
@@ -56,4 +59,3 @@ export {
   PLANNING_PROMPT_TEMPLATE,
   REPLANNING_PROMPT_TEMPLATE,
 } from './prompts.js';
-

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -239,14 +239,22 @@ export function createExecutorNode(config: ExecutorConfig) {
 
             // Execute with timeout
             const startTime = Date.now();
-            const timeoutPromise = new Promise((_, reject) =>
-              setTimeout(() => reject(new Error('Step execution timeout')), stepTimeout)
-            );
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-            result = await Promise.race([
-              invokePlanExecuteTool(tool, currentStep.args || {}),
-              timeoutPromise,
-            ]);
+            try {
+              const timeoutPromise = new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => reject(new Error('Step execution timeout')), stepTimeout);
+              });
+
+              result = await Promise.race([
+                invokePlanExecuteTool(tool, currentStep.args || {}),
+                timeoutPromise,
+              ]);
+            } finally {
+              if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+              }
+            }
 
             const executionTime = Date.now() - startTime;
 

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -123,9 +123,21 @@ export function createPlannerNode(config: PlannerConfig) {
 export function createExecutorNode(config: ExecutorConfig) {
   const {
     tools,
+    model,
+    parallel,
     stepTimeout = 30000,
     enableDeduplication = true,
   } = config;
+
+  if (typeof model !== 'undefined') {
+    executorLogger.warn('ExecutorConfig.model is currently unsupported and will be ignored');
+  }
+
+  if (typeof parallel !== 'undefined') {
+    executorLogger.warn('ExecutorConfig.parallel is currently unsupported and will be ignored', {
+      parallel,
+    });
+  }
 
   return async (state: PlanExecuteStateType): Promise<Partial<PlanExecuteStateType>> => {
     const { plan, currentStepIndex = 0, pastSteps = [], iteration = 0 } = state;
@@ -308,8 +320,15 @@ export function createExecutorNode(config: ExecutorConfig) {
 export function createReplannerNode(config: ReplannerConfig) {
   const {
     model,
+    replanThreshold,
     systemPrompt = DEFAULT_REPLANNER_SYSTEM_PROMPT,
   } = config;
+
+  if (typeof replanThreshold !== 'undefined') {
+    replannerLogger.warn('ReplannerConfig.replanThreshold is currently unsupported and will be ignored', {
+      replanThreshold,
+    });
+  }
 
   return async (state: PlanExecuteStateType): Promise<Partial<PlanExecuteStateType>> => {
     const startTime = Date.now();

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -8,8 +8,8 @@
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import type { PlanExecuteStateType } from './state.js';
-import type { PlannerConfig, ExecutorConfig, ReplannerConfig } from './types.js';
-import type { Plan, CompletedStep, PlanStep } from './schemas.js';
+import type { PlannerConfig, ExecutorConfig, ReplannerConfig, PlanExecuteTool } from './types.js';
+import type { Plan, CompletedStep, PlanStep, PlanStepArguments, PlanStepResult } from './schemas.js';
 import {
   DEFAULT_PLANNER_SYSTEM_PROMPT,
   DEFAULT_REPLANNER_SYSTEM_PROMPT,
@@ -29,6 +29,10 @@ import { handleNodeError } from '../shared/error-handling.js';
 const plannerLogger = createPatternLogger('agentforge:patterns:plan-execute:planner');
 const executorLogger = createPatternLogger('agentforge:patterns:plan-execute:executor');
 const replannerLogger = createPatternLogger('agentforge:patterns:plan-execute:replanner');
+
+function invokePlanExecuteTool(tool: PlanExecuteTool, args: PlanStepArguments): Promise<PlanStepResult> {
+  return (tool.invoke as (input: PlanStepArguments) => Promise<PlanStepResult>)(args);
+}
 
 /**
  * Create a planner node that generates a multi-step plan
@@ -184,7 +188,7 @@ export function createExecutorNode(config: ExecutorConfig) {
       }
 
       // Execute the step
-      let result: any;
+      let result: PlanStepResult;
       let success = true;
       let error: string | undefined;
       let isDuplicate = false;
@@ -231,7 +235,7 @@ export function createExecutorNode(config: ExecutorConfig) {
             );
 
             result = await Promise.race([
-              tool.invoke(currentStep.args || {}),
+              invokePlanExecuteTool(tool, currentStep.args || {}),
               timeoutPromise,
             ]);
 

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -9,13 +9,12 @@
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import type { PlanExecuteStateType } from './state.js';
 import type { PlannerConfig, ExecutorConfig, ReplannerConfig, PlanExecuteTool } from './types.js';
-import type { Plan, CompletedStep, PlanStep, PlanStepArguments, PlanStepResult } from './schemas.js';
+import type { Plan, CompletedStep, PlanStepArguments, PlanStepResult } from './schemas.js';
 import {
   DEFAULT_PLANNER_SYSTEM_PROMPT,
   DEFAULT_REPLANNER_SYSTEM_PROMPT,
   PLANNING_PROMPT_TEMPLATE,
   REPLANNING_PROMPT_TEMPLATE,
-  TOOL_DESCRIPTIONS_TEMPLATE,
   COMPLETED_STEP_TEMPLATE,
   REMAINING_STEP_TEMPLATE,
 } from './prompts.js';
@@ -122,8 +121,6 @@ export function createPlannerNode(config: PlannerConfig) {
 export function createExecutorNode(config: ExecutorConfig) {
   const {
     tools,
-    model,
-    parallel = false,
     stepTimeout = 30000,
     enableDeduplication = true,
   } = config;
@@ -309,7 +306,6 @@ export function createExecutorNode(config: ExecutorConfig) {
 export function createReplannerNode(config: ReplannerConfig) {
   const {
     model,
-    replanThreshold = 0.7,
     systemPrompt = DEFAULT_REPLANNER_SYSTEM_PROMPT,
   } = config;
 

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -30,7 +30,9 @@ const executorLogger = createPatternLogger('agentforge:patterns:plan-execute:exe
 const replannerLogger = createPatternLogger('agentforge:patterns:plan-execute:replanner');
 
 function invokePlanExecuteTool(tool: PlanExecuteTool, args: PlanStepArguments): Promise<PlanStepResult> {
-  return (tool.invoke as (input: PlanStepArguments) => Promise<PlanStepResult>)(args);
+  return (
+    tool.invoke as (this: PlanExecuteTool, input: PlanStepArguments) => Promise<PlanStepResult>
+  ).call(tool, args);
 }
 
 /**

--- a/packages/patterns/src/plan-execute/nodes.ts
+++ b/packages/patterns/src/plan-execute/nodes.ts
@@ -30,9 +30,7 @@ const executorLogger = createPatternLogger('agentforge:patterns:plan-execute:exe
 const replannerLogger = createPatternLogger('agentforge:patterns:plan-execute:replanner');
 
 function invokePlanExecuteTool(tool: PlanExecuteTool, args: PlanStepArguments): Promise<PlanStepResult> {
-  return (
-    tool.invoke as (this: PlanExecuteTool, input: PlanStepArguments) => Promise<PlanStepResult>
-  ).call(tool, args);
+  return tool.invoke.call(tool, args);
 }
 
 /**

--- a/packages/patterns/src/plan-execute/schemas.ts
+++ b/packages/patterns/src/plan-execute/schemas.ts
@@ -9,6 +9,9 @@
 
 import { z } from 'zod';
 
+export type PlanStepArguments = Record<string, unknown>;
+export type PlanStepResult = unknown;
+
 /**
  * Schema for a single step in the plan
  */
@@ -36,7 +39,7 @@ export const PlanStepSchema = z.object({
   /**
    * Optional arguments for the tool
    */
-  args: z.record(z.any()).optional().describe('Arguments to pass to the tool'),
+  args: z.record(z.string(), z.unknown()).optional().describe('Arguments to pass to the tool'),
 });
 
 export type PlanStep = z.infer<typeof PlanStepSchema>;
@@ -53,7 +56,7 @@ export const CompletedStepSchema = z.object({
   /**
    * The result of executing the step
    */
-  result: z.any().describe('The result of executing the step'),
+  result: z.unknown().describe('The result of executing the step'),
 
   /**
    * Whether the step succeeded
@@ -141,4 +144,3 @@ export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>;
 export {
   PlanStepSchema as default,
 };
-

--- a/packages/patterns/src/plan-execute/types.ts
+++ b/packages/patterns/src/plan-execute/types.ts
@@ -8,12 +8,13 @@
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
-import type { Tool, ToolMetadata } from '@agentforge/core';
+import type { ToolMetadata } from '@agentforge/core';
 import type { PlanExecuteStateType } from './state.js';
+import type { PlanStepArguments, PlanStepResult } from './schemas.js';
 
 export interface PlanExecuteTool {
   metadata: ToolMetadata;
-  invoke: Tool<never, unknown>['invoke'];
+  invoke(input: PlanStepArguments): Promise<PlanStepResult>;
 }
 
 /**

--- a/packages/patterns/src/plan-execute/types.ts
+++ b/packages/patterns/src/plan-execute/types.ts
@@ -85,9 +85,9 @@ export interface ReplannerConfig {
   model: BaseChatModel;
 
   /**
-   * Confidence threshold for replanning (0-1)
-   * If confidence is below this, trigger replanning
-   * Currently unsupported and ignored by the runtime replanner node.
+   * Intended confidence threshold for replanning (0-1).
+   * This is a forward-compatibility option and is currently ignored by the runtime replanner node.
+   * Future versions may use this to decide when to trigger replanning.
    */
   replanThreshold?: number;
 

--- a/packages/patterns/src/plan-execute/types.ts
+++ b/packages/patterns/src/plan-execute/types.ts
@@ -51,12 +51,14 @@ export interface ExecutorConfig<TTool extends PlanExecuteTool = PlanExecuteTool>
   tools: readonly TTool[];
 
   /**
-   * Optional language model for sub-tasks
+   * Optional language model for sub-tasks.
+   * Currently unsupported and ignored by the runtime executor node.
    */
   model?: BaseChatModel;
 
   /**
-   * Enable parallel execution of independent steps
+   * Enable parallel execution of independent steps.
+   * Currently unsupported and ignored by the runtime executor node.
    */
   parallel?: boolean;
 
@@ -84,6 +86,7 @@ export interface ReplannerConfig {
   /**
    * Confidence threshold for replanning (0-1)
    * If confidence is below this, trigger replanning
+   * Currently unsupported and ignored by the runtime replanner node.
    */
   replanThreshold?: number;
 

--- a/packages/patterns/src/plan-execute/types.ts
+++ b/packages/patterns/src/plan-execute/types.ts
@@ -8,8 +8,13 @@
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
-import type { Tool } from '@agentforge/core';
+import type { Tool, ToolMetadata } from '@agentforge/core';
 import type { PlanExecuteStateType } from './state.js';
+
+export interface PlanExecuteTool {
+  metadata: ToolMetadata;
+  invoke: Tool<never, unknown>['invoke'];
+}
 
 /**
  * Configuration for the planner node
@@ -39,11 +44,11 @@ export interface PlannerConfig {
 /**
  * Configuration for the executor node
  */
-export interface ExecutorConfig {
+export interface ExecutorConfig<TTool extends PlanExecuteTool = PlanExecuteTool> {
   /**
    * Available tools for execution
    */
-  tools: Tool<any, any>[];
+  tools: readonly TTool[];
 
   /**
    * Optional language model for sub-tasks
@@ -91,7 +96,7 @@ export interface ReplannerConfig {
 /**
  * Configuration for creating a Plan-Execute agent
  */
-export interface PlanExecuteAgentConfig {
+export interface PlanExecuteAgentConfig<TTool extends PlanExecuteTool = PlanExecuteTool> {
   /**
    * Planner configuration
    */
@@ -100,7 +105,7 @@ export interface PlanExecuteAgentConfig {
   /**
    * Executor configuration
    */
-  executor: ExecutorConfig;
+  executor: ExecutorConfig<TTool>;
 
   /**
    * Optional replanner configuration
@@ -156,4 +161,3 @@ export type PlanExecuteRoute = 'execute' | 'replan' | 'finish' | 'error';
  * Router function type
  */
 export type PlanExecuteRouter = (state: PlanExecuteStateType) => PlanExecuteRoute;
-

--- a/packages/patterns/tests/plan-execute/nodes.test.ts
+++ b/packages/patterns/tests/plan-execute/nodes.test.ts
@@ -6,6 +6,48 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { createMockLLM } from '@agentforge/testing';
 import { z } from 'zod';
 
+function createMockPatternLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+async function importNodesWithMockedPatternLoggers() {
+  vi.resetModules();
+
+  const plannerLogger = createMockPatternLogger();
+  const executorLogger = createMockPatternLogger();
+  const replannerLogger = createMockPatternLogger();
+  const loggers = [plannerLogger, executorLogger, replannerLogger];
+  let index = 0;
+
+  vi.doMock('../../src/shared/deduplication.js', async () => {
+    const actual = await vi.importActual<typeof import('../../src/shared/deduplication.js')>(
+      '../../src/shared/deduplication.js'
+    );
+
+    return {
+      ...actual,
+      createPatternLogger: vi.fn(() => loggers[index++] ?? createMockPatternLogger()),
+    };
+  });
+
+  const nodesModule = await import('../../src/plan-execute/nodes.js');
+
+  vi.doUnmock('../../src/shared/deduplication.js');
+  vi.resetModules();
+
+  return {
+    createExecutorNode: nodesModule.createExecutorNode,
+    createReplannerNode: nodesModule.createReplannerNode,
+    executorWarn: executorLogger.warn,
+    replannerWarn: replannerLogger.warn,
+  };
+}
+
 // Helper to create mock planner LLM
 function createMockPlannerLLM() {
   return createMockLLM({
@@ -131,21 +173,21 @@ describe('Plan-Execute Nodes', () => {
     });
 
     it('should warn when unsupported executor options are provided', () => {
-      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-      try {
-        createExecutorNode({
+      return importNodesWithMockedPatternLoggers().then(({ createExecutorNode: createExecutorNodeWithMocks, executorWarn }) => {
+        createExecutorNodeWithMocks({
           tools: [calculatorTool],
           model: createMockPlannerLLM() as any,
           parallel: true,
         });
 
-        const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
-        expect(output).toContain('ExecutorConfig.model is currently unsupported and will be ignored');
-        expect(output).toContain('ExecutorConfig.parallel is currently unsupported and will be ignored');
-        expect(output).toContain('"parallel":true');
-      } finally {
-        writeSpy.mockRestore();
-      }
+        expect(executorWarn).toHaveBeenCalledWith(
+          'ExecutorConfig.model is currently unsupported and will be ignored'
+        );
+        expect(executorWarn).toHaveBeenCalledWith(
+          'ExecutorConfig.parallel is currently unsupported and will be ignored',
+          { parallel: true }
+        );
+      });
     });
 
     it('should execute a step with a tool', async () => {
@@ -272,19 +314,17 @@ describe('Plan-Execute Nodes', () => {
     });
 
     it('should warn when replanThreshold is provided', () => {
-      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-      try {
-        createReplannerNode({
+      return importNodesWithMockedPatternLoggers().then(({ createReplannerNode: createReplannerNodeWithMocks, replannerWarn }) => {
+        createReplannerNodeWithMocks({
           model: createMockReplannerLLM() as any,
           replanThreshold: 0.7,
         });
 
-        const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
-        expect(output).toContain('ReplannerConfig.replanThreshold is currently unsupported and will be ignored');
-        expect(output).toContain('"replanThreshold":0.7');
-      } finally {
-        writeSpy.mockRestore();
-      }
+        expect(replannerWarn).toHaveBeenCalledWith(
+          'ReplannerConfig.replanThreshold is currently unsupported and will be ignored',
+          { replanThreshold: 0.7 }
+        );
+      });
     });
 
     it('should decide to continue with current plan', async () => {

--- a/packages/patterns/tests/plan-execute/nodes.test.ts
+++ b/packages/patterns/tests/plan-execute/nodes.test.ts
@@ -130,6 +130,21 @@ describe('Plan-Execute Nodes', () => {
       expect(typeof executor).toBe('function');
     });
 
+    it('should warn when unsupported executor options are provided', () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      createExecutorNode({
+        tools: [calculatorTool],
+        model: createMockPlannerLLM() as any,
+        parallel: true,
+      });
+
+      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(output).toContain('ExecutorConfig.model is currently unsupported and will be ignored');
+      expect(output).toContain('ExecutorConfig.parallel is currently unsupported and will be ignored');
+      expect(output).toContain('"parallel":true');
+    });
+
     it('should execute a step with a tool', async () => {
       const executor = createExecutorNode({ tools: [calculatorTool] });
 
@@ -253,6 +268,19 @@ describe('Plan-Execute Nodes', () => {
       expect(typeof replanner).toBe('function');
     });
 
+    it('should warn when replanThreshold is provided', () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      createReplannerNode({
+        model: createMockReplannerLLM() as any,
+        replanThreshold: 0.7,
+      });
+
+      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(output).toContain('ReplannerConfig.replanThreshold is currently unsupported and will be ignored');
+      expect(output).toContain('"replanThreshold":0.7');
+    });
+
     it('should decide to continue with current plan', async () => {
       const llm = createMockReplannerLLM(false) as any;
       const replanner = createReplannerNode({ model: llm });
@@ -330,4 +358,3 @@ describe('Plan-Execute Nodes', () => {
     });
   });
 });
-

--- a/packages/patterns/tests/plan-execute/nodes.test.ts
+++ b/packages/patterns/tests/plan-execute/nodes.test.ts
@@ -132,17 +132,20 @@ describe('Plan-Execute Nodes', () => {
 
     it('should warn when unsupported executor options are provided', () => {
       const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      try {
+        createExecutorNode({
+          tools: [calculatorTool],
+          model: createMockPlannerLLM() as any,
+          parallel: true,
+        });
 
-      createExecutorNode({
-        tools: [calculatorTool],
-        model: createMockPlannerLLM() as any,
-        parallel: true,
-      });
-
-      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
-      expect(output).toContain('ExecutorConfig.model is currently unsupported and will be ignored');
-      expect(output).toContain('ExecutorConfig.parallel is currently unsupported and will be ignored');
-      expect(output).toContain('"parallel":true');
+        const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+        expect(output).toContain('ExecutorConfig.model is currently unsupported and will be ignored');
+        expect(output).toContain('ExecutorConfig.parallel is currently unsupported and will be ignored');
+        expect(output).toContain('"parallel":true');
+      } finally {
+        writeSpy.mockRestore();
+      }
     });
 
     it('should execute a step with a tool', async () => {
@@ -270,15 +273,18 @@ describe('Plan-Execute Nodes', () => {
 
     it('should warn when replanThreshold is provided', () => {
       const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      try {
+        createReplannerNode({
+          model: createMockReplannerLLM() as any,
+          replanThreshold: 0.7,
+        });
 
-      createReplannerNode({
-        model: createMockReplannerLLM() as any,
-        replanThreshold: 0.7,
-      });
-
-      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
-      expect(output).toContain('ReplannerConfig.replanThreshold is currently unsupported and will be ignored');
-      expect(output).toContain('"replanThreshold":0.7');
+        const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+        expect(output).toContain('ReplannerConfig.replanThreshold is currently unsupported and will be ignored');
+        expect(output).toContain('"replanThreshold":0.7');
+      } finally {
+        writeSpy.mockRestore();
+      }
     });
 
     it('should decide to continue with current plan', async () => {

--- a/packages/patterns/tests/plan-execute/nodes.test.ts
+++ b/packages/patterns/tests/plan-execute/nodes.test.ts
@@ -21,8 +21,11 @@ async function importNodesWithMockedPatternLoggers() {
   const plannerLogger = createMockPatternLogger();
   const executorLogger = createMockPatternLogger();
   const replannerLogger = createMockPatternLogger();
-  const loggers = [plannerLogger, executorLogger, replannerLogger];
-  let index = 0;
+  const loggersByName = new Map([
+    ['agentforge:patterns:plan-execute:planner', plannerLogger],
+    ['agentforge:patterns:plan-execute:executor', executorLogger],
+    ['agentforge:patterns:plan-execute:replanner', replannerLogger],
+  ]);
 
   vi.doMock('../../src/shared/deduplication.js', async () => {
     const actual = await vi.importActual<typeof import('../../src/shared/deduplication.js')>(
@@ -31,7 +34,7 @@ async function importNodesWithMockedPatternLoggers() {
 
     return {
       ...actual,
-      createPatternLogger: vi.fn(() => loggers[index++] ?? createMockPatternLogger()),
+      createPatternLogger: vi.fn((name: string) => loggersByName.get(name) ?? createMockPatternLogger()),
     };
   });
 

--- a/packages/patterns/tests/plan-execute/nodes.test.ts
+++ b/packages/patterns/tests/plan-execute/nodes.test.ts
@@ -214,6 +214,34 @@ describe('Plan-Execute Nodes', () => {
       expect(result.currentStepIndex).toBe(1);
     });
 
+    it('should clear step timeout after successful execution', async () => {
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+      try {
+        const executor = createExecutorNode({ tools: [calculatorTool], stepTimeout: 1000 });
+
+        const state: Partial<PlanExecuteStateType> = {
+          plan: {
+            steps: [
+              { id: 'step-1', description: 'Add numbers', tool: 'calculator', args: { a: 5, b: 3 } },
+            ],
+            goal: 'Calculate',
+            createdAt: new Date().toISOString(),
+          },
+          currentStepIndex: 0,
+          pastSteps: [],
+          status: 'executing',
+        };
+
+        const result = await executor(state as PlanExecuteStateType);
+
+        expect(result.pastSteps?.[0].success).toBe(true);
+        expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
     it('should handle tool not found', async () => {
       const executor = createExecutorNode({ tools: [calculatorTool] });
 

--- a/packages/patterns/tests/plan-execute/state.test.ts
+++ b/packages/patterns/tests/plan-execute/state.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   PlanExecuteState,
   PlanExecuteStateConfig,
-  type PlanExecuteStateType,
 } from '../../src/plan-execute/state.js';
 import {
   PlanStepSchema,

--- a/packages/patterns/tests/plan-execute/state.test.ts
+++ b/packages/patterns/tests/plan-execute/state.test.ts
@@ -87,6 +87,31 @@ describe('Plan-Execute State', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should preserve flexible argument and result validation without any-typed schemas', () => {
+      const validStep = {
+        id: 'step-3',
+        description: 'Use nested tool arguments',
+        tool: 'search',
+        args: {
+          query: 'test',
+          options: {
+            filters: ['recent', 'relevant'],
+            limit: 5,
+          },
+        },
+      };
+
+      const validCompletedStep = {
+        step: validStep,
+        result: ['summary', { score: 0.9 }, null],
+        success: true,
+        timestamp: new Date().toISOString(),
+      };
+
+      expect(PlanStepSchema.safeParse(validStep).success).toBe(true);
+      expect(CompletedStepSchema.safeParse(validCompletedStep).success).toBe(true);
+    });
+
     it('should validate Plan schema', () => {
       const validPlan = {
         steps: [
@@ -142,4 +167,3 @@ describe('Plan-Execute State', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -518,7 +518,9 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `f5caf74` `refactor(st-09014): tighten plan-execute shared contracts`
   - `a3168aa` `docs(st-09014): record plan-execute contract progress`
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - `84e499d` `docs(st-09014): record validation and move story to in-review`
+  - PR #76 marked ready: https://github.com/TVScoundrel/agentforge/pull/76
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -527,6 +527,7 @@ Implementation notes:
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
+  - Pending latest review-fix commit for kanban cleanup and baseline note refresh
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -521,6 +521,10 @@ Implementation notes:
 - [x] Mark PR Ready only after all story tasks are complete
   - `84e499d` `docs(st-09014): record validation and move story to in-review`
   - PR #76 marked ready: https://github.com/TVScoundrel/agentforge/pull/76
+- [x] Review fixes applied on the active PR branch
+  - `9d1ea7c` `fix(st-09014): clean touched plan-execute warnings`
+  - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
+  - Pending latest review-fix commit for bound invocation and typecheck fixture validity
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -529,7 +529,7 @@ Implementation notes:
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
-  - Pending latest review-fix commit for executor timeout cleanup
+  - `224514d` `fix(st-09014): clear executor step timeout handles`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -525,6 +525,7 @@ Implementation notes:
   - `9d1ea7c` `fix(st-09014): clean touched plan-execute warnings`
   - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
+  - Pending latest review-fix commit for unsupported executor/replanner option handling
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -526,6 +526,7 @@ Implementation notes:
   - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
+  - Pending latest review-fix commit for plan-execute test spy restoration and brittle doc cleanup
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -498,16 +498,26 @@ Implementation notes:
 ### Checklist
 - [x] Create branch `fix/st-09014-plan-execute-shared-type-boundaries`
   - Created as `codex/fix/st-09014-plan-execute-shared-type-boundaries` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
-- [ ] Remove broad tool/schema `any` boundaries from `packages/patterns/src/plan-execute/types.ts` and adjacent shared contracts as needed
-- [ ] Preserve current planner/executor/replanner compatibility while tightening shared type inference
-- [ ] Add/update focused tests for type-driven plan-execute configuration and execution flows
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09014-plan-execute-shared-type-boundaries.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Create draft PR with story ID in title
+  - Draft PR #76: https://github.com/TVScoundrel/agentforge/pull/76
+- [x] Remove broad tool/schema `any` boundaries from `packages/patterns/src/plan-execute/types.ts` and adjacent shared contracts as needed
+  - Replaced `Tool<any, any>[]` with the exported `PlanExecuteTool` runtime contract, generic executor/agent config typing, `PlanStepArguments`/`PlanStepResult` aliases, and a single executor-side invocation seam
+- [x] Preserve current planner/executor/replanner compatibility while tightening shared type inference
+  - Planner, executor, replanner, and finisher runtime flows remain unchanged; only the shared type surfaces and schema helper typings were narrowed
+- [x] Add/update focused tests for type-driven plan-execute configuration and execution flows
+  - Added `packages/patterns/src/plan-execute/contracts.typecheck.ts` for source-included config inference coverage and expanded `packages/patterns/tests/plan-execute/state.test.ts` for schema compatibility
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09014-plan-execute-shared-type-boundaries.md` (`types.ts`: `1 -> 0`, `nodes.ts`: `1 -> 0`; baseline `289 -> 278`, `patterns 28 -> 25`)
+- [x] Add or update story documentation at `docs/st09014-plan-execute-shared-type-boundaries.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused automated coverage; no manual-only gap remains for the changed surface
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `152 passed | 16 skipped` files; `2126 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `f5caf74` `refactor(st-09014): tighten plan-execute shared contracts`
+  - `a3168aa` `docs(st-09014): record plan-execute contract progress`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -527,7 +527,7 @@ Implementation notes:
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
-  - Pending latest review-fix commit for kanban cleanup and baseline note refresh
+  - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -529,6 +529,7 @@ Implementation notes:
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
+  - Pending latest review-fix commit for executor timeout cleanup
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -526,7 +526,7 @@ Implementation notes:
   - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
-  - Pending latest review-fix commit for plan-execute test spy restoration and brittle doc cleanup
+  - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -496,7 +496,8 @@ Implementation notes:
 **Branch:** `fix/st-09014-plan-execute-shared-type-boundaries`
 
 ### Checklist
-- [ ] Create branch `fix/st-09014-plan-execute-shared-type-boundaries`
+- [x] Create branch `fix/st-09014-plan-execute-shared-type-boundaries`
+  - Created as `codex/fix/st-09014-plan-execute-shared-type-boundaries` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
 - [ ] Remove broad tool/schema `any` boundaries from `packages/patterns/src/plan-execute/types.ts` and adjacent shared contracts as needed
 - [ ] Preserve current planner/executor/replanner compatibility while tightening shared type inference

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -817,3 +817,25 @@ Implementation notes:
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+---
+
+## ST-09029: Modularize Plan-Execute Node Responsibilities
+
+**Branch:** `refactor/st-09029-plan-execute-node-modularization`
+
+### Checklist
+- [ ] Create branch `refactor/st-09029-plan-execute-node-modularization`
+- [ ] Create draft PR with story ID in title
+- [ ] Split `packages/patterns/src/plan-execute/nodes.ts` into planner, executor, replanner, and finisher modules or focused helpers
+- [ ] Preserve the public plan-execute node entrypoint and current runtime behavior
+- [ ] Extract shared helpers where they reduce duplication without obscuring control flow
+- [ ] Add/update focused tests for planning, execution, replanning, and node-level error handling
+- [ ] Record explicit-`any` warning deltas for touched files in story docs
+- [ ] Add or update story documentation at `docs/st09029-plan-execute-node-modularization.md` (or document why not required)
+- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Commit completed checklist items as logical commits and push updates
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -530,7 +530,7 @@ Implementation notes:
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
   - `224514d` `fix(st-09014): clear executor step timeout handles`
-  - Pending latest review-fix commit for replanner threshold JSDoc alignment
+  - `17cd270` `docs(st-09014): align replanner threshold contract notes`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -528,7 +528,7 @@ Implementation notes:
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
-  - Pending latest review-fix commit for callable tool boundary and logger-mocked warning tests
+  - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -531,6 +531,7 @@ Implementation notes:
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
   - `224514d` `fix(st-09014): clear executor step timeout handles`
   - `17cd270` `docs(st-09014): align replanner threshold contract notes`
+  - Pending latest review-fix commit for stable name-based logger mocks
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -528,6 +528,7 @@ Implementation notes:
   - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
   - `e6e03f2` `fix(st-09014): restore plan-execute warning spies and trim brittle docs`
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
+  - Pending latest review-fix commit for callable tool boundary and logger-mocked warning tests
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -525,7 +525,7 @@ Implementation notes:
   - `9d1ea7c` `fix(st-09014): clean touched plan-execute warnings`
   - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
   - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
-  - Pending latest review-fix commit for unsupported executor/replanner option handling
+  - `3787bf1` `fix(st-09014): warn on unsupported plan-execute options`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -524,7 +524,7 @@ Implementation notes:
 - [x] Review fixes applied on the active PR branch
   - `9d1ea7c` `fix(st-09014): clean touched plan-execute warnings`
   - `9915726` `chore(st-09014): add plan-execute node modularization follow-up`
-  - Pending latest review-fix commit for bound invocation and typecheck fixture validity
+  - `d057c3c` `fix(st-09014): preserve bound tool invocation and valid typecheck fixture`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -531,7 +531,7 @@ Implementation notes:
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
   - `224514d` `fix(st-09014): clear executor step timeout handles`
   - `17cd270` `docs(st-09014): align replanner threshold contract notes`
-  - Pending latest review-fix commit for stable name-based logger mocks
+  - `a781d91` `test(st-09014): stabilize logger-mock lookup by name`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -530,6 +530,7 @@ Implementation notes:
   - `c18df1a` `docs(st-09014): clean kanban separators and baseline note`
   - `350a2bc` `fix(st-09014): make plan-execute tool boundary callable`
   - `224514d` `fix(st-09014): clear executor step timeout handles`
+  - Pending latest review-fix commit for replanner threshold JSDoc alignment
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1056,7 +1056,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09013
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/plan-execute/types.ts` removes the current `Tool<any, any>[]` style boundaries and replaces them with safer generic or erased runtime contracts

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1056,7 +1056,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09013
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/plan-execute/types.ts` removes the current `Tool<any, any>[]` style boundaries and replaces them with safer generic or erased runtime contracts
@@ -1327,4 +1327,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → [ST-09013 (Merged), ST-09014 (Ready), ST-09016 (Ready), ST-09017 (Ready)]; ST-09014 → ST-09015; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → [ST-09014 (In Review), ST-09016 (Ready), ST-09017 (Ready)]; ST-09014 → ST-09015; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -121,7 +121,7 @@
 - Story slices are intentionally small (1 day each) so quality improvements can ship continuously
 - Lightweight quality-gate follow-ups keep release/build feedback tight by reducing stale warning caps and easy package metadata warnings
 
-**Stories:** ST-09001 through ST-09028
+**Stories:** ST-09001 through ST-09029
 
 ---
 
@@ -1308,15 +1308,33 @@
 
 ---
 
+#### ST-09029: Modularize Plan-Execute Node Responsibilities
+**User story:** As a patterns maintainer, I want the plan-execute node layer split into clearer responsibility boundaries so planning, execution, replanning, and finishing logic are easier to reason about and evolve independently.
+
+**Priority:** P2 (Medium)
+**Estimate:** 4 hours
+**Dependencies:** ST-09014
+**Status:** Backlog
+
+**Acceptance criteria:**
+- [ ] `packages/patterns/src/plan-execute/nodes.ts` is split into smaller modules or helper layers that separate planner, executor, replanner, and finisher responsibilities
+- [ ] The public plan-execute node entrypoint remains stable and preserves current runtime behavior
+- [ ] Shared helpers are extracted where they reduce duplication without obscuring the control flow
+- [ ] Focused tests are added or updated for planning, execution, replanning, and node-level error handling after the split
+- [ ] Touched files do not regress on explicit-`any` warning counts and the outcome is recorded in story documentation
+- [ ] Add or update story documentation at `docs/st09029-plan-execute-node-modularization.md`
+
+---
+
 ## Story Summary
 
-**Total Stories:** 64
+**Total Stories:** 65
 **By Priority:**
 - P0 (Critical): 17 stories
 - P1 (High): 27 stories
-- P2 (Medium): 20 stories
+- P2 (Medium): 21 stories
 
-**Total Estimated Effort:** ~239 hours (29.9 working days)
+**Total Estimated Effort:** ~243 hours (30.4 working days)
 
 **Dependency Chain:**
 1. Phase 1 (Foundation): ST-01001 → ST-01002 → ST-01003 → ST-01004
@@ -1327,4 +1345,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → [ST-09014 (In Review), ST-09016 (Ready), ST-09017 (Ready)]; ST-09014 → ST-09015; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → [ST-09014 (In Review), ST-09016 (Ready), ST-09017 (Ready)]; ST-09014 → ST-09015; ST-09014 → ST-09029; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-03-23
-**Active Story:** ST-09014 (Ready)
+**Last Updated:** 2026-03-24
+**Active Story:** ST-09014 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -47,7 +47,7 @@ Top runtime hotspots informing this feature slice:
 6. `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts` still concentrate a large share of the remaining `testing` package `any` warnings
 7. `packages/core/src/prompt-loader/index.ts`, `packages/core/src/streaming/websocket.ts`, and `packages/patterns/src/reflection/agent.ts` form the next small runtime boundary-hardening slice
 8. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
-9. `packages/patterns/src/plan-execute/nodes.ts` is now `435` lines and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
+9. `packages/patterns/src/plan-execute/nodes.ts` has grown into a larger mixed-responsibility module and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
 
 Recent improvement snapshot:
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-24
-**Active Story:** ST-09014 (In Progress)
+**Active Story:** ST-09014 (In Review)
 
 ---
 
@@ -60,7 +60,8 @@ Recent improvement snapshot:
 - `ST-09011` tightened the committed explicit-`any` baseline caps from `496` to the current measured `289`, aligning the no-regression gate with the post-EP-09 warning floor.
 - `ST-09012` removed the remaining `exports.types` ordering warnings from `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing`, quieting the routine build output without changing published entrypoint targets.
 - `ST-09013` merged with an intentional breaking tightening to the sequential workflow builder contract: explicit state generics were removed, and downstream callers must rely on schema-derived inference from `Annotation.Root(...)`.
-- `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting plan-execute shared contracts, monitoring payloads, CLI error handling, testing helpers, and multi-agent modularization.
+- `ST-09014` tightened the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
+- `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, and multi-agent modularization.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -47,6 +47,7 @@ Top runtime hotspots informing this feature slice:
 6. `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts` still concentrate a large share of the remaining `testing` package `any` warnings
 7. `packages/core/src/prompt-loader/index.ts`, `packages/core/src/streaming/websocket.ts`, and `packages/patterns/src/reflection/agent.ts` form the next small runtime boundary-hardening slice
 8. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
+9. `packages/patterns/src/plan-execute/nodes.ts` is now `435` lines and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
 
 Recent improvement snapshot:
 
@@ -61,7 +62,7 @@ Recent improvement snapshot:
 - `ST-09012` removed the remaining `exports.types` ordering warnings from `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing`, quieting the routine build output without changing published entrypoint targets.
 - `ST-09013` merged with an intentional breaking tightening to the sequential workflow builder contract: explicit state generics were removed, and downstream callers must rely on schema-derived inference from `Annotation.Root(...)`.
 - `ST-09014` tightened the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
-- `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, and multi-agent modularization.
+- `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, multi-agent modularization, and plan-execute node modularization.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 
 ---
@@ -85,7 +86,7 @@ Recent improvement snapshot:
 
 ## Story Coverage by Epic
 
-- EP-09: ST-09001, ST-09002, ST-09003, ST-09004, ST-09005, ST-09006, ST-09007, ST-09008, ST-09009, ST-09010, ST-09011, ST-09012, ST-09013, ST-09014, ST-09015, ST-09016, ST-09017, ST-09018, ST-09019, ST-09020, ST-09021, ST-09022, ST-09023, ST-09024, ST-09025, ST-09026, ST-09027, ST-09028
+- EP-09: ST-09001, ST-09002, ST-09003, ST-09004, ST-09005, ST-09006, ST-09007, ST-09008, ST-09009, ST-09010, ST-09011, ST-09012, ST-09013, ST-09014, ST-09015, ST-09016, ST-09017, ST-09018, ST-09019, ST-09020, ST-09021, ST-09022, ST-09023, ST-09024, ST-09025, ST-09026, ST-09027, ST-09028, ST-09029
 
 ---
 
@@ -101,7 +102,7 @@ Recent improvement snapshot:
 
 ## Related Planning Documents
 
-- `planning/epics-and-stories.md` (EP-09 and ST-09001 through ST-09028)
+- `planning/epics-and-stories.md` (EP-09 and ST-09001 through ST-09029)
 - `planning/checklists/epic-09-story-tasks.md`
 - `planning/kanban-queue.md`
 - `scripts/no-explicit-any-baseline.json`

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -25,8 +25,6 @@
 
 ---
 
----
-
 ## In Progress
 
 _No stories currently in progress_
@@ -125,4 +123,4 @@ _No stories currently blocked_
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded again on 2026-03-23 with daily hardening stories ST-09013 through ST-09018
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a third time on 2026-03-23 with daily hardening stories ST-09019 through ST-09028
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a fourth time on 2026-03-24 with the plan-execute node modularization follow-up story ST-09029
-- Current measured `no-explicit-any` baseline is `289` warnings (`cli 24`, `core 119`, `patterns 28`, `testing 51`, `tools 67`)
+- Current measured `no-explicit-any` baseline is `278` warnings (`cli 24`, `core 119`, `patterns 25`, `testing 51`, `tools 67`)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -8,7 +8,7 @@
 - **In Progress:** 0 stories
 - **In Review:** 1 story
 - **Blocked:** 0 stories
-- **Backlog:** 12 stories
+- **Backlog:** 13 stories
 
 ---
 
@@ -58,6 +58,8 @@ _No stories currently blocked_
 - `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 - `ST-09028` - Modularize Connection Manager Lifecycle and Reconnection Control
   - Depends on `ST-09027`
+- `ST-09029` - Modularize Plan-Execute Node Responsibilities
+  - Depends on `ST-09014`
 
 ---
 
@@ -122,4 +124,5 @@ _No stories currently blocked_
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded on 2026-03-22 with low-hanging follow-on stories ST-09008 through ST-09012
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded again on 2026-03-23 with daily hardening stories ST-09013 through ST-09018
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a third time on 2026-03-23 with daily hardening stories ST-09019 through ST-09028
+- Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a fourth time on 2026-03-24 with the plan-execute node modularization follow-up story ST-09029
 - Current measured `no-explicit-any` baseline is `289` warnings (`cli 24`, `core 119`, `patterns 28`, `testing 51`, `tools 67`)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-23
+**Last Updated:** 2026-03-24
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 12 stories
@@ -14,17 +14,16 @@
 
 ## Ready
 
-- `ST-09014` - Tighten Plan-Execute Shared Type Boundaries
 - `ST-09016` - Harden Monitoring Audit and Health Payload Types
 - `ST-09017` - Centralize CLI Command Error Handling
 
 ---
 
----
-
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09014` - Tighten Plan-Execute Shared Type Boundaries
+
+---
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 12 stories
 
@@ -19,11 +19,17 @@
 
 ---
 
-## In Progress
+## In Review
 
 - `ST-09014` - Tighten Plan-Execute Shared Type Boundaries
 
 ---
+
+---
+
+## In Progress
+
+_No stories currently in progress_
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09014: Tighten Plan-Execute Shared Type Boundaries

## What Changed
- replaced the broad `Tool<any, any>[]` executor boundary with the exported `PlanExecuteTool` runtime contract plus generic executor and agent config typing
- changed shared step argument and completed-step result schemas from `any`-based typing to `unknown`-based contracts while preserving runtime validation behavior
- localized runtime tool invocation widening to a single helper in the executor and removed the executor `result: any` seam
- added a source-included typecheck regression file to lock in concrete tool preservation through `ExecutorConfig` and `PlanExecuteAgentConfig`
- added focused schema validation coverage for nested step arguments and flexible completed-step results
- moved ST-09014 to `In Review` in the planning trackers and recorded the warning delta in the story doc

## Acceptance Criteria Coverage
- `packages/patterns/src/plan-execute/types.ts` no longer exposes `Tool<any, any>[]`; the executor and agent configs now use safer generic typing over an erased runtime tool contract
- shared planner/executor/replanner flows remain compatible; focused routing and integration tests still pass unchanged
- touched schema helpers preserve runtime flexibility while switching the TypeScript surface from `any` to `unknown`
- focused automated coverage now includes source-level typecheck assertions plus updated schema validation tests for plan-execute state
- explicit-`any` warning deltas are recorded in `docs/st09014-plan-execute-shared-type-boundaries.md`
- story documentation added at `docs/st09014-plan-execute-shared-type-boundaries.md`

## Validation Performed
- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
- `pnpm exec eslint packages/patterns/src/plan-execute/agent.ts packages/patterns/src/plan-execute/types.ts packages/patterns/src/plan-execute/nodes.ts packages/patterns/src/plan-execute/schemas.ts packages/patterns/src/plan-execute/contracts.typecheck.ts packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts`
- `pnpm test --run packages/patterns/tests/plan-execute/agent.test.ts packages/patterns/tests/plan-execute/state.test.ts packages/patterns/tests/plan-execute/integration.test.ts` -> `19 passed`
- `pnpm lint:explicit-any:baseline` -> `278/289`, `patterns 25/28`
- `pnpm test --run` -> `152 passed | 16 skipped` files; `2126 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only (`0` errors)

## Status
- Ready for review
