### PR TITLE
refactor(st-09017): centralize cli command error handling

### DIFF
--- a/docs/st09017-cli-error-handling-centralization.md
+++ b/docs/st09017-cli-error-handling-centralization.md
@@ -1,0 +1,54 @@
+# ST-09017: Centralize CLI Command Error Handling
+
+## Summary
+
+Consolidated repeated CLI command failure handling behind a shared helper so command modules no longer need their own `catch (error: any)` formatting and `process.exit(1)` boilerplate.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/cli/src/utils/command-errors.ts` | Added the shared CLI command error helper for unknown-error normalization, optional spinner failure handling, and command exit behavior |
+| `packages/cli/src/commands/build.ts` | Replaced the local build failure catch block with the shared command error helper |
+| `packages/cli/src/commands/dev.ts` | Replaced the local dev-server failure catch block with the shared command error helper |
+| `packages/cli/src/commands/test.ts` | Replaced the local test failure catch block with the shared command error helper |
+| `packages/cli/src/commands/lint.ts` | Replaced the outer lint command failure catch block with the shared command error helper while keeping lint/format subprocess failures non-fatal |
+| `packages/cli/src/commands/create.ts` | Replaced repeated project-create validation and command failure exits with the shared helper and removed touched `any` usage |
+| `packages/cli/src/commands/tool/*.ts` | Centralized the tool create/list/test/publish command failure paths while preserving npm-specific publish guidance |
+| `packages/cli/src/commands/agent/*.ts` | Centralized the agent create/list/test/create-reusable/deploy failure paths while preserving the current deployment guidance output |
+| `packages/cli/tests/utils/command-errors.test.ts` | Added focused coverage for error normalization, prefixed messages, spinner failure handling, and caller-managed logging |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/cli/src/commands/**`: `18 -> 0` (`-18`)
+- `packages/cli/src/utils/command-errors.ts`: introduced with `0` explicit-`any` warnings
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `271 -> 253` (`-18`)
+- `cli` package: `24 -> 6` (`-18`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-03-27.)
+
+## Compatibility Notes
+
+- Touched CLI commands preserve the existing user-facing failure messages, spinner failure text, and exit code `1`.
+- `tool:publish` still emits its existing npm-specific guidance for auth, permission, and version-conflict failures; only the generic exit plumbing is centralized.
+- `lint` still treats lint and format subprocess failures as non-fatal informational results inside the command, with only the outer command boundary routed through the shared helper.
+- Commander top-level parse/help handling in `packages/cli/src/index.ts` was left unchanged; this story only centralizes command-module failure handling.
+
+## Validation
+
+- `pnpm exec tsc -p packages/cli/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/cli/src/commands/build.ts packages/cli/src/commands/dev.ts packages/cli/src/commands/test.ts packages/cli/src/commands/lint.ts packages/cli/src/commands/create.ts packages/cli/src/commands/tool/create.ts packages/cli/src/commands/tool/list.ts packages/cli/src/commands/tool/test.ts packages/cli/src/commands/tool/publish.ts packages/cli/src/commands/agent/create.ts packages/cli/src/commands/agent/list.ts packages/cli/src/commands/agent/test.ts packages/cli/src/commands/agent/create-reusable.ts packages/cli/src/commands/agent/deploy.ts packages/cli/src/utils/command-errors.ts packages/cli/tests/utils/command-errors.test.ts packages/cli/tests/commands/build.test.ts packages/cli/tests/commands/dev.test.ts packages/cli/tests/commands/lint.test.ts packages/cli/tests/commands/test.test.ts packages/cli/tests/commands/create.test.ts packages/cli/tests/commands/tool/create.test.ts packages/cli/tests/commands/tool/list.test.ts packages/cli/tests/commands/tool/test.test.ts packages/cli/tests/commands/tool/publish.test.ts packages/cli/tests/commands/agent/create.test.ts packages/cli/tests/commands/agent/list.test.ts packages/cli/tests/commands/agent/test.test.ts packages/cli/tests/commands/agent/create-reusable.test.ts packages/cli/tests/commands/agent/deploy.test.ts`
+  - passed with warnings only in pre-existing CLI test files
+- `pnpm test --run packages/cli/tests/commands/build.test.ts packages/cli/tests/commands/dev.test.ts packages/cli/tests/commands/lint.test.ts packages/cli/tests/commands/test.test.ts packages/cli/tests/commands/create.test.ts packages/cli/tests/commands/tool/create.test.ts packages/cli/tests/commands/tool/list.test.ts packages/cli/tests/commands/tool/test.test.ts packages/cli/tests/commands/tool/publish.test.ts packages/cli/tests/commands/agent/create.test.ts packages/cli/tests/commands/agent/list.test.ts packages/cli/tests/commands/agent/test.test.ts packages/cli/tests/commands/agent/create-reusable.test.ts packages/cli/tests/commands/agent/deploy.test.ts packages/cli/tests/utils/command-errors.test.ts` -> `15 passed` files, `105 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `253/289` warnings, `cli 6/24`
+- `pnpm test --run` -> `154 passed | 16 skipped` files; `2146 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only (`0` errors)
+
+## Test Impact
+
+Added direct automated coverage for the new shared CLI command error helper and revalidated the touched command suite through focused command tests plus the full workspace test pass. No manual-only gap remains for the changed command error boundary.

--- a/packages/cli/src/commands/agent/create-reusable.ts
+++ b/packages/cli/src/commands/agent/create-reusable.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { copyTemplate, getTemplatePath } from '../../utils/fs.js';
 
 interface ReusableAgentCreateOptions {
@@ -106,9 +107,8 @@ export async function agentCreateReusableCommand(
 
     logger.newLine();
     logger.info(chalk.gray('💡 Tip: See examples/vertical-agents/ for reference implementations'));
-  } catch (error: any) {
-    logger.error(`Failed to create reusable agent: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to create reusable agent' });
   }
 }
 
@@ -129,4 +129,3 @@ function kebabToCamel(str: string): string {
   const pascal = kebabToPascal(str);
   return pascal.charAt(0).toLowerCase() + pascal.slice(1);
 }
-

--- a/packages/cli/src/commands/agent/create.ts
+++ b/packages/cli/src/commands/agent/create.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { promptAgentSetup } from '../../utils/prompts.js';
 import { writeFile, ensureDir } from '../../utils/fs.js';
 
@@ -64,9 +65,8 @@ export async function agentCreateCommand(
         ? `Run ${chalk.cyan(`pnpm test tests/agents/${answers.name}.test.ts`)} to test your agent`
         : '',
     ].filter(Boolean));
-  } catch (error: any) {
-    logger.error(`Failed to create agent: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to create agent' });
   }
 }
 
@@ -182,4 +182,3 @@ describe('${capitalize(name)} ${pattern === 'multi-agent' ? 'System' : 'Agent'}'
 function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
-

--- a/packages/cli/src/commands/agent/deploy.ts
+++ b/packages/cli/src/commands/agent/deploy.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 
 interface AgentDeployOptions {
   environment?: string;
@@ -19,9 +20,6 @@ export async function agentDeployCommand(
 
     // Agent deployment is complex and platform-specific
     // Users should use deployment templates or manual deployment
-    logger.error('Automated agent deployment is not yet implemented');
-    logger.newLine();
-
     logger.info(chalk.bold('Please use one of the following deployment methods:'));
     logger.newLine();
 
@@ -51,10 +49,8 @@ export async function agentDeployCommand(
     logger.info(chalk.dim('For detailed deployment guides, see:'));
     logger.info(chalk.dim('https://tvscoundrel.github.io/agentforge/guide/advanced/deployment'));
 
-    process.exit(1);
-  } catch (error: any) {
-    logger.error(error.message);
-    process.exit(1);
+    return exitWithCommandError('Automated agent deployment is not yet implemented');
+  } catch (error: unknown) {
+    return exitWithCommandError(error);
   }
 }
-

--- a/packages/cli/src/commands/agent/deploy.ts
+++ b/packages/cli/src/commands/agent/deploy.ts
@@ -20,6 +20,9 @@ export async function agentDeployCommand(
 
     // Agent deployment is complex and platform-specific
     // Users should use deployment templates or manual deployment
+    logger.error('Automated agent deployment is not yet implemented');
+    logger.newLine();
+
     logger.info(chalk.bold('Please use one of the following deployment methods:'));
     logger.newLine();
 
@@ -49,7 +52,9 @@ export async function agentDeployCommand(
     logger.info(chalk.dim('For detailed deployment guides, see:'));
     logger.info(chalk.dim('https://tvscoundrel.github.io/agentforge/guide/advanced/deployment'));
 
-    return exitWithCommandError('Automated agent deployment is not yet implemented');
+    return exitWithCommandError('Automated agent deployment is not yet implemented', {
+      logError: false,
+    });
   } catch (error: unknown) {
     return exitWithCommandError(error);
   }

--- a/packages/cli/src/commands/agent/list.ts
+++ b/packages/cli/src/commands/agent/list.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { findFiles, readFile } from '../../utils/fs.js';
 
 interface AgentListOptions {
@@ -53,9 +54,8 @@ export async function agentListCommand(options: AgentListOptions): Promise<void>
       logger.newLine();
       logger.info(`Use ${chalk.cyan('--verbose')} for more details`);
     }
-  } catch (error: any) {
-    logger.error(`Failed to list agents: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to list agents' });
   }
 }
 
@@ -73,4 +73,3 @@ function extractDescription(content: string): string | null {
   const match = content.match(/\/\*\*\s*\n\s*\*\s*(.+?)\s*\n/);
   return match ? match[1] : null;
 }
-

--- a/packages/cli/src/commands/agent/test.ts
+++ b/packages/cli/src/commands/agent/test.ts
@@ -21,8 +21,9 @@ export async function agentTestCommand(
 
     // Check if test file exists
     if (!(await pathExists(testFile))) {
+      logger.error(`Test file not found: ${testFile}`);
       logger.info(`Create tests with: ${chalk.cyan(`agentforge agent:create ${name} --test`)}`);
-      return exitWithCommandError(`Test file not found: ${testFile}`);
+      return exitWithCommandError(`Test file not found: ${testFile}`, { logError: false });
     }
 
     logger.info(`Testing agent: ${chalk.cyan(name)}`);

--- a/packages/cli/src/commands/agent/test.ts
+++ b/packages/cli/src/commands/agent/test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../../utils/package-manager.js';
 import { pathExists } from '../../utils/fs.js';
 
@@ -20,9 +21,8 @@ export async function agentTestCommand(
 
     // Check if test file exists
     if (!(await pathExists(testFile))) {
-      logger.error(`Test file not found: ${testFile}`);
       logger.info(`Create tests with: ${chalk.cyan(`agentforge agent:create ${name} --test`)}`);
-      process.exit(1);
+      return exitWithCommandError(`Test file not found: ${testFile}`);
     }
 
     logger.info(`Testing agent: ${chalk.cyan(name)}`);
@@ -40,10 +40,7 @@ export async function agentTestCommand(
     await runScript(cwd, testCommand, packageManager);
 
     logger.succeedSpinner('Tests completed');
-  } catch (error: any) {
-    logger.failSpinner('Tests failed');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { spinnerFailureText: 'Tests failed' });
   }
 }
-

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger.js';
+import { exitWithCommandError } from '../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../utils/package-manager.js';
 
 interface BuildOptions {
@@ -33,10 +34,7 @@ export async function buildCommand(options: BuildOptions): Promise<void> {
     logger.succeedSpinner('Build completed successfully');
     logger.newLine();
     logger.success('✨ Production build ready!');
-  } catch (error: any) {
-    logger.failSpinner('Build failed');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { spinnerFailureText: 'Build failed' });
   }
 }
-

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../utils/logger.js';
+import { exitWithCommandError } from '../utils/command-errors.js';
 import { promptProjectSetup } from '../utils/prompts.js';
 import { copyTemplate, ensureDir, isEmptyDir, writeJson, readJson, getTemplatePath } from '../utils/fs.js';
 import { installDependencies, getRunCommand, type PackageManager } from '../utils/package-manager.js';
@@ -13,6 +14,12 @@ interface CreateOptions {
   git?: boolean;
 }
 
+interface ProjectPackageJson {
+  name?: string;
+  author?: string;
+  description?: string;
+}
+
 export async function createCommand(
   projectName: string,
   options: CreateOptions
@@ -22,16 +29,14 @@ export async function createCommand(
 
     // Validate project name
     if (!projectName) {
-      logger.error('Project name is required');
-      process.exit(1);
+      return exitWithCommandError('Project name is required');
     }
 
     const targetPath = path.join(process.cwd(), projectName);
 
     // Check if directory exists and is not empty
     if (!(await isEmptyDir(targetPath))) {
-      logger.error(`Directory ${projectName} already exists and is not empty`);
-      process.exit(1);
+      return exitWithCommandError(`Directory ${projectName} already exists and is not empty`);
     }
 
     // Prompt for project setup if not all options provided
@@ -68,7 +73,7 @@ export async function createCommand(
     // Update package.json
     logger.startSpinner('Updating package.json...');
     const packageJsonPath = path.join(targetPath, 'package.json');
-    const packageJson = await readJson<any>(packageJsonPath);
+    const packageJson = await readJson<ProjectPackageJson>(packageJsonPath);
     packageJson.name = answers.projectName;
     if (answers.author) {
       packageJson.author = answers.author;
@@ -85,7 +90,7 @@ export async function createCommand(
       try {
         await installDependencies(targetPath, answers.packageManager);
         logger.succeedSpinner('Dependencies installed');
-      } catch (error) {
+      } catch {
         logger.failSpinner('Failed to install dependencies');
         logger.warn('You can install them manually later');
       }
@@ -98,7 +103,7 @@ export async function createCommand(
         await initGitRepository(targetPath);
         await createInitialCommit(targetPath);
         logger.succeedSpinner('Git repository initialized');
-      } catch (error) {
+      } catch {
         logger.failSpinner('Failed to initialize git');
         logger.warn('You can initialize it manually later');
       }
@@ -117,9 +122,7 @@ export async function createCommand(
     ]);
     logger.newLine();
     logger.info('Happy coding! 🎉');
-  } catch (error: any) {
-    logger.error(`Failed to create project: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to create project' });
   }
 }
-

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger.js';
+import { exitWithCommandError } from '../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../utils/package-manager.js';
 
 interface DevOptions {
@@ -27,10 +28,9 @@ export async function devCommand(options: DevOptions): Promise<void> {
     await runScript(cwd, 'dev', packageManager);
 
     logger.succeedSpinner('Development server started');
-  } catch (error: any) {
-    logger.failSpinner('Failed to start development server');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, {
+      spinnerFailureText: 'Failed to start development server',
+    });
   }
 }
-

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger.js';
+import { exitWithCommandError } from '../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../utils/package-manager.js';
 
 interface LintOptions {
@@ -22,7 +23,7 @@ export async function lintCommand(options: LintOptions): Promise<void> {
     try {
       await runScript(cwd, options.fix ? 'lint:fix' : 'lint', packageManager);
       logger.succeedSpinner('Linting completed');
-    } catch (error) {
+    } catch {
       logger.failSpinner('Linting found issues');
       if (!options.fix) {
         logger.info('Run with --fix to automatically fix issues');
@@ -35,16 +36,14 @@ export async function lintCommand(options: LintOptions): Promise<void> {
       try {
         await runScript(cwd, 'format', packageManager);
         logger.succeedSpinner('Formatting completed');
-      } catch (error) {
+      } catch {
         logger.failSpinner('Formatting failed');
       }
     }
 
     logger.newLine();
     logger.success('✨ Code quality check completed!');
-  } catch (error: any) {
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error);
   }
 }
-

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger.js';
+import { exitWithCommandError } from '../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../utils/package-manager.js';
 
 interface TestOptions {
@@ -34,10 +35,7 @@ export async function testCommand(options: TestOptions): Promise<void> {
     await runScript(cwd, script, packageManager);
 
     logger.succeedSpinner('Tests completed');
-  } catch (error: any) {
-    logger.failSpinner('Tests failed');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { spinnerFailureText: 'Tests failed' });
   }
 }
-

--- a/packages/cli/src/commands/tool/create.ts
+++ b/packages/cli/src/commands/tool/create.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { promptToolSetup } from '../../utils/prompts.js';
 import { writeFile, ensureDir, copyTemplate, getTemplatePath } from '../../utils/fs.js';
 
@@ -67,9 +68,8 @@ export async function toolCreateCommand(
         ];
 
     logger.list(nextSteps.filter(Boolean));
-  } catch (error: any) {
-    logger.error(`Failed to create tool: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to create tool' });
   }
 }
 
@@ -201,4 +201,3 @@ async function createMultiFileTool(
     logger.succeedSpinner('Test files removed');
   }
 }
-

--- a/packages/cli/src/commands/tool/list.ts
+++ b/packages/cli/src/commands/tool/list.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { findFiles, readFile } from '../../utils/fs.js';
 
 interface ToolListOptions {
@@ -74,9 +75,8 @@ export async function toolListCommand(options: ToolListOptions): Promise<void> {
       logger.newLine();
       logger.info(`Use ${chalk.cyan('--verbose')} for more details`);
     }
-  } catch (error: any) {
-    logger.error(`Failed to list tools: ${error.message}`);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to list tools' });
   }
 }
 
@@ -89,4 +89,3 @@ function extractDescription(content: string): string | null {
   const match = content.match(/\/\*\*\s*\n\s*\*\s*(.+?)\s*\n/);
   return match ? match[1] : null;
 }
-

--- a/packages/cli/src/commands/tool/publish.ts
+++ b/packages/cli/src/commands/tool/publish.ts
@@ -76,6 +76,7 @@ export async function toolPublishCommand(
       }
     } catch (error: unknown) {
       const errorMessage = getErrorMessage(error);
+      logger.failSpinner('Publishing failed');
 
       // Provide helpful error messages for common issues
       if (errorMessage.includes('ENEEDAUTH') || errorMessage.includes('E401')) {
@@ -92,7 +93,6 @@ export async function toolPublishCommand(
       }
 
       return exitWithCommandError(error, {
-        spinnerFailureText: 'Publishing failed',
         logError: false,
       });
     }

--- a/packages/cli/src/commands/tool/publish.ts
+++ b/packages/cli/src/commands/tool/publish.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError, getErrorMessage } from '../../utils/command-errors.js';
 import { runScript, detectPackageManager, publishPackage } from '../../utils/package-manager.js';
 
 interface ToolPublishOptions {
@@ -36,10 +37,11 @@ export async function toolPublishCommand(
       try {
         await runScript(toolPath, 'test', packageManager);
         logger.succeedSpinner('Tests passed');
-      } catch (error) {
-        logger.failSpinner('Tests failed');
-        logger.error('Cannot publish tool with failing tests');
-        process.exit(1);
+      } catch (error: unknown) {
+        return exitWithCommandError(error, {
+          spinnerFailureText: 'Tests failed',
+          message: 'Cannot publish tool with failing tests',
+        });
       }
     } else {
       logger.info('⚠️  Skipping tests (no test script found)');
@@ -51,9 +53,8 @@ export async function toolPublishCommand(
       try {
         await runScript(toolPath, 'build', packageManager);
         logger.succeedSpinner('Build completed');
-      } catch (error) {
-        logger.failSpinner('Build failed');
-        process.exit(1);
+      } catch (error: unknown) {
+        return exitWithCommandError(error, { spinnerFailureText: 'Build failed' });
       }
     } else {
       logger.info('⚠️  Skipping build (no build script found)');
@@ -73,24 +74,27 @@ export async function toolPublishCommand(
       } else {
         logger.succeedSpinner('Published to npm');
       }
-    } catch (error: any) {
-      logger.failSpinner('Publishing failed');
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
 
       // Provide helpful error messages for common issues
-      if (error.message.includes('ENEEDAUTH') || error.message.includes('E401')) {
+      if (errorMessage.includes('ENEEDAUTH') || errorMessage.includes('E401')) {
         logger.error('Not authenticated with npm');
         logger.info('Run: npm login');
-      } else if (error.message.includes('E403')) {
+      } else if (errorMessage.includes('E403')) {
         logger.error('Permission denied - you may not have access to publish this package');
         logger.info('Check package name and npm organization permissions');
-      } else if (error.message.includes('EPUBLISHCONFLICT') || error.message.includes('E409')) {
+      } else if (errorMessage.includes('EPUBLISHCONFLICT') || errorMessage.includes('E409')) {
         logger.error('Version already published');
         logger.info('Update the version in package.json before publishing');
       } else {
-        logger.error(error.message);
+        logger.error(errorMessage);
       }
 
-      process.exit(1);
+      return exitWithCommandError(error, {
+        spinnerFailureText: 'Publishing failed',
+        logError: false,
+      });
     }
 
     logger.newLine();
@@ -105,10 +109,8 @@ export async function toolPublishCommand(
       logger.info(`Published ${chalk.cyan(name)} with tag ${chalk.cyan(options.tag || 'latest')}`);
       logger.info('Users can now install with: npm install ' + name);
     }
-  } catch (error: any) {
-    logger.failSpinner('Publishing failed');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { spinnerFailureText: 'Publishing failed' });
   }
 }
 
@@ -116,6 +118,14 @@ interface ToolPathInfo {
   toolPath: string;
   hasTestScript: boolean;
   hasBuildScript: boolean;
+}
+
+interface ToolPackageJson {
+  name?: string;
+  scripts?: {
+    test?: string;
+    build?: string;
+  };
 }
 
 /**
@@ -191,7 +201,7 @@ async function resolveToolPath(name: string): Promise<ToolPathInfo> {
     'Providing a path to the tool package directory',
     'Have the tool in a standard location (./tools/<name>, ./packages/<name>)',
   ]);
-  process.exit(1);
+  return exitWithCommandError(`Could not find tool package: ${name}`);
 }
 
 /**
@@ -201,31 +211,27 @@ async function resolveToolPath(name: string): Promise<ToolPathInfo> {
 async function validateToolPath(toolPath: string, expectedName: string): Promise<ToolPathInfo> {
   // Check if directory exists
   if (!(await fs.pathExists(toolPath))) {
-    logger.error(`Tool directory not found: ${toolPath}`);
-    process.exit(1);
+    return exitWithCommandError(`Tool directory not found: ${toolPath}`);
   }
 
   // Check if package.json exists
   const packageJsonPath = path.join(toolPath, 'package.json');
   if (!(await fs.pathExists(packageJsonPath))) {
-    logger.error(`package.json not found in: ${toolPath}`);
     logger.info('Tool packages must have a package.json file');
-    process.exit(1);
+    return exitWithCommandError(`package.json not found in: ${toolPath}`);
   }
 
   // Read and validate package.json
-  let packageJson: any;
+  let packageJson: ToolPackageJson;
   try {
-    packageJson = await fs.readJson(packageJsonPath);
-  } catch (error: any) {
-    logger.error(`Failed to read package.json: ${error.message}`);
-    process.exit(1);
+    packageJson = (await fs.readJson(packageJsonPath)) as ToolPackageJson;
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { prefix: 'Failed to read package.json' });
   }
 
   // Validate package name
   if (!packageJson.name) {
-    logger.error('package.json must have a "name" field');
-    process.exit(1);
+    return exitWithCommandError('package.json must have a "name" field');
   }
 
   // Warn if package name doesn't match expected name (but don't fail)
@@ -252,4 +258,3 @@ async function validateToolPath(toolPath: string, expectedName: string): Promise
     hasBuildScript,
   };
 }
-

--- a/packages/cli/src/commands/tool/publish.ts
+++ b/packages/cli/src/commands/tool/publish.ts
@@ -201,7 +201,7 @@ async function resolveToolPath(name: string): Promise<ToolPathInfo> {
     'Providing a path to the tool package directory',
     'Have the tool in a standard location (./tools/<name>, ./packages/<name>)',
   ]);
-  return exitWithCommandError(`Could not find tool package: ${name}`);
+  return exitWithCommandError(`Could not find tool package: ${name}`, { logError: false });
 }
 
 /**

--- a/packages/cli/src/commands/tool/test.ts
+++ b/packages/cli/src/commands/tool/test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from '../../utils/logger.js';
+import { exitWithCommandError } from '../../utils/command-errors.js';
 import { runScript, detectPackageManager } from '../../utils/package-manager.js';
 import { pathExists } from '../../utils/fs.js';
 
@@ -20,9 +21,8 @@ export async function toolTestCommand(
 
     // Check if test file exists
     if (!(await pathExists(testFile))) {
-      logger.error(`Test file not found: ${testFile}`);
       logger.info(`Create tests with: ${chalk.cyan(`agentforge tool:create ${name} --test`)}`);
-      process.exit(1);
+      return exitWithCommandError(`Test file not found: ${testFile}`);
     }
 
     logger.info(`Testing tool: ${chalk.cyan(name)}`);
@@ -40,10 +40,7 @@ export async function toolTestCommand(
     await runScript(cwd, testCommand, packageManager);
 
     logger.succeedSpinner('Tests completed');
-  } catch (error: any) {
-    logger.failSpinner('Tests failed');
-    logger.error(error.message);
-    process.exit(1);
+  } catch (error: unknown) {
+    return exitWithCommandError(error, { spinnerFailureText: 'Tests failed' });
   }
 }
-

--- a/packages/cli/src/commands/tool/test.ts
+++ b/packages/cli/src/commands/tool/test.ts
@@ -21,8 +21,9 @@ export async function toolTestCommand(
 
     // Check if test file exists
     if (!(await pathExists(testFile))) {
+      logger.error(`Test file not found: ${testFile}`);
       logger.info(`Create tests with: ${chalk.cyan(`agentforge tool:create ${name} --test`)}`);
-      return exitWithCommandError(`Test file not found: ${testFile}`);
+      return exitWithCommandError(`Test file not found: ${testFile}`, { logError: false });
     }
 
     logger.info(`Testing tool: ${chalk.cyan(name)}`);

--- a/packages/cli/src/utils/command-errors.ts
+++ b/packages/cli/src/utils/command-errors.ts
@@ -1,0 +1,46 @@
+import { logger } from './logger.js';
+
+export interface CommandFailureOptions {
+  spinnerFailureText?: string;
+  message?: string;
+  prefix?: string;
+  logError?: boolean;
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export function exitWithCommandError<T = void>(
+  error: unknown,
+  options: CommandFailureOptions = {}
+): T {
+  if (options.spinnerFailureText) {
+    logger.failSpinner(options.spinnerFailureText);
+  }
+
+  if (options.logError !== false) {
+    const message = options.message ?? getErrorMessage(error);
+    logger.error(options.prefix ? `${options.prefix}: ${message}` : message);
+  }
+
+  process.exit(1);
+  return undefined as T;
+}

--- a/packages/cli/src/utils/command-errors.ts
+++ b/packages/cli/src/utils/command-errors.ts
@@ -28,10 +28,10 @@ export function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
-export function exitWithCommandError<T = void>(
+export function exitWithCommandError(
   error: unknown,
   options: CommandFailureOptions = {}
-): T {
+): never {
   if (options.spinnerFailureText) {
     logger.failSpinner(options.spinnerFailureText);
   }
@@ -42,5 +42,4 @@ export function exitWithCommandError<T = void>(
   }
 
   process.exit(1);
-  return undefined as T;
 }

--- a/packages/cli/tests/utils/command-errors.test.ts
+++ b/packages/cli/tests/utils/command-errors.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  exitWithCommandError,
+  getErrorMessage,
+} from '../../src/utils/command-errors.js';
+import * as logger from '../../src/utils/logger.js';
+
+vi.mock('../../src/utils/logger.js');
+
+describe('command-errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  describe('getErrorMessage', () => {
+    it('returns Error messages', () => {
+      expect(getErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('returns string inputs unchanged', () => {
+      expect(getErrorMessage('boom')).toBe('boom');
+    });
+
+    it('reads string message properties from unknown objects', () => {
+      expect(getErrorMessage({ message: 'boom' })).toBe('boom');
+    });
+  });
+
+  describe('exitWithCommandError', () => {
+    it('fails the spinner and logs the normalized message', () => {
+      exitWithCommandError(new Error('boom'), { spinnerFailureText: 'Failed' });
+
+      expect(logger.logger.failSpinner).toHaveBeenCalledWith('Failed');
+      expect(logger.logger.error).toHaveBeenCalledWith('boom');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('supports prefixed messages', () => {
+      exitWithCommandError(new Error('boom'), { prefix: 'Failed to create tool' });
+
+      expect(logger.logger.error).toHaveBeenCalledWith('Failed to create tool: boom');
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it('can skip error logging when the caller already handled it', () => {
+      exitWithCommandError(new Error('boom'), { logError: false });
+
+      expect(logger.logger.error).not.toHaveBeenCalled();
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/cli/tests/utils/command-errors.test.ts
+++ b/packages/cli/tests/utils/command-errors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   exitWithCommandError,
   getErrorMessage,
@@ -8,9 +8,15 @@ import * as logger from '../../src/utils/logger.js';
 vi.mock('../../src/utils/logger.js');
 
 describe('command-errors', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
   });
 
   describe('getErrorMessage', () => {

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -611,19 +611,19 @@ Implementation notes:
 
 ## ST-09017: Centralize CLI Command Error Handling
 
-**Branch:** `refactor/st-09017-cli-error-handling-centralization`
+**Branch:** `codex/refactor/st-09017-cli-error-handling-centralization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09017-cli-error-handling-centralization`
+- [x] Create branch `codex/refactor/st-09017-cli-error-handling-centralization`
 - [ ] Create draft PR with story ID in title
-- [ ] Consolidate repeated command-level error formatting and exit handling in `packages/cli/src/commands/**`
-- [ ] Preserve current CLI user-visible behavior and exit codes while reducing repetitive `catch (error: any)` usage
-- [ ] Add/update focused tests for shared command error handling where the existing CLI test surface supports it
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09017-cli-error-handling-centralization.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Consolidate repeated command-level error formatting and exit handling in `packages/cli/src/commands/**`
+- [x] Preserve current CLI user-visible behavior and exit codes while reducing repetitive `catch (error: any)` usage
+- [x] Add/update focused tests for shared command error handling where the existing CLI test surface supports it
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09017-cli-error-handling-centralization.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -635,6 +635,7 @@ Implementation notes:
 - [x] Review fixes applied on the active PR branch
   - `399d76d` `fix(st-09017): preserve cli error output ordering`
   - `0f54f57` `fix(st-09017): fail publish spinner before npm guidance`
+  - `f1aa02d` `fix(st-09017): tighten command error helper contract`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -615,7 +615,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `codex/refactor/st-09017-cli-error-handling-centralization`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #79 (draft): https://github.com/TVScoundrel/agentforge/pull/79
 - [x] Consolidate repeated command-level error formatting and exit handling in `packages/cli/src/commands/**`
 - [x] Preserve current CLI user-visible behavior and exit codes while reducing repetitive `catch (error: any)` usage
 - [x] Add/update focused tests for shared command error handling where the existing CLI test surface supports it
@@ -623,9 +624,14 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09017-cli-error-handling-centralization.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
 - [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `154 passed | 16 skipped` files; `2146 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `af0dbac` `refactor(st-09017): centralize cli command error handling`
+  - `ab45437` `docs(st-09017): record validation and move story to in-review`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #79 marked ready: https://github.com/TVScoundrel/agentforge/pull/79
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -632,6 +632,8 @@ Implementation notes:
   - `ab45437` `docs(st-09017): record validation and move story to in-review`
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #79 marked ready: https://github.com/TVScoundrel/agentforge/pull/79
+- [x] Review fixes applied on the active PR branch
+  - `399d76d` `fix(st-09017): preserve cli error output ordering`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -634,6 +634,7 @@ Implementation notes:
   - PR #79 marked ready: https://github.com/TVScoundrel/agentforge/pull/79
 - [x] Review fixes applied on the active PR branch
   - `399d76d` `fix(st-09017): preserve cli error output ordering`
+  - `0f54f57` `fix(st-09017): fail publish spinner before npm guidance`
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1109,7 +1109,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09012
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] Repeated command-level error formatting/exit handling in `packages/cli/src/commands/**` is consolidated behind a shared helper or wrapper
@@ -1345,4 +1345,4 @@
 6. Phase 6 (Agent Skills): ST-06001 → ST-06002 → ST-06003 → ST-06004 → ST-06005 → ST-06006
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
-9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged) → ST-09016 (Merged); [ST-09017 (Ready), ST-09018 (Ready), ST-09029 (Ready)]; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009
+9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged) → ST-09016 (Merged); [ST-09017 (In Review), ST-09018 (Ready), ST-09029 (Ready)]; ST-09025 → ST-09026; ST-09027 → ST-09028; [ST-09019, ST-09020, ST-09021, ST-09022, ST-09023] remain independently queueable after ST-09012; ST-09024 follows the ask-human/interrupt hardening slice after ST-09009

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-03-26
-**Active Story:** ST-09017 (Ready)
+**Last Updated:** 2026-03-27
+**Active Story:** ST-09017 (In Review)
 
 ---
 
@@ -32,17 +32,17 @@
 
 ## Current Hotspot Snapshot
 
-Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-23):
+Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-03-27):
 
-- Total: `289` warnings (`src/**`)
-- By package: `core 119`, `tools 67`, `testing 51`, `patterns 28`, `cli 24`
+- Total: `253` warnings (`src/**`)
+- By package: `core 106`, `tools 67`, `testing 51`, `patterns 23`, `cli 6`
 
 Top runtime hotspots informing this feature slice:
 
 1. `packages/core/src/langgraph/builders/sequential.ts` still carries an easy schema/edge `any` boundary that mirrors the already-completed parallel builder cleanup
 2. `packages/patterns/src/plan-execute/types.ts` still exposes a small but high-leverage `Tool<any, any>[]` boundary in active EP-09 code
 3. `packages/patterns/src/multi-agent/nodes.ts` was split behind the stable public entrypoint in `ST-09015`, with follow-up hardening landed for log redaction, workload invariants, interrupt propagation, and model-content serialization
-4. `packages/cli/src/commands/**` still repeat command-level `catch (error: any)` handling in multiple entrypoints
+4. `ST-09017` has centralized repeated CLI command-level `catch (error: any)` handling behind a shared helper and is now in review
 5. `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts` still concentrate a large share of the remaining `testing` package `any` warnings
 6. `packages/core/src/prompt-loader/index.ts`, `packages/core/src/streaming/websocket.ts`, and `packages/patterns/src/reflection/agent.ts` form the next small runtime boundary-hardening slice
 7. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
@@ -63,7 +63,8 @@ Recent improvement snapshot:
 - `ST-09014` merged after tightening the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
 - `ST-09015` merged after splitting the multi-agent node runtime into focused supervisor, worker, aggregator, and shared helper modules, lowering the workspace explicit-`any` baseline from `278` to `276` and the `patterns` package from `25` to `23`.
 - `ST-09016` merged after tightening the audit/health monitoring payload contracts, lowering the workspace explicit-`any` baseline from `276` to `271` and the `core` package from `111` to `106`, with follow-up fixes for falsy JSON payload retention, structured startup logging, and explicit zero timestamps.
-- `EP-09` remains open as the daily hardening stream, with the next follow-on slice targeting monitoring payloads, CLI error handling, testing helpers, multi-agent modularization, and plan-execute node modularization.
+- `ST-09017` has moved to In Review after centralizing CLI command error handling, lowering the workspace explicit-`any` baseline from `271` to `253` and the `cli` package from `24` to `6`.
+- `EP-09` remains open as the daily hardening stream, with the next follow-on slice now centered on testing helper hardening, plan-execute node modularization, prompt-loading contracts, reflection routing, and the larger registry/connection-manager split work.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-26
+**Last Updated:** 2026-03-27
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
+- **Ready:** 2 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 10 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09017` - Centralize CLI Command Error Handling
 - `ST-09018` - Harden Testing Assertion and State Builder Helpers
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 
@@ -22,7 +21,7 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09017` - Centralize CLI Command Error Handling
 
 ---
 
@@ -117,8 +116,9 @@ _No stories currently blocked_
 - ✅ ST-09014 complete - plan-execute shared type boundaries tightened (PR #76, 2026-03-24)
 - ✅ ST-09015 complete - multi-agent node responsibilities modularized with follow-up hardening for logging, workload invariants, interrupts, and model-content serialization (PR #77, 2026-03-25)
 - ✅ ST-09016 complete - monitoring audit and health payload contracts hardened with follow-up fixes for falsy JSON payload preservation, structured startup logging, and timestamp semantics (PR #78, 2026-03-26)
+- `ST-09017` moved to In Review on 2026-03-27 after centralizing CLI command error handling behind a shared helper and lowering the `cli` explicit-`any` baseline from `24` to `6`
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded on 2026-03-22 with low-hanging follow-on stories ST-09008 through ST-09012
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded again on 2026-03-23 with daily hardening stories ST-09013 through ST-09018
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a third time on 2026-03-23 with daily hardening stories ST-09019 through ST-09028
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a fourth time on 2026-03-24 with the plan-execute node modularization follow-up story ST-09029
-- Current measured `no-explicit-any` baseline is `278` warnings (`cli 24`, `core 119`, `patterns 25`, `testing 51`, `tools 67`)
+- Current measured `no-explicit-any` baseline is `253` warnings (`cli 6`, `core 106`, `patterns 23`, `testing 51`, `tools 67`)


### PR DESCRIPTION
## Summary
- centralize shared CLI command failure normalization, spinner failure handling, and exit behavior in `packages/cli/src/utils/command-errors.ts`
- migrate CLI build/dev/test/lint/create, tool, and agent commands off repeated `catch (error: any)` blocks while preserving command-specific behavior
- add focused coverage for the shared helper and revalidate the touched CLI command surface

## Testing
- `pnpm exec tsc -p packages/cli/tsconfig.json --noEmit`
- `pnpm exec eslint packages/cli/src/commands/build.ts packages/cli/src/commands/dev.ts packages/cli/src/commands/test.ts packages/cli/src/commands/lint.ts packages/cli/src/commands/create.ts packages/cli/src/commands/tool/create.ts packages/cli/src/commands/tool/list.ts packages/cli/src/commands/tool/test.ts packages/cli/src/commands/tool/publish.ts packages/cli/src/commands/agent/create.ts packages/cli/src/commands/agent/list.ts packages/cli/src/commands/agent/test.ts packages/cli/src/commands/agent/create-reusable.ts packages/cli/src/commands/agent/deploy.ts packages/cli/src/utils/command-errors.ts packages/cli/tests/utils/command-errors.test.ts packages/cli/tests/commands/build.test.ts packages/cli/tests/commands/dev.test.ts packages/cli/tests/commands/lint.test.ts packages/cli/tests/commands/test.test.ts packages/cli/tests/commands/create.test.ts packages/cli/tests/commands/tool/create.test.ts packages/cli/tests/commands/tool/list.test.ts packages/cli/tests/commands/tool/test.test.ts packages/cli/tests/commands/tool/publish.test.ts packages/cli/tests/commands/agent/create.test.ts packages/cli/tests/commands/agent/list.test.ts packages/cli/tests/commands/agent/test.test.ts packages/cli/tests/commands/agent/create-reusable.test.ts packages/cli/tests/commands/agent/deploy.test.ts`
- `pnpm test --run packages/cli/tests/commands/build.test.ts packages/cli/tests/commands/dev.test.ts packages/cli/tests/commands/lint.test.ts packages/cli/tests/commands/test.test.ts packages/cli/tests/commands/create.test.ts packages/cli/tests/commands/tool/create.test.ts packages/cli/tests/commands/tool/list.test.ts packages/cli/tests/commands/tool/test.test.ts packages/cli/tests/commands/tool/publish.test.ts packages/cli/tests/commands/agent/create.test.ts packages/cli/tests/commands/agent/list.test.ts packages/cli/tests/commands/agent/test.test.ts packages/cli/tests/commands/agent/create-reusable.test.ts packages/cli/tests/commands/agent/deploy.test.ts packages/cli/tests/utils/command-errors.test.ts` -> `15 passed` files, `105 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `253/289` warnings, `cli 6/24`
- `pnpm test --run` -> `154 passed | 16 skipped` files; `2146 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Notes
- `packages/cli/src/index.ts` top-level Commander parse/help handling is intentionally unchanged; this story centralizes command-module failure handling only.
- `tool:publish` keeps its npm-specific auth/permission/conflict messaging while delegating generic exit plumbing to the shared helper.
