### PR TITLE
fix(st-09024): tighten langgraph interrupt type contracts

### DIFF
--- a/docs/st09024-langgraph-interrupt-type-contracts.md
+++ b/docs/st09024-langgraph-interrupt-type-contracts.md
@@ -1,0 +1,48 @@
+# ST-09024: Tighten LangGraph Interrupt Type Contracts
+
+## Summary
+
+Tightened the shared LangGraph interrupt contracts so human-request and approval flows keep their explicit domain shapes while custom interrupt payloads, metadata, and resume values move to safer JSON-first boundaries.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/langgraph/interrupts/types.ts` | Replaced broad `any` interrupt boundaries with generic interrupt contracts, explicit approval payload types, JSON-safe custom interrupt/resume payload aliases, and JSON-object metadata/context contracts |
+| `packages/core/src/langgraph/interrupts/utils.ts` | Updated approval/custom interrupt helpers to use the tighter contracts while preserving current helper behavior and custom-interrupt payload inference |
+| `packages/core/src/langgraph/interrupts/contracts.typecheck.ts` | Added source-included type regressions for approval interrupts, generic custom interrupts, and resume command/options payload typing |
+| `packages/core/tests/langgraph/interrupts/utils.test.ts` | Added focused runtime coverage for JSON-safe primitive and array custom interrupt payloads and localized the `HumanRequest` test type import to the interrupt module |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/langgraph/interrupts/types.ts`: `10 -> 0` (`-10`)
+- `packages/core/src/langgraph/interrupts/utils.ts`: `3 -> 0` (`-3`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `195 -> 182` (`-13`)
+- `core` package: `76 -> 63` (`-13`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-07.)
+
+## Compatibility Notes
+
+- Human-request interrupts still carry the same `HumanRequest` shape, including optional context, timeout handling, suggestions, and response metadata.
+- Approval-required interrupts keep the same runtime payload keys: `action`, `description`, and optional `context`.
+- Custom interrupts still accept object, array, and primitive payloads, but the public contract is now JSON-safe instead of `any`.
+- Resume commands and resume options now expose JSON-safe payload/value contracts while keeping the existing `resume`, `value`, and optional `metadata` fields unchanged.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/langgraph/interrupts/types.ts packages/core/src/langgraph/interrupts/utils.ts packages/core/src/langgraph/interrupts/contracts.typecheck.ts packages/core/tests/langgraph/interrupts/utils.test.ts`
+- `pnpm test --run packages/core/tests/langgraph/interrupts/utils.test.ts packages/core/tests/streaming/human-in-loop.test.ts` -> `2 passed` files, `20 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+- `pnpm test --run` -> `156 passed | 16 skipped` files; `2178 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
+
+## Test Impact
+
+Added one source-included type regression file and expanded focused interrupt utility coverage so custom interrupt payload inference, approval payload typing, and resume command/value contracts stay precise without changing the existing human-in-the-loop runtime helpers.

--- a/packages/core/src/langgraph/interrupts/contracts.typecheck.ts
+++ b/packages/core/src/langgraph/interrupts/contracts.typecheck.ts
@@ -1,0 +1,44 @@
+import type { JsonObject } from '../observability/payload.js';
+import type {
+  ApprovalRequiredInterrupt,
+  CustomInterrupt,
+  ResumeCommand,
+  ResumeOptions,
+} from './types.js';
+import { createApprovalRequiredInterrupt, createCustomInterrupt } from './utils.js';
+
+const customInterrupt = createCustomInterrupt(
+  'custom-123',
+  { action: 'review', flags: ['urgent'] },
+  { source: 'manual' }
+);
+
+const typedCustomInterrupt: CustomInterrupt<
+  { action: string; flags: string[] },
+  { source: string }
+> = customInterrupt;
+
+void typedCustomInterrupt;
+
+const approvalInterrupt: ApprovalRequiredInterrupt = createApprovalRequiredInterrupt(
+  'delete-project',
+  'Delete a project',
+  { projectId: 'proj-1' }
+);
+
+void approvalInterrupt;
+
+const resumeCommand: ResumeCommand<{ approved: boolean }, { actor: string }> = {
+  resume: { approved: true },
+  metadata: { actor: 'tom' },
+};
+
+const resumeOptions: ResumeOptions = {
+  threadId: 'thread-1',
+  interruptId: 'interrupt-1',
+  value: { approved: true, metadata: ['keep'] },
+  metadata: { actor: 'tom' } satisfies JsonObject,
+};
+
+void resumeCommand;
+void resumeOptions;

--- a/packages/core/src/langgraph/interrupts/types.ts
+++ b/packages/core/src/langgraph/interrupts/types.ts
@@ -3,6 +3,8 @@
  * @module langgraph/interrupts/types
  */
 
+import type { JsonObject, JsonValue } from '../observability/payload.js';
+
 /**
  * Priority level for human requests
  */
@@ -30,7 +32,7 @@ export interface HumanRequest {
   /**
    * Optional context
    */
-  context?: Record<string, any>;
+  context?: JsonObject;
 
   /**
    * Priority level
@@ -79,13 +81,27 @@ export interface HumanRequest {
 export type InterruptType = 'human_request' | 'approval_required' | 'custom';
 
 /**
+ * Shared interrupt metadata contract.
+ */
+export type InterruptMetadata = JsonObject;
+
+/**
+ * JSON-safe payload allowed in generic interrupt and resume flows.
+ */
+export type InterruptPayload = JsonValue;
+
+/**
  * Interrupt data stored in the checkpoint
  */
-export interface InterruptData {
+export interface InterruptData<
+  TType extends InterruptType = InterruptType,
+  TData = unknown,
+  TMetadata extends InterruptMetadata = InterruptMetadata,
+> {
   /**
    * Type of interrupt
    */
-  type: InterruptType;
+  type: TType;
 
   /**
    * Unique ID for this interrupt
@@ -100,41 +116,40 @@ export interface InterruptData {
   /**
    * The data associated with this interrupt
    */
-  data: any;
+  data: TData;
 
   /**
    * Optional metadata
    */
-  metadata?: Record<string, any>;
+  metadata?: TMetadata;
+}
+
+/**
+ * Approval request payload.
+ */
+export interface ApprovalRequiredData {
+  action: string;
+  description: string;
+  context?: JsonObject;
 }
 
 /**
  * Human request interrupt data
  */
-export interface HumanRequestInterrupt extends InterruptData {
-  type: 'human_request';
-  data: HumanRequest;
-}
+export type HumanRequestInterrupt = InterruptData<'human_request', HumanRequest>;
 
 /**
  * Approval required interrupt data
  */
-export interface ApprovalRequiredInterrupt extends InterruptData {
-  type: 'approval_required';
-  data: {
-    action: string;
-    description: string;
-    context?: Record<string, any>;
-  };
-}
+export type ApprovalRequiredInterrupt = InterruptData<'approval_required', ApprovalRequiredData>;
 
 /**
  * Custom interrupt data
  */
-export interface CustomInterrupt extends InterruptData {
-  type: 'custom';
-  data: any;
-}
+export type CustomInterrupt<
+  TData extends InterruptPayload = InterruptPayload,
+  TMetadata extends InterruptMetadata = InterruptMetadata,
+> = InterruptData<'custom', TData, TMetadata>;
 
 /**
  * Union type of all interrupt types
@@ -144,16 +159,19 @@ export type AnyInterrupt = HumanRequestInterrupt | ApprovalRequiredInterrupt | C
 /**
  * Resume command for continuing after an interrupt
  */
-export interface ResumeCommand {
+export interface ResumeCommand<
+  TResume extends InterruptPayload = InterruptPayload,
+  TMetadata extends InterruptMetadata = InterruptMetadata,
+> {
   /**
    * The response to the interrupt
    */
-  resume: any;
+  resume: TResume;
 
   /**
    * Optional metadata about the response
    */
-  metadata?: Record<string, any>;
+  metadata?: TMetadata;
 }
 
 /**
@@ -188,7 +206,7 @@ export interface ThreadInfo {
   /**
    * Optional metadata
    */
-  metadata?: Record<string, any>;
+  metadata?: InterruptMetadata;
 }
 
 /**
@@ -223,11 +241,10 @@ export interface ResumeOptions {
   /**
    * The response/value to resume with
    */
-  value: any;
+  value: InterruptPayload;
 
   /**
    * Optional metadata
    */
-  metadata?: Record<string, any>;
+  metadata?: InterruptMetadata;
 }
-

--- a/packages/core/src/langgraph/interrupts/utils.ts
+++ b/packages/core/src/langgraph/interrupts/utils.ts
@@ -4,15 +4,16 @@
  */
 
 import type {
-  InterruptData,
   HumanRequestInterrupt,
   ApprovalRequiredInterrupt,
   CustomInterrupt,
   AnyInterrupt,
-  ThreadInfo,
   ThreadStatus,
   HumanRequest,
+  InterruptMetadata,
+  InterruptPayload,
 } from './types.js';
+import type { JsonObject } from '../observability/payload.js';
 
 /**
  * Create a human request interrupt
@@ -61,7 +62,7 @@ export function createHumanRequestInterrupt(request: HumanRequest): HumanRequest
 export function createApprovalRequiredInterrupt(
   action: string,
   description: string,
-  context?: Record<string, any>
+  context?: JsonObject
 ): ApprovalRequiredInterrupt {
   return {
     type: 'approval_required',
@@ -91,11 +92,14 @@ export function createApprovalRequiredInterrupt(
  * );
  * ```
  */
-export function createCustomInterrupt(
+export function createCustomInterrupt<
+  TData extends InterruptPayload,
+  TMetadata extends InterruptMetadata = InterruptMetadata,
+>(
   id: string,
-  data: any,
-  metadata?: Record<string, any>
-): CustomInterrupt {
+  data: TData,
+  metadata?: TMetadata
+): CustomInterrupt<TData, TMetadata> {
   return {
     type: 'custom',
     id,
@@ -153,4 +157,3 @@ export function getThreadStatus(
   if (hasInterrupts) return 'interrupted';
   return 'running';
 }
-

--- a/packages/core/tests/langgraph/interrupts/utils.test.ts
+++ b/packages/core/tests/langgraph/interrupts/utils.test.ts
@@ -8,7 +8,7 @@ import {
   isCustomInterrupt,
   getThreadStatus,
 } from '../../../src/langgraph/interrupts/utils.js';
-import type { HumanRequest } from '../../../src/tools/builtin/ask-human/types.js';
+import type { HumanRequest } from '../../../src/langgraph/interrupts/types.js';
 
 describe('Interrupt Utilities', () => {
   describe('createHumanRequestInterrupt', () => {
@@ -79,6 +79,20 @@ describe('Interrupt Utilities', () => {
       expect(interrupt.type).toBe('custom');
       expect(interrupt.metadata).toBeUndefined();
     });
+
+    it('should preserve JSON-safe primitive and array payloads', () => {
+      const primitiveInterrupt = createCustomInterrupt('custom-primitive', 'approved');
+      const arrayInterrupt = createCustomInterrupt('custom-array', [
+        { step: 'reviewed', approved: true },
+        { step: 'published', approved: false },
+      ]);
+
+      expect(primitiveInterrupt.data).toBe('approved');
+      expect(arrayInterrupt.data).toEqual([
+        { step: 'reviewed', approved: true },
+        { step: 'published', approved: false },
+      ]);
+    });
   });
 
   describe('Type guards', () => {
@@ -136,4 +150,3 @@ describe('Interrupt Utilities', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -877,7 +877,8 @@ Implementation notes:
   - `pnpm lint` -> exit `0`; warnings only
 - [x] Commit completed checklist items as logical commits and push updates
   - `82d7ca6` `fix(st-09024): tighten langgraph interrupt contracts`
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #86 marked ready: https://github.com/TVScoundrel/agentforge/pull/86
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -858,19 +858,40 @@ Implementation notes:
 **Branch:** `fix/st-09024-langgraph-interrupt-type-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09024-langgraph-interrupt-type-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Replace broad payload boundaries in `packages/core/src/langgraph/interrupts/types.ts` with safer interrupt/resume contracts
-- [ ] Preserve current human-request, approval, custom interrupt, and resume-command compatibility
-- [ ] Add/update focused tests for touched interrupt type helpers or adjacent runtime consumers as needed
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09024-langgraph-interrupt-type-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Create branch `fix/st-09024-langgraph-interrupt-type-contracts`
+  - Created as `codex/fix/st-09024-langgraph-interrupt-type-contracts` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #86: https://github.com/TVScoundrel/agentforge/pull/86
+- [x] Replace broad payload boundaries in `packages/core/src/langgraph/interrupts/types.ts` with safer interrupt/resume contracts
+- [x] Preserve current human-request, approval, custom interrupt, and resume-command compatibility
+- [x] Add/update focused tests for touched interrupt type helpers or adjacent runtime consumers as needed
+  - `pnpm test --run packages/core/tests/langgraph/interrupts/utils.test.ts packages/core/tests/streaming/human-in-loop.test.ts` -> `2 passed` files, `20 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09024-langgraph-interrupt-type-contracts.md` (`types.ts 10 -> 0`, `utils.ts 3 -> 0`, overall `195 -> 182`)
+- [x] Add or update story documentation at `docs/st09024-langgraph-interrupt-type-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added `packages/core/src/langgraph/interrupts/contracts.typecheck.ts` plus focused interrupt utility coverage in `packages/core/tests/langgraph/interrupts/utils.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `156 passed | 16 skipped` files; `2178 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
+- [x] Commit completed checklist items as logical commits and push updates
+  - `82d7ca6` `fix(st-09024): tighten langgraph interrupt contracts`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `fix/st-09024-langgraph-interrupt-type-contracts` (workspace branch: `codex/fix/st-09024-langgraph-interrupt-type-contracts`)
+- Draft PR: #86 `fix(st-09024): tighten langgraph interrupt type contracts`
+- Implementation commit: `82d7ca6` `fix(st-09024): tighten langgraph interrupt contracts`
+- Validation:
+  - `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/core/src/langgraph/interrupts/types.ts packages/core/src/langgraph/interrupts/utils.ts packages/core/src/langgraph/interrupts/contracts.typecheck.ts packages/core/tests/langgraph/interrupts/utils.test.ts`
+  - `pnpm test --run packages/core/tests/langgraph/interrupts/utils.test.ts packages/core/tests/streaming/human-in-loop.test.ts` -> `2 passed` files, `20 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+  - `pnpm test --run` -> `156 passed | 16 skipped` files; `2178 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1229,7 +1229,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09009
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/langgraph/interrupts/types.ts` replaces avoidable broad payload boundaries with safer domain-specific contracts

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-04-07
-**Active Story:** ST-09024 (Ready)
+**Active Story:** ST-09024 (In Review)
 
 ---
 
@@ -34,8 +34,8 @@
 
 Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-04-07):
 
-- Total: `195` warnings (`src/**`)
-- By package: `core 76`, `tools 67`, `testing 31`, `patterns 15`, `cli 6`
+- Total: `182` warnings (`src/**`)
+- By package: `core 63`, `tools 67`, `testing 31`, `patterns 15`, `cli 6`
 
 Top runtime hotspots informing this feature slice:
 
@@ -44,7 +44,7 @@ Top runtime hotspots informing this feature slice:
 3. `packages/patterns/src/multi-agent/nodes.ts` was split behind the stable public entrypoint in `ST-09015`, with follow-up hardening landed for log redaction, workload invariants, interrupt propagation, and model-content serialization
 4. `ST-09017` has centralized repeated CLI command-level `catch (error: any)` handling behind a shared helper and is now merged
 5. `ST-09018` has tightened `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts`, reducing the `testing` package warning floor from `51` to `31` and is now merged
-6. `ST-09023` has now merged after tightening `packages/core/src/tools/builder.ts` around fluent generic stages, metadata isolation, example clone safety, and invoke compatibility; `packages/core/src/langgraph/interrupts/types.ts` is the next small runtime boundary-hardening slice after this builder cleanup
+6. `ST-09023` has now merged after tightening `packages/core/src/tools/builder.ts` around fluent generic stages, metadata isolation, example clone safety, and invoke compatibility; `ST-09024` is now in review after tightening `packages/core/src/langgraph/interrupts/types.ts` around domain-specific interrupt payload and resume contracts
 7. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
 8. `packages/patterns/src/plan-execute/nodes.ts` has grown into a larger mixed-responsibility module and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
 
@@ -70,6 +70,7 @@ Recent improvement snapshot:
 - `ST-09021` merged after tightening the streaming WebSocket helper contracts around structural socket types and unknown-first payload handling, lowering the workspace explicit-`any` baseline from `219` to `205` and the `core` package from `96` to `82`.
 - `ST-09022` merged after tightening the shared deduplication helper contracts around unknown-first normalization and null-prototype cache-key handling, lowering the workspace explicit-`any` baseline from `205` to `201` and the `patterns` package from `19` to `15`.
 - `ST-09023` merged after tightening the core tool builder fluent typing surface, lowering the workspace explicit-`any` baseline from `201` to `195` and the `core` package from `82` to `76`, with follow-up fixes for branched metadata isolation, clone-failure messaging, and `this`-binding compatibility.
+- `ST-09024` is now in review after tightening the LangGraph interrupt contracts around JSON-safe custom payloads, JSON-object metadata, and safer resume values, lowering the workspace explicit-`any` baseline from `195` to `182` and the `core` package from `76` to `63`.
 - `EP-09` remains open as the daily hardening stream, with the next follow-on slice now centered on shared deduplication helpers, core tool builder typing, interrupt contracts, and the plan-execute node modularization follow-up.
 - A second follow-on slice is now queued for prompt loading, reflection routing, streaming websocket contracts, shared deduplication helpers, core tool builder typing, interrupt contracts, and split-out registry/connection-manager modularization.
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories
+- **Ready:** 3 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09024` - Tighten LangGraph Interrupt Type Contracts
 - `ST-09025` - Extract Tool Registry Collection and Search Operations
 - `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
@@ -23,7 +22,7 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09024` - Tighten LangGraph Interrupt Type Contracts
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09024: Tighten LangGraph Interrupt Type Contracts

## What Changed
- tightened `packages/core/src/langgraph/interrupts/types.ts` around generic interrupt contracts, JSON-safe custom payloads, JSON-object metadata, and safer resume value typing
- updated `packages/core/src/langgraph/interrupts/utils.ts` to preserve helper behavior while matching the stronger approval/custom interrupt contracts
- added source-included type regressions in `packages/core/src/langgraph/interrupts/contracts.typecheck.ts`
- expanded focused runtime coverage in `packages/core/tests/langgraph/interrupts/utils.test.ts`
- added story documentation in `docs/st09024-langgraph-interrupt-type-contracts.md`
- moved `ST-09024` to `In Review` in the planning trackers

## Acceptance Criteria Coverage
- replaced broad interrupt payload boundaries in `packages/core/src/langgraph/interrupts/types.ts` with safer domain-specific contracts
- preserved current human-request, approval, custom interrupt, and resume-command flows
- added focused tests and type regressions for touched interrupt helpers
- recorded explicit-`any` warning deltas for touched files in the story doc
- added the story doc at `docs/st09024-langgraph-interrupt-type-contracts.md`

## Validation Performed
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec eslint packages/core/src/langgraph/interrupts/types.ts packages/core/src/langgraph/interrupts/utils.ts packages/core/src/langgraph/interrupts/contracts.typecheck.ts packages/core/tests/langgraph/interrupts/utils.test.ts`
- `pnpm test --run packages/core/tests/langgraph/interrupts/utils.test.ts packages/core/tests/streaming/human-in-loop.test.ts` -> `2 passed` files, `20 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
- `pnpm test --run` -> `156 passed | 16 skipped` files; `2178 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Status
- Ready for review
