### PR TITLE
ST-09019: Harden Reflection Agent Routing Typing

### DIFF
--- a/docs/st09019-reflection-agent-routing-typing.md
+++ b/docs/st09019-reflection-agent-routing-typing.md
@@ -1,0 +1,45 @@
+# ST-09019: Harden Reflection Agent Routing Typing
+
+## Summary
+
+Tightened the reflection agent factory so its routing and compile boundary no longer rely on `as any`, while preserving the existing generator, reflector, reviser, and finisher workflow behavior.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/patterns/src/reflection/agent.ts` | Replaced inline `as any` routing with node-specific typed route maps and removed the compile-time `as any` cast from `createReflectionAgent(...)` |
+| `packages/patterns/tests/reflection/agent.test.ts` | Added focused route-behavior coverage for direct completion after reflection and max-iteration finishing after revision |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/patterns/src/reflection/agent.ts`: `4 -> 0` (`-4`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `233 -> 229` (`-4`)
+- `patterns` package: `23 -> 19` (`-4`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-03-30.)
+
+## Compatibility Notes
+
+- `createReflectionAgent(...)` keeps the same runtime node flow: generator -> reflector -> reviser/finisher -> end.
+- The route return values are now typed per node instead of being erased through `as any`, which keeps the compile-time contract aligned with the actual graph edges.
+- The compiled graph return type is now inferred directly from `workflow.compile(...)` rather than being widened with a cast.
+- The new focused test coverage locks in two key route paths without changing the broader reflection integration surface.
+
+## Validation
+
+- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/patterns/src/reflection/agent.ts packages/patterns/tests/reflection/agent.test.ts packages/patterns/tests/reflection/integration.test.ts`
+- `pnpm test --run packages/patterns/tests/reflection/agent.test.ts packages/patterns/tests/reflection/integration.test.ts packages/patterns/tests/reflection/state.test.ts packages/patterns/tests/reflection/nodes.test.ts` -> `4 passed` files, `32 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `229/289` warnings, `patterns 19/28`
+- `pnpm test --run` -> `156 passed | 16 skipped` files; `2160 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
+
+## Test Impact
+
+Added focused automated coverage for the reflection factory’s route decisions while preserving the existing state, node, and integration coverage for the reflection pattern.

--- a/packages/patterns/src/reflection/agent.ts
+++ b/packages/patterns/src/reflection/agent.ts
@@ -9,7 +9,28 @@
 import { StateGraph, END } from '@langchain/langgraph';
 import { ReflectionState, type ReflectionStateType } from './state.js';
 import { createGeneratorNode, createReflectorNode, createReviserNode, createFinisherNode } from './nodes.js';
-import type { ReflectionAgentConfig, ReflectionRoute } from './types.js';
+import type { ReflectionAgentConfig } from './types.js';
+
+type RouteAfterGenerator = 'reflect' | 'error';
+type RouteAfterReflector = 'revise' | 'finish' | 'error';
+type RouteAfterReviser = 'reflect' | 'finish' | 'error';
+
+const generatorRouteMap = {
+  reflect: 'reflector',
+  error: END,
+} as const satisfies Record<RouteAfterGenerator, 'reflector' | typeof END>;
+
+const reflectorRouteMap = {
+  revise: 'reviser',
+  finish: 'finisher',
+  error: END,
+} as const satisfies Record<RouteAfterReflector, 'reviser' | 'finisher' | typeof END>;
+
+const reviserRouteMap = {
+  reflect: 'reflector',
+  finish: 'finisher',
+  error: END,
+} as const satisfies Record<RouteAfterReviser, 'reflector' | 'finisher' | typeof END>;
 
 /**
  * Create a Reflection agent
@@ -89,14 +110,14 @@ export function createReflectionAgent(config: ReflectionAgentConfig) {
   const finisherNode = createFinisherNode();
 
   // Define routing logic
-  const routeAfterGenerator = (state: ReflectionStateType): ReflectionRoute => {
+  const routeAfterGenerator = (state: ReflectionStateType): RouteAfterGenerator => {
     if (state.status === 'failed') {
       return 'error';
     }
     return 'reflect';
   };
 
-  const routeAfterReflector = (state: ReflectionStateType): ReflectionRoute => {
+  const routeAfterReflector = (state: ReflectionStateType): RouteAfterReflector => {
     if (state.status === 'failed') {
       return 'error';
     }
@@ -113,7 +134,7 @@ export function createReflectionAgent(config: ReflectionAgentConfig) {
     return 'revise';
   };
 
-  const routeAfterReviser = (state: ReflectionStateType): ReflectionRoute => {
+  const routeAfterReviser = (state: ReflectionStateType): RouteAfterReviser => {
     if (state.status === 'failed') {
       return 'error';
     }
@@ -138,32 +159,21 @@ export function createReflectionAgent(config: ReflectionAgentConfig) {
     .addEdge('__start__', 'generator')
     .addConditionalEdges(
       'generator',
-      routeAfterGenerator as any,
-      {
-        reflect: 'reflector',
-        error: END,
-      }
+      routeAfterGenerator,
+      generatorRouteMap
     )
     .addConditionalEdges(
       'reflector',
-      routeAfterReflector as any,
-      {
-        revise: 'reviser',
-        finish: 'finisher',
-        error: END,
-      }
+      routeAfterReflector,
+      reflectorRouteMap
     )
     .addConditionalEdges(
       'reviser',
-      routeAfterReviser as any,
-      {
-        reflect: 'reflector',
-        finish: 'finisher',
-        error: END,
-      }
+      routeAfterReviser,
+      reviserRouteMap
     )
     .addEdge('finisher', END);
 
   // Compile with checkpointer if provided
-  return workflow.compile(checkpointer ? { checkpointer } : undefined) as any;
+  return workflow.compile(checkpointer ? { checkpointer } : undefined);
 }

--- a/packages/patterns/tests/reflection/agent.test.ts
+++ b/packages/patterns/tests/reflection/agent.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { createReflectionAgent } from '../../src/reflection/agent.js';
+
+describe('Reflection Agent Factory', () => {
+  it('routes directly to finish when the reflector marks the response complete', async () => {
+    const llm = new FakeListChatModel({
+      responses: [
+        'Initial response',
+        JSON.stringify({
+          critique: 'Looks good',
+          issues: [],
+          suggestions: [],
+          score: 9,
+          meetsStandards: true,
+        }),
+      ],
+    });
+
+    const agent = createReflectionAgent({
+      generator: { model: llm },
+      reflector: { model: llm },
+      reviser: { model: llm },
+      maxIterations: 3,
+    });
+
+    const result = await agent.invoke({
+      input: 'Write a short summary',
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.reflections).toHaveLength(1);
+    expect(result.revisions).toHaveLength(0);
+    expect(result.response).toBe('Initial response');
+  });
+
+  it('finishes after revision when max iterations are reached', async () => {
+    const llm = new FakeListChatModel({
+      responses: [
+        'Initial draft',
+        JSON.stringify({
+          critique: 'Needs improvement',
+          issues: ['Too brief'],
+          suggestions: ['Add more detail'],
+          score: 5,
+          meetsStandards: false,
+        }),
+        'Revised draft',
+      ],
+    });
+
+    const agent = createReflectionAgent({
+      generator: { model: llm },
+      reflector: { model: llm },
+      reviser: { model: llm },
+      maxIterations: 2,
+    });
+
+    const result = await agent.invoke({
+      input: 'Write a short summary',
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.reflections).toHaveLength(1);
+    expect(result.revisions).toHaveLength(1);
+    expect(result.response).toBe('Revised draft');
+    expect(result.iteration).toBe(2);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -683,7 +683,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `codex/fix/st-09019-reflection-agent-routing-typing`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - Draft PR #81 created: https://github.com/TVScoundrel/agentforge/pull/81
 - [x] Remove avoidable route/compile `as any` usage from `packages/patterns/src/reflection/agent.ts`
 - [x] Preserve current reflection generator/reflector/reviser/completion routing behavior while tightening route typing
 - [x] Add/update focused tests for route decisions and compiled agent invocation behavior
@@ -696,7 +697,9 @@ Implementation notes:
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [x] Commit completed checklist items as logical commits and push updates
   - `8553a62` `refactor(st-09019): tighten reflection routing typing`
-- [ ] Mark PR Ready only after all story tasks are complete
+  - `ac82aa4` `docs(st-09019): record validation and move story to in-review`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #81 marked ready: https://github.com/TVScoundrel/agentforge/pull/81
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -679,20 +679,23 @@ Implementation notes:
 
 ## ST-09019: Harden Reflection Agent Routing Typing
 
-**Branch:** `fix/st-09019-reflection-agent-routing-typing`
+**Branch:** `codex/fix/st-09019-reflection-agent-routing-typing`
 
 ### Checklist
-- [ ] Create branch `fix/st-09019-reflection-agent-routing-typing`
+- [x] Create branch `codex/fix/st-09019-reflection-agent-routing-typing`
 - [ ] Create draft PR with story ID in title
-- [ ] Remove avoidable route/compile `as any` usage from `packages/patterns/src/reflection/agent.ts`
-- [ ] Preserve current reflection generator/reflector/reviser/completion routing behavior while tightening route typing
-- [ ] Add/update focused tests for route decisions and compiled agent invocation behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09019-reflection-agent-routing-typing.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Remove avoidable route/compile `as any` usage from `packages/patterns/src/reflection/agent.ts`
+- [x] Preserve current reflection generator/reflector/reviser/completion routing behavior while tightening route typing
+- [x] Add/update focused tests for route decisions and compiled agent invocation behavior
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09019-reflection-agent-routing-typing.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `156 passed | 16 skipped` files; `2160 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `8553a62` `refactor(st-09019): tighten reflection routing typing`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1144,7 +1144,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09012
-**Status:** Backlog
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/reflection/agent.ts` removes avoidable `as any` usage around conditional routing and compile return handling

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-03-29
-**Active Story:** ST-09019 (Ready)
+**Last Updated:** 2026-03-30
+**Active Story:** ST-09019 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-03-29
+**Last Updated:** 2026-03-30
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
+- **Ready:** 4 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 6 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09019` - Harden Reflection Agent Routing Typing
 - `ST-09020` - Tighten Prompt Loader Variable Contracts
 - `ST-09021` - Harden Streaming WebSocket and Message Contracts
 - `ST-09022` - Harden Shared Deduplication Utility Contracts
@@ -24,7 +23,7 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09019` - Harden Reflection Agent Routing Typing
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09019 - Harden Reflection Agent Routing Typing

## What Changed
- replaced the reflection factory's inline `as any` routing casts with typed node-specific route maps in `packages/patterns/src/reflection/agent.ts`
- removed the factory's compile-time `as any` cast and relied on direct `workflow.compile(...)` inference
- added focused route-behavior coverage in `packages/patterns/tests/reflection/agent.test.ts`
- recorded the warning delta, compatibility notes, and validation evidence in `docs/st09019-reflection-agent-routing-typing.md`
- updated the EP-09 trackers to move ST-09019 into review state

## Acceptance Criteria Coverage
- removed avoidable route and compile `as any` usage from `packages/patterns/src/reflection/agent.ts`
- preserved generator, reflector, reviser, and finisher runtime behavior with focused route tests plus existing integration coverage
- added focused automated tests for route decisions and compiled invocation behavior
- recorded the explicit-`any` warning delta for the touched reflection factory file
- added the required story documentation

## Validation Performed
- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
- `pnpm exec eslint packages/patterns/src/reflection/agent.ts packages/patterns/tests/reflection/agent.test.ts packages/patterns/tests/reflection/integration.test.ts`
- `pnpm test --run packages/patterns/tests/reflection/agent.test.ts packages/patterns/tests/reflection/integration.test.ts packages/patterns/tests/reflection/state.test.ts packages/patterns/tests/reflection/nodes.test.ts` -> `4 passed` files, `32 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `229/289` warnings, `patterns 19/28`
- `pnpm test --run` -> `156 passed | 16 skipped` files; `2160 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Status
- Ready for review
