### PR TITLE
fix(st-09022): harden shared deduplication utility contracts

### DIFF
--- a/docs/st09022-shared-deduplication-contracts.md
+++ b/docs/st09022-shared-deduplication-contracts.md
@@ -1,0 +1,46 @@
+# ST-09022: Harden Shared Deduplication Utility Contracts
+
+## Summary
+
+Tightened the shared deduplication helpers around unknown-first normalization and cache-key generation so the ReAct and Plan-Execute runtimes no longer depend on broad `any` inputs while preserving the current deduplication behavior.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/patterns/src/shared/deduplication.ts` | Replaced broad normalization and cache-key `any` seams with `unknown` plus explicit plain-object guards, and normalized sorted objects onto null-prototype maps so special keys are treated as data |
+| `packages/patterns/tests/shared/deduplication.test.ts` | Added focused coverage for the `__proto__` special-key path while retaining existing cache-key normalization and metrics checks |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/patterns/src/shared/deduplication.ts`: `4 -> 0` (`-4`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `205 -> 201` (`-4`)
+- `patterns` package: `19 -> 15` (`-4`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-03.)
+
+## Compatibility Notes
+
+- `generateToolCallCacheKey(...)` still produces stable keys for nested plain objects whose property order differs only by insertion order.
+- Arrays are still order-sensitive and are still serialized without reordering.
+- Non-plain objects are still passed through unchanged into `JSON.stringify(...)`; only plain objects and arrays are recursively normalized.
+- Special keys such as `__proto__` are now handled as data during normalization instead of mutating the intermediate normalized object shape.
+
+## Validation
+
+- `pnpm exec eslint packages/patterns/src/shared/deduplication.ts packages/patterns/tests/shared/deduplication.test.ts`
+- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+- `pnpm test --run packages/patterns/tests/shared/deduplication.test.ts` -> `1 passed` file, `13 passed` tests
+- `pnpm test --run packages/patterns/tests/react/deduplication.test.ts packages/patterns/tests/plan-execute/deduplication.test.ts packages/patterns/tests/shared/deduplication.test.ts` -> `3 passed` files, `25 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `201/289` warnings, `patterns 15/28`
+- `pnpm test --run` -> `156 passed | 16 skipped` files; `2170 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
+
+## Test Impact
+
+Expanded the shared deduplication utility coverage with a special-key regression and re-ran the ReAct and Plan-Execute deduplication suites so the shared helper remains validated through its two primary runtime consumers.

--- a/packages/patterns/src/shared/deduplication.ts
+++ b/packages/patterns/src/shared/deduplication.ts
@@ -8,6 +8,16 @@
 
 import { createLogger, type LogLevel } from '@agentforge/core';
 
+type DeduplicationObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is DeduplicationObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
 /**
  * Recursively normalize an object by sorting all keys at all levels
  * This ensures consistent serialization regardless of key order
@@ -15,7 +25,7 @@ import { createLogger, type LogLevel } from '@agentforge/core';
  * @param obj - Object to normalize
  * @returns Normalized object with sorted keys at all levels
  */
-function normalizeObject(obj: any): any {
+function normalizeObject(obj: unknown): unknown {
   if (obj === null || obj === undefined) {
     return obj;
   }
@@ -26,8 +36,8 @@ function normalizeObject(obj: any): any {
   }
 
   // Handle objects - sort keys and normalize values recursively
-  if (typeof obj === 'object' && obj.constructor === Object) {
-    const normalized: any = {};
+  if (isPlainObject(obj)) {
+    const normalized = Object.create(null) as DeduplicationObject;
     const sortedKeys = Object.keys(obj).sort();
     for (const key of sortedKeys) {
       normalized[key] = normalizeObject(obj[key]);
@@ -69,7 +79,7 @@ function normalizeObject(obj: any): any {
  * // key3 === key4 (nested object order doesn't matter)
  * ```
  */
-export function generateToolCallCacheKey(toolName: string, args: any): string {
+export function generateToolCallCacheKey(toolName: string, args: unknown): string {
   // Normalize the arguments recursively to ensure consistent key ordering
   const normalizedArgs = normalizeObject(args);
   const sortedArgs = JSON.stringify(normalizedArgs);
@@ -158,4 +168,3 @@ export function buildDeduplicationMetrics(
     deduplicationSavings: calculateDeduplicationSavings(duplicatesSkipped, toolsExecuted),
   };
 }
-

--- a/packages/patterns/tests/shared/deduplication.test.ts
+++ b/packages/patterns/tests/shared/deduplication.test.ts
@@ -135,6 +135,19 @@ describe('Deduplication Utilities', () => {
 
       expect(key1).toBe(key2);
     });
+
+    it('should treat __proto__ as data without mutating object prototypes', () => {
+      const args = JSON.parse('{"__proto__":{"polluted":true},"query":"test"}') as Record<
+        string,
+        unknown
+      >;
+
+      const cacheKey = generateToolCallCacheKey('search', args);
+
+      expect(cacheKey).toContain('"__proto__":{"polluted":true}');
+      expect(cacheKey).toContain('"query":"test"');
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
   });
 
   describe('calculateDeduplicationSavings', () => {
@@ -155,4 +168,3 @@ describe('Deduplication Utilities', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -783,19 +783,33 @@ Implementation notes:
 **Branch:** `fix/st-09022-shared-deduplication-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09022-shared-deduplication-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Replace broad normalization and cache-key `any` boundaries in `packages/patterns/src/shared/deduplication.ts`
-- [ ] Preserve current deduplication metrics, cache-key generation, and logging behavior
-- [ ] Add/update focused tests for normalization, cache-key generation, and metrics helpers
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09022-shared-deduplication-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create branch `fix/st-09022-shared-deduplication-contracts`
+- [x] Create draft PR with story ID in title
+- [x] Replace broad normalization and cache-key `any` boundaries in `packages/patterns/src/shared/deduplication.ts`
+- [x] Preserve current deduplication metrics, cache-key generation, and logging behavior
+- [x] Add/update focused tests for normalization, cache-key generation, and metrics helpers
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09022-shared-deduplication-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `fix/st-09022-shared-deduplication-contracts` (workspace branch: `codex/fix/st-09022-shared-deduplication-contracts`)
+- Draft PR: #84 `fix(st-09022): harden shared deduplication utility contracts`
+- Implementation commit: `52b6bf0` `fix(st-09022): harden shared deduplication contracts`
+- Validation:
+  - `pnpm exec eslint packages/patterns/src/shared/deduplication.ts packages/patterns/tests/shared/deduplication.test.ts`
+  - `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
+  - `pnpm test --run packages/patterns/tests/shared/deduplication.test.ts` -> `1 passed` file, `13 passed` tests
+  - `pnpm test --run packages/patterns/tests/react/deduplication.test.ts packages/patterns/tests/plan-execute/deduplication.test.ts packages/patterns/tests/shared/deduplication.test.ts` -> `3 passed` files, `25 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `201/289` warnings, `patterns 15/28`
+  - `pnpm test --run` -> `156 passed | 16 skipped` files; `2170 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1195,7 +1195,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** ST-09012
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/shared/deduplication.ts` replaces broad `any` normalization and cache-key boundaries with safer unknown-first contracts

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-04-03
-**Active Story:** ST-09022 (Ready)
+**Active Story:** ST-09022 (In Review)
 
 ---
 
@@ -34,8 +34,8 @@
 
 Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-04-03):
 
-- Total: `205` warnings (`src/**`)
-- By package: `core 82`, `tools 67`, `testing 31`, `patterns 19`, `cli 6`
+- Total: `201` warnings (`src/**`)
+- By package: `core 82`, `tools 67`, `testing 31`, `patterns 15`, `cli 6`
 
 Top runtime hotspots informing this feature slice:
 
@@ -44,7 +44,7 @@ Top runtime hotspots informing this feature slice:
 3. `packages/patterns/src/multi-agent/nodes.ts` was split behind the stable public entrypoint in `ST-09015`, with follow-up hardening landed for log redaction, workload invariants, interrupt propagation, and model-content serialization
 4. `ST-09017` has centralized repeated CLI command-level `catch (error: any)` handling behind a shared helper and is now merged
 5. `ST-09018` has tightened `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts`, reducing the `testing` package warning floor from `51` to `31` and is now merged
-6. `ST-09021` has now merged after hardening `packages/core/src/streaming/websocket.ts` and adjacent streaming types; `packages/patterns/src/shared/deduplication.ts` is the next small runtime boundary-hardening slice after the prompt-loader cleanup
+6. `ST-09022` has now tightened `packages/patterns/src/shared/deduplication.ts` around unknown-first normalization and cache-key handling; `packages/core/src/tools/builder.ts` is the next small runtime boundary-hardening slice after this shared helper cleanup
 7. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
 8. `packages/patterns/src/plan-execute/nodes.ts` has grown into a larger mixed-responsibility module and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
 
@@ -68,6 +68,7 @@ Recent improvement snapshot:
 - `ST-09019` merged after tightening the reflection agent factory around typed route maps and direct compile inference, lowering the workspace explicit-`any` baseline from `233` to `229` and the `patterns` package from `23` to `19`.
 - `ST-09020` merged after tightening the prompt-loader variable contracts around unknown-first trusted/untrusted maps, lowering the workspace explicit-`any` baseline from `229` to `219` and the `core` package from `106` to `96`, with follow-up fixes for null-prototype map handling, own-property option detection, and documented own-enumerable compatibility boundaries.
 - `ST-09021` merged after tightening the streaming WebSocket helper contracts around structural socket types and unknown-first payload handling, lowering the workspace explicit-`any` baseline from `219` to `205` and the `core` package from `96` to `82`.
+- `ST-09022` is now in review after tightening the shared deduplication helper contracts around unknown-first normalization and null-prototype cache-key handling, lowering the workspace explicit-`any` baseline from `205` to `201` and the `patterns` package from `19` to `15`.
 - `EP-09` remains open as the daily hardening stream, with the next follow-on slice now centered on shared deduplication helpers, core tool builder typing, interrupt contracts, and the plan-execute node modularization follow-up.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories
+- **Ready:** 3 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09022` - Harden Shared Deduplication Utility Contracts
 - `ST-09023` - Tighten Core Tool Builder Fluent Typing
 - `ST-09024` - Tighten LangGraph Interrupt Type Contracts
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
@@ -23,7 +22,7 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09022` - Harden Shared Deduplication Utility Contracts
 
 ---
 
@@ -116,8 +115,9 @@ _No stories currently blocked_
 - ✅ ST-09019 complete - reflection agent routing typing hardened by replacing route and compile casts with typed route maps plus focused factory route coverage (PR #81, 2026-03-31)
 - ✅ ST-09020 complete - prompt-loader variable contracts hardened around unknown-first and null-prototype variable maps, with follow-up fixes for own-property detection and documented own-enumerable compatibility boundaries (PR #82, 2026-04-02)
 - ✅ ST-09021 complete - streaming websocket contracts hardened around structural socket boundaries and unknown-first message payloads (merged 2026-04-03, PR #83)
+- 🔄 ST-09022 in review - shared deduplication contracts hardened around unknown-first normalization and null-prototype cache-key handling (PR #84)
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded on 2026-03-22 with low-hanging follow-on stories ST-09008 through ST-09012
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded again on 2026-03-23 with daily hardening stories ST-09013 through ST-09018
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a third time on 2026-03-23 with daily hardening stories ST-09019 through ST-09028
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a fourth time on 2026-03-24 with the plan-execute node modularization follow-up story ST-09029
-- Current measured `no-explicit-any` baseline is `205` warnings (`cli 6`, `core 82`, `patterns 19`, `testing 31`, `tools 67`)
+- Current measured `no-explicit-any` baseline is `201` warnings (`cli 6`, `core 82`, `patterns 15`, `testing 31`, `tools 67`)


### PR DESCRIPTION
## Story
- ST-09022: Harden Shared Deduplication Utility Contracts

## What Changed
- Tightened `packages/patterns/src/shared/deduplication.ts` around unknown-first normalization and cache-key generation.
- Added focused shared-deduplication coverage in `packages/patterns/tests/shared/deduplication.test.ts`.
- Recorded the warning delta and review-ready tracker state in `docs/st09022-shared-deduplication-contracts.md` plus the EP-09 planning files.

## Acceptance Criteria Coverage
- Replaced broad normalization and cache-key `any` boundaries in `packages/patterns/src/shared/deduplication.ts` with safer unknown-first contracts.
- Preserved deduplication metrics, cache-key generation, and logging behavior.
- Added focused tests for normalization, cache-key generation, and metrics helpers.
- Recorded explicit-`any` warning deltas for the touched scope in the story doc.
- Added story documentation at `docs/st09022-shared-deduplication-contracts.md`.

## Validation Performed
- `pnpm exec eslint packages/patterns/src/shared/deduplication.ts packages/patterns/tests/shared/deduplication.test.ts`
- `pnpm exec tsc -p packages/patterns/tsconfig.json --noEmit`
- `pnpm test --run packages/patterns/tests/shared/deduplication.test.ts` -> `1 passed` file, `13 passed` tests
- `pnpm test --run packages/patterns/tests/react/deduplication.test.ts packages/patterns/tests/plan-execute/deduplication.test.ts packages/patterns/tests/shared/deduplication.test.ts` -> `3 passed` files, `25 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `201/289` warnings, `patterns 15/28`
- `pnpm test --run` -> `156 passed | 16 skipped` files; `2170 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Status
- Ready for review
