### PR TITLE
ST-09016: Harden Monitoring Audit and Health Payload Types

### DIFF
--- a/docs/st09016-monitoring-payload-type-hardening.md
+++ b/docs/st09016-monitoring-payload-type-hardening.md
@@ -1,0 +1,43 @@
+# ST-09016: Harden Monitoring Audit and Health Payload Types
+
+## Summary
+
+Tightened the monitoring audit and health payload contracts so the public monitoring helpers no longer expose broad `any` payload fields, while preserving the current runtime behavior for JSON-safe observability data.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/monitoring/audit.ts` | Replaced broad audit `input`, `output`, metadata, and storage config payloads with shared JSON-safe observability contracts |
+| `packages/core/src/monitoring/health.ts` | Replaced health-check metadata `Record<string, any>` with the shared JSON-object payload contract |
+| `packages/core/tests/monitoring/audit-health.test.ts` | Added focused coverage for audit payload preservation, health metadata handling, and `onCheckFail` error propagation |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/monitoring/audit.ts`: `4 -> 0` (`-4`)
+- `packages/core/src/monitoring/health.ts`: `1 -> 0` (`-1`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `276 -> 271` (`-5`)
+- `core` package: `111 -> 106` (`-5`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-03-26.)
+
+## Compatibility Notes
+
+- Monitoring runtime behavior remains the same for JSON-safe payloads and metadata; this story only tightens the TypeScript surface to match the observability payload contracts already used elsewhere in `@agentforge/core`.
+- `AuditLogger` storage configuration remains structurally open to JSON-safe nested objects, preserving current in-memory and callback behavior.
+- `HealthChecker` result metadata remains optional and free-form within JSON-object constraints, which aligns with the current runtime usage patterns.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/monitoring/audit.ts packages/core/src/monitoring/health.ts packages/core/tests/monitoring/audit-health.test.ts`
+- `pnpm test --run packages/core/tests/monitoring/audit-health.test.ts packages/core/tests/monitoring/alerts.test.ts` -> `2 passed` files, `10 passed` tests
+
+## Test Impact
+
+Added focused automated coverage for audit payload preservation and health-check metadata handling. Full-suite and workspace lint validation will be recorded before the story is moved to review.

--- a/docs/st09016-monitoring-payload-type-hardening.md
+++ b/docs/st09016-monitoring-payload-type-hardening.md
@@ -37,7 +37,9 @@ Tightened the monitoring audit and health payload contracts so the public monito
 - `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
 - `pnpm exec eslint packages/core/src/monitoring/audit.ts packages/core/src/monitoring/health.ts packages/core/tests/monitoring/audit-health.test.ts`
 - `pnpm test --run packages/core/tests/monitoring/audit-health.test.ts packages/core/tests/monitoring/alerts.test.ts` -> `2 passed` files, `10 passed` tests
+- `pnpm test --run` -> `153 passed | 16 skipped` files; `2137 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
 
 ## Test Impact
 
-Added focused automated coverage for audit payload preservation and health-check metadata handling. Full-suite and workspace lint validation will be recorded before the story is moved to review.
+Added focused automated coverage for audit payload preservation and health-check metadata handling, then validated the change through the full workspace test suite and lint pass. No manual-only gap remains for the changed surface.

--- a/packages/core/src/monitoring/audit.ts
+++ b/packages/core/src/monitoring/audit.ts
@@ -63,7 +63,7 @@ export class AuditLogger {
     const fullEntry: AuditLogEntry = {
       ...entry,
       id: this.generateId(),
-      timestamp: entry.timestamp || Date.now(),
+      timestamp: entry.timestamp ?? Date.now(),
       success: entry.success ?? true,
     };
 

--- a/packages/core/src/monitoring/audit.ts
+++ b/packages/core/src/monitoring/audit.ts
@@ -77,11 +77,11 @@ export class AuditLogger {
       timestamp: fields.timestamp !== false ? fullEntry.timestamp : undefined,
     };
 
-    if (fields.input !== false && fullEntry.input) {
+    if (fields.input !== false && fullEntry.input !== undefined) {
       filteredEntry.input = fullEntry.input;
     }
 
-    if (fields.output !== false && fullEntry.output) {
+    if (fields.output !== false && fullEntry.output !== undefined) {
       filteredEntry.output = fullEntry.output;
     }
 

--- a/packages/core/src/monitoring/audit.ts
+++ b/packages/core/src/monitoring/audit.ts
@@ -2,15 +2,17 @@
  * Audit logging for compliance and tracking
  */
 
+import type { JsonObject, JsonValue } from '../langgraph/observability/payload.js';
+
 export interface AuditLogEntry {
   id?: string;
   userId: string;
   action: string;
   resource: string;
   timestamp?: number;
-  input?: any;
-  output?: any;
-  metadata?: Record<string, any>;
+  input?: JsonValue;
+  output?: JsonValue;
+  metadata?: JsonObject;
   success?: boolean;
   error?: string;
 }
@@ -28,7 +30,7 @@ export interface AuditLogQuery {
 export interface AuditLoggerOptions {
   storage?: {
     type: 'memory' | 'database' | 'file';
-    config?: Record<string, any>;
+    config?: JsonObject;
   };
   retention?: {
     days: number;
@@ -207,4 +209,3 @@ export class AuditLogger {
 export function createAuditLogger(options?: AuditLoggerOptions): AuditLogger {
   return new AuditLogger(options);
 }
-

--- a/packages/core/src/monitoring/health.ts
+++ b/packages/core/src/monitoring/health.ts
@@ -2,6 +2,8 @@
  * Health check system for production monitoring
  */
 
+import type { JsonObject } from '../langgraph/observability/payload.js';
+
 export type HealthStatus = 'healthy' | 'unhealthy' | 'degraded';
 
 export interface HealthCheckResult {
@@ -11,7 +13,7 @@ export interface HealthCheckResult {
   error?: string;
   timestamp?: number;
   duration?: number;
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 }
 
 export interface HealthCheck {
@@ -159,4 +161,3 @@ export class HealthChecker {
 export function createHealthChecker(options: HealthCheckerOptions): HealthChecker {
   return new HealthChecker(options);
 }
-

--- a/packages/core/src/monitoring/health.ts
+++ b/packages/core/src/monitoring/health.ts
@@ -2,7 +2,10 @@
  * Health check system for production monitoring
  */
 
+import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 import type { JsonObject } from '../langgraph/observability/payload.js';
+
+const logger = createLogger('agentforge:core:monitoring:health', { level: LogLevel.INFO });
 
 export type HealthStatus = 'healthy' | 'unhealthy' | 'degraded';
 
@@ -54,13 +57,19 @@ export class HealthChecker {
 
     // Run initial check
     this.runChecks().catch((error) => {
-      console.error('Initial health check failed:', error);
+      logger.error('Initial health check failed', {
+        error: error instanceof Error ? error.message : String(error),
+        ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+      });
     });
 
     // Schedule periodic checks
     this.checkTimer = setInterval(() => {
       this.runChecks().catch((error) => {
-        console.error('Health check failed:', error);
+        logger.error('Health check failed', {
+          error: error instanceof Error ? error.message : String(error),
+          ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+        });
       });
     }, interval);
   }

--- a/packages/core/tests/monitoring/audit-health.test.ts
+++ b/packages/core/tests/monitoring/audit-health.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAuditLogger } from '../../src/monitoring/audit.js';
+import { createHealthChecker } from '../../src/monitoring/health.js';
+
+describe('monitoring payload contracts', () => {
+  it('preserves JSON-safe audit payloads and metadata', async () => {
+    const logger = createAuditLogger();
+
+    await logger.log({
+      userId: 'user-1',
+      action: 'update',
+      resource: 'invoice',
+      input: {
+        id: 'inv-1',
+        amount: 42,
+        tags: ['urgent'],
+      },
+      output: {
+        ok: true,
+        nested: {
+          retryable: false,
+        },
+      },
+      metadata: {
+        requestId: 'req-1',
+        attempt: 1,
+      },
+    });
+
+    const [entry] = await logger.query();
+
+    expect(entry.input).toEqual({
+      id: 'inv-1',
+      amount: 42,
+      tags: ['urgent'],
+    });
+    expect(entry.output).toEqual({
+      ok: true,
+      nested: {
+        retryable: false,
+      },
+    });
+    expect(entry.metadata).toEqual({
+      requestId: 'req-1',
+      attempt: 1,
+    });
+  });
+
+  it('preserves JSON-safe metadata in health check results', async () => {
+    const checker = createHealthChecker({
+      checks: {
+        database: async () => ({
+          healthy: true,
+          status: 'healthy',
+          metadata: {
+            shard: 'primary',
+            latencyBucket: 'fast',
+          },
+        }),
+      },
+    });
+
+    const report = await checker.getHealth();
+
+    expect(report.status).toBe('healthy');
+    expect(report.checks.database.metadata).toEqual({
+      shard: 'primary',
+      latencyBucket: 'fast',
+    });
+  });
+
+  it('reports health check errors through onCheckFail', async () => {
+    const onCheckFail = vi.fn();
+    const checker = createHealthChecker({
+      checks: {
+        database: async () => {
+          throw new Error('database unavailable');
+        },
+      },
+      onCheckFail,
+    });
+
+    const report = await checker.getHealth();
+
+    expect(report.status).toBe('unhealthy');
+    expect(report.checks.database.error).toBe('database unavailable');
+    expect(onCheckFail).toHaveBeenCalledWith('database', expect.any(Error));
+  });
+});

--- a/packages/core/tests/monitoring/audit-health.test.ts
+++ b/packages/core/tests/monitoring/audit-health.test.ts
@@ -46,6 +46,29 @@ describe('monitoring payload contracts', () => {
     });
   });
 
+  it('preserves explicit falsy audit payloads', async () => {
+    const logger = createAuditLogger();
+
+    await logger.log({
+      userId: 'user-2',
+      action: 'sync',
+      resource: 'feature-flag',
+      input: 0,
+      output: false,
+      metadata: {
+        seen: null,
+      },
+    });
+
+    const [entry] = await logger.query();
+
+    expect(entry.input).toBe(0);
+    expect(entry.output).toBe(false);
+    expect(entry.metadata).toEqual({
+      seen: null,
+    });
+  });
+
   it('preserves JSON-safe metadata in health check results', async () => {
     const checker = createHealthChecker({
       checks: {

--- a/packages/core/tests/monitoring/audit-health.test.ts
+++ b/packages/core/tests/monitoring/audit-health.test.ts
@@ -146,11 +146,14 @@ describe('monitoring payload contracts', () => {
     });
 
     checker.start();
-    await vi.waitFor(() => {
-      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
-      expect(output).toContain('Initial health check failed');
-      expect(output).toContain('startup failure');
-    });
-    checker.stop();
+    try {
+      await vi.waitFor(() => {
+        const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+        expect(output).toContain('Initial health check failed');
+        expect(output).toContain('startup failure');
+      });
+    } finally {
+      checker.stop();
+    }
   });
 });

--- a/packages/core/tests/monitoring/audit-health.test.ts
+++ b/packages/core/tests/monitoring/audit-health.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createAuditLogger } from '../../src/monitoring/audit.js';
 import { createHealthChecker } from '../../src/monitoring/health.js';
 
 describe('monitoring payload contracts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('preserves JSON-safe audit payloads and metadata', async () => {
     const logger = createAuditLogger();
 
@@ -69,6 +73,21 @@ describe('monitoring payload contracts', () => {
     });
   });
 
+  it('preserves explicit zero timestamps in audit entries', async () => {
+    const logger = createAuditLogger();
+
+    await logger.log({
+      userId: 'user-3',
+      action: 'seed',
+      resource: 'timeline',
+      timestamp: 0,
+    });
+
+    const [entry] = await logger.query();
+
+    expect(entry.timestamp).toBe(0);
+  });
+
   it('preserves JSON-safe metadata in health check results', async () => {
     const checker = createHealthChecker({
       checks: {
@@ -108,5 +127,30 @@ describe('monitoring payload contracts', () => {
     expect(report.status).toBe('unhealthy');
     expect(report.checks.database.error).toBe('database unavailable');
     expect(onCheckFail).toHaveBeenCalledWith('database', expect.any(Error));
+  });
+
+  it('routes health check start failures through the shared logger', async () => {
+    vi.resetModules();
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const { createHealthChecker: createDynamicHealthChecker } = await import('../../src/monitoring/health.js');
+    const checks = {};
+    Object.defineProperty(checks, 'database', {
+      enumerable: true,
+      get() {
+        throw new Error('startup failure');
+      },
+    });
+    const checker = createDynamicHealthChecker({
+      checks: checks as Record<string, () => Promise<never>>,
+      interval: 1_000,
+    });
+
+    checker.start();
+    await vi.waitFor(() => {
+      const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(output).toContain('Initial health check failed');
+      expect(output).toContain('startup failure');
+    });
+    checker.stop();
   });
 });

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -581,17 +581,17 @@ Implementation notes:
 
 ## ST-09016: Harden Monitoring Audit and Health Payload Types
 
-**Branch:** `fix/st-09016-monitoring-payload-type-hardening`
+**Branch:** `codex/fix/st-09016-monitoring-payload-type-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-09016-monitoring-payload-type-hardening`
+- [x] Create branch `codex/fix/st-09016-monitoring-payload-type-hardening`
 - [ ] Create draft PR with story ID in title
-- [ ] Replace broad payload `any` fields in `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` with safer contracts
-- [ ] Preserve current monitoring runtime behavior and public compatibility while tightening audit/health payload typing
-- [ ] Add/update focused tests for audit event serialization and health metadata handling
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09016-monitoring-payload-type-hardening.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Replace broad payload `any` fields in `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` with safer contracts
+- [x] Preserve current monitoring runtime behavior and public compatibility while tightening audit/health payload typing
+- [x] Add/update focused tests for audit event serialization and health metadata handling
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09016-monitoring-payload-type-hardening.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -603,6 +603,7 @@ Implementation notes:
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #78 marked ready: https://github.com/TVScoundrel/agentforge/pull/78
 - [x] Review fixes applied on the active PR branch
+  - `a894d45` `fix(st-09016): preserve explicit falsy audit payloads`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -599,7 +599,9 @@ Implementation notes:
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [x] Commit completed checklist items as logical commits and push updates
   - `c4d11f6` `fix(st-09016): harden monitoring payload contracts`
-- [ ] Mark PR Ready only after all story tasks are complete
+  - `388e2be` `docs(st-09016): record validation and move story to in-review`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #78 marked ready: https://github.com/TVScoundrel/agentforge/pull/78
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -602,6 +602,7 @@ Implementation notes:
   - `388e2be` `docs(st-09016): record validation and move story to in-review`
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #78 marked ready: https://github.com/TVScoundrel/agentforge/pull/78
+- [x] Review fixes applied on the active PR branch
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -585,16 +585,20 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `codex/fix/st-09016-monitoring-payload-type-hardening`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #78 (draft): https://github.com/TVScoundrel/agentforge/pull/78
 - [x] Replace broad payload `any` fields in `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` with safer contracts
 - [x] Preserve current monitoring runtime behavior and public compatibility while tightening audit/health payload typing
 - [x] Add/update focused tests for audit event serialization and health metadata handling
 - [x] Record explicit-`any` warning deltas for touched files in story docs
 - [x] Add or update story documentation at `docs/st09016-monitoring-payload-type-hardening.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `153 passed | 16 skipped` files; `2137 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `c4d11f6` `fix(st-09016): harden monitoring payload contracts`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1092,7 +1092,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09012
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` replace broad `any` payload fields with safer JSON-safe or domain-specific contracts
@@ -1345,4 +1345,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged); ST-09016 (In Progress); [ST-09017 (Ready), ST-09029 (Ready)]; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged); ST-09016 (In Review); [ST-09017 (Ready), ST-09029 (Ready)]; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1092,7 +1092,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09012
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` replace broad `any` payload fields with safer JSON-safe or domain-specific contracts
@@ -1345,4 +1345,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged); [ST-09016 (Ready), ST-09017 (Ready), ST-09029 (Ready)]; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged); ST-09016 (In Progress); [ST-09017 (Ready), ST-09029 (Ready)]; ST-09016 → ST-09018; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-03-25
-**Active Story:** ST-09016 (Ready)
+**Last Updated:** 2026-03-26
+**Active Story:** ST-09016 (In Progress)
 
 ---
 
@@ -42,7 +42,7 @@ Top runtime hotspots informing this feature slice:
 1. `packages/core/src/langgraph/builders/sequential.ts` still carries an easy schema/edge `any` boundary that mirrors the already-completed parallel builder cleanup
 2. `packages/patterns/src/plan-execute/types.ts` still exposes a small but high-leverage `Tool<any, any>[]` boundary in active EP-09 code
 3. `packages/patterns/src/multi-agent/nodes.ts` was split behind the stable public entrypoint in `ST-09015`, with follow-up hardening landed for log redaction, workload invariants, interrupt propagation, and model-content serialization
-4. `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts` still expose broad payload `any` fields in released monitoring contracts
+4. `ST-09016` is tightening the released monitoring payload contracts in `packages/core/src/monitoring/audit.ts` and `packages/core/src/monitoring/health.ts`
 5. `packages/cli/src/commands/**` still repeat command-level `catch (error: any)` handling in multiple entrypoints
 6. `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts` still concentrate a large share of the remaining `testing` package `any` warnings
 7. `packages/core/src/prompt-loader/index.ts`, `packages/core/src/streaming/websocket.ts`, and `packages/patterns/src/reflection/agent.ts` form the next small runtime boundary-hardening slice
@@ -63,6 +63,7 @@ Recent improvement snapshot:
 - `ST-09013` merged with an intentional breaking tightening to the sequential workflow builder contract: explicit state generics were removed, and downstream callers must rely on schema-derived inference from `Annotation.Root(...)`.
 - `ST-09014` merged after tightening the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
 - `ST-09015` merged after splitting the multi-agent node runtime into focused supervisor, worker, aggregator, and shared helper modules, lowering the workspace explicit-`any` baseline from `278` to `276` and the `patterns` package from `25` to `23`.
+- `ST-09016` is in progress after tightening the audit/health monitoring payload contracts, with the current focused delta at `276` to `271` workspace warnings and `111` to `106` in `core`.
 - `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, multi-agent modularization, and plan-execute node modularization.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-03-26
-**Active Story:** ST-09016 (In Progress)
+**Active Story:** ST-09016 (In Review)
 
 ---
 
@@ -63,7 +63,7 @@ Recent improvement snapshot:
 - `ST-09013` merged with an intentional breaking tightening to the sequential workflow builder contract: explicit state generics were removed, and downstream callers must rely on schema-derived inference from `Annotation.Root(...)`.
 - `ST-09014` merged after tightening the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
 - `ST-09015` merged after splitting the multi-agent node runtime into focused supervisor, worker, aggregator, and shared helper modules, lowering the workspace explicit-`any` baseline from `278` to `276` and the `patterns` package from `25` to `23`.
-- `ST-09016` is in progress after tightening the audit/health monitoring payload contracts, with the current focused delta at `276` to `271` workspace warnings and `111` to `106` in `core`.
+- `ST-09016` is in review after tightening the audit/health monitoring payload contracts, lowering the workspace explicit-`any` baseline from `276` to `271` and the `core` package from `111` to `106`.
 - `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, multi-agent modularization, and plan-execute node modularization.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 11 stories
 
@@ -21,13 +21,13 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09016` - Harden Monitoring Audit and Health Payload Types
 
 ---
 
 ## In Progress
 
-- `ST-09016` - Harden Monitoring Audit and Health Payload Types
+_No stories currently in progress_
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-03-26
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 11 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09016` - Harden Monitoring Audit and Health Payload Types
 - `ST-09017` - Centralize CLI Command Error Handling
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 
@@ -28,7 +27,7 @@ _No stories currently in review_
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09016` - Harden Monitoring Audit and Health Payload Types
 
 ---
 


### PR DESCRIPTION
## Summary
- tighten monitoring audit and health payload contracts to use shared JSON-safe observability types
- add focused audit and health regression coverage for payload preservation and health-check error propagation
- move ST-09016 trackers to in-review with recorded explicit-any baseline deltas

## Validation
- pnpm exec tsc -p packages/core/tsconfig.json --noEmit
- pnpm exec eslint packages/core/src/monitoring/audit.ts packages/core/src/monitoring/health.ts packages/core/tests/monitoring/audit-health.test.ts
- pnpm test --run packages/core/tests/monitoring/audit-health.test.ts packages/core/tests/monitoring/alerts.test.ts
- pnpm lint:explicit-any:baseline --silent
- pnpm test --run
- pnpm lint

## Results
- explicit-any baseline: workspace `276 -> 271`, `core 111 -> 106`
- full test suite: `153 passed | 16 skipped` files; `2137 passed | 286 skipped` tests
- lint: exit `0`; warnings only
