### PR TITLE
refactor(st-09025): extract registry collection and search operations

### DIFF
--- a/docs/st09025-tool-registry-collection-search-extraction.md
+++ b/docs/st09025-tool-registry-collection-search-extraction.md
@@ -1,0 +1,46 @@
+# ST-09025: Extract Tool Registry Collection and Search Operations
+
+## Summary
+
+Extracted the tool registry’s collection and search behavior into a focused helper module so the main `ToolRegistry` class stops owning both storage/event flows and basic lookup logic.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/tools/registry.ts` | Delegated `getAll`, `getByCategory`, `getByTag`, `search`, and `getNames` to a dedicated collection/search helper while keeping the public registry API unchanged |
+| `packages/core/src/tools/registry-collection.ts` | Added focused helper functions for ordered tool listing, category/tag filtering, and case-insensitive search across tool name, display name, and description |
+| `packages/core/tests/tools/registry-collection.test.ts` | Added focused runtime coverage for ordered tool listing, category/tag filtering, and name/display-name/description search behavior |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/tools/registry.ts`: `8 -> 8` (`0`)
+- `packages/core/src/tools/registry-collection.ts`: `0 -> 0` (`0`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `182 -> 182` (`0`)
+- `core` package: `63 -> 63` (`0`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-08.)
+
+## Compatibility Notes
+
+- Public `ToolRegistry` lookup behavior remains unchanged for `getAll`, `getByCategory`, `getByTag`, `search`, and `getNames`.
+- Search remains case-insensitive and still matches against tool name, display name, and description.
+- The extraction is internal only; no new tool-registry helper APIs were added to the public `@agentforge/core` export surface.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts`
+- `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts` -> `2 passed` files, `46 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+- `pnpm test --run` -> pending
+- `pnpm lint` -> pending
+
+## Test Impact
+
+Added a focused registry-collection test suite so the extracted lookup/search helpers have direct coverage without relying only on the broader `ToolRegistry` integration tests.

--- a/docs/st09025-tool-registry-collection-search-extraction.md
+++ b/docs/st09025-tool-registry-collection-search-extraction.md
@@ -38,8 +38,8 @@ Extracted the tool registry’s collection and search behavior into a focused he
 - `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts`
 - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts` -> `2 passed` files, `46 passed` tests
 - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
-- `pnpm test --run` -> pending
-- `pnpm lint` -> pending
+- `pnpm test --run` -> `157 passed | 16 skipped` files; `2181 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
 
 ## Test Impact
 

--- a/packages/core/src/tools/registry-collection.ts
+++ b/packages/core/src/tools/registry-collection.ts
@@ -1,0 +1,44 @@
+import { Tool, ToolCategory } from './types.js';
+
+export type RegistryTool = Tool<unknown, unknown>;
+
+export function getAllRegistryTools(tools: ReadonlyMap<string, RegistryTool>): RegistryTool[] {
+  return Array.from(tools.values());
+}
+
+export function getRegistryToolNames(tools: ReadonlyMap<string, RegistryTool>): string[] {
+  return Array.from(tools.keys());
+}
+
+export function getRegistryToolsByCategory(
+  tools: ReadonlyMap<string, RegistryTool>,
+  category: ToolCategory
+): RegistryTool[] {
+  return getAllRegistryTools(tools).filter((tool) => tool.metadata.category === category);
+}
+
+export function getRegistryToolsByTag(
+  tools: ReadonlyMap<string, RegistryTool>,
+  tag: string
+): RegistryTool[] {
+  return getAllRegistryTools(tools).filter((tool) => tool.metadata.tags?.includes(tag));
+}
+
+export function searchRegistryTools(
+  tools: ReadonlyMap<string, RegistryTool>,
+  query: string
+): RegistryTool[] {
+  const lowerQuery = query.toLowerCase();
+
+  return getAllRegistryTools(tools).filter((tool) => {
+    const name = tool.metadata.name.toLowerCase();
+    const displayName = tool.metadata.displayName?.toLowerCase() ?? '';
+    const description = tool.metadata.description.toLowerCase();
+
+    return (
+      name.includes(lowerQuery) ||
+      displayName.includes(lowerQuery) ||
+      description.includes(lowerQuery)
+    );
+  });
+}

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -21,6 +21,14 @@ import { toLangChainTools as convertToLangChainTools } from '../langchain/conver
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
+import {
+  getAllRegistryTools,
+  getRegistryToolNames,
+  getRegistryToolsByCategory,
+  getRegistryToolsByTag,
+  searchRegistryTools,
+  type RegistryTool,
+} from './registry-collection.js';
 
 const logger = createLogger('agentforge:core:tools:registry', { level: LogLevel.INFO });
 
@@ -39,7 +47,6 @@ export enum RegistryEvent {
  */
 export type EventHandler = (data: unknown) => void;
 
-type RegistryTool = Tool<unknown, unknown>;
 // Use `never` for erased input so heterogeneous Tool<TInput, TOutput> values
 // remain assignable through the contravariant invoke parameter.
 type RegisterManyTool = Tool<never, unknown>;
@@ -242,7 +249,7 @@ export class ToolRegistry {
    * ```
    */
   getAll(): RegistryTool[] {
-    return Array.from(this.tools.values());
+    return getAllRegistryTools(this.tools);
   }
 
   /**
@@ -257,7 +264,7 @@ export class ToolRegistry {
    * ```
    */
   getByCategory(category: ToolCategory): RegistryTool[] {
-    return this.getAll().filter((tool) => tool.metadata.category === category);
+    return getRegistryToolsByCategory(this.tools, category);
   }
 
   /**
@@ -272,9 +279,7 @@ export class ToolRegistry {
    * ```
    */
   getByTag(tag: string): RegistryTool[] {
-    return this.getAll().filter((tool) =>
-      tool.metadata.tags?.includes(tag)
-    );
+    return getRegistryToolsByTag(this.tools, tag);
   }
 
   /**
@@ -292,19 +297,7 @@ export class ToolRegistry {
    * ```
    */
   search(query: string): RegistryTool[] {
-    const lowerQuery = query.toLowerCase();
-
-    return this.getAll().filter((tool) => {
-      const name = tool.metadata.name.toLowerCase();
-      const displayName = tool.metadata.displayName?.toLowerCase() || '';
-      const description = tool.metadata.description.toLowerCase();
-
-      return (
-        name.includes(lowerQuery) ||
-        displayName.includes(lowerQuery) ||
-        description.includes(lowerQuery)
-      );
-    });
+    return searchRegistryTools(this.tools, query);
   }
 
   /**
@@ -400,7 +393,7 @@ export class ToolRegistry {
    * ```
    */
   getNames(): string[] {
-    return Array.from(this.tools.keys());
+    return getRegistryToolNames(this.tools);
   }
 
   /**

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -27,7 +27,6 @@ import {
   getRegistryToolsByCategory,
   getRegistryToolsByTag,
   searchRegistryTools,
-  type RegistryTool,
 } from './registry-collection.js';
 
 const logger = createLogger('agentforge:core:tools:registry', { level: LogLevel.INFO });
@@ -50,6 +49,7 @@ export type EventHandler = (data: unknown) => void;
 // Use `never` for erased input so heterogeneous Tool<TInput, TOutput> values
 // remain assignable through the contravariant invoke parameter.
 type RegisterManyTool = Tool<never, unknown>;
+type RegistryTool = Tool<unknown, unknown>;
 
 function eraseToolType<TInput, TOutput>(tool: Tool<TInput, TOutput>): RegistryTool {
   return tool as unknown as RegistryTool;

--- a/packages/core/tests/tools/registry-collection.test.ts
+++ b/packages/core/tests/tools/registry-collection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { toolBuilder, ToolCategory } from '../../src/index.js';
+import {
+  getAllRegistryTools,
+  getRegistryToolNames,
+  getRegistryToolsByCategory,
+  getRegistryToolsByTag,
+  searchRegistryTools,
+  type RegistryTool,
+} from '../../src/tools/registry-collection.js';
+
+function createTestTools(): ReadonlyMap<string, RegistryTool> {
+  const readFileTool = toolBuilder()
+    .name('read-file')
+    .description('Read a file from the file system')
+    .category(ToolCategory.FILE_SYSTEM)
+    .tag('file')
+    .tag('read')
+    .schema(z.object({ path: z.string().describe('File path') }))
+    .implement(async ({ path }) => path)
+    .build() as RegistryTool;
+
+  const searchFilesTool = toolBuilder()
+    .name('search-files')
+    .displayName('File Search')
+    .description('Search for files in a directory')
+    .category(ToolCategory.FILE_SYSTEM)
+    .tag('file')
+    .tag('search')
+    .schema(z.object({ query: z.string().describe('Search query') }))
+    .implement(async ({ query }) => query)
+    .build() as RegistryTool;
+
+  const httpTool = toolBuilder()
+    .name('http-request')
+    .displayName('HTTP Client')
+    .description('Make an HTTP request')
+    .category(ToolCategory.WEB)
+    .tag('web')
+    .tag('network')
+    .schema(z.object({ url: z.string().describe('Target URL') }))
+    .implement(async ({ url }) => url)
+    .build() as RegistryTool;
+
+  return new Map([
+    [readFileTool.metadata.name, readFileTool],
+    [searchFilesTool.metadata.name, searchFilesTool],
+    [httpTool.metadata.name, httpTool],
+  ]);
+}
+
+describe('registry-collection', () => {
+  it('returns all tools and names in insertion order', () => {
+    const tools = createTestTools();
+
+    expect(getAllRegistryTools(tools).map((tool) => tool.metadata.name)).toEqual([
+      'read-file',
+      'search-files',
+      'http-request',
+    ]);
+    expect(getRegistryToolNames(tools)).toEqual([
+      'read-file',
+      'search-files',
+      'http-request',
+    ]);
+  });
+
+  it('filters tools by category and tag', () => {
+    const tools = createTestTools();
+
+    expect(getRegistryToolsByCategory(tools, ToolCategory.FILE_SYSTEM)).toHaveLength(2);
+    expect(getRegistryToolsByCategory(tools, ToolCategory.WEB)).toHaveLength(1);
+    expect(getRegistryToolsByTag(tools, 'file').map((tool) => tool.metadata.name)).toEqual([
+      'read-file',
+      'search-files',
+    ]);
+    expect(getRegistryToolsByTag(tools, 'search').map((tool) => tool.metadata.name)).toEqual([
+      'search-files',
+    ]);
+  });
+
+  it('searches by name, display name, and description case-insensitively', () => {
+    const tools = createTestTools();
+
+    expect(searchRegistryTools(tools, 'file').map((tool) => tool.metadata.name)).toEqual([
+      'read-file',
+      'search-files',
+    ]);
+    expect(searchRegistryTools(tools, 'client').map((tool) => tool.metadata.name)).toEqual([
+      'http-request',
+    ]);
+    expect(searchRegistryTools(tools, 'HTTP').map((tool) => tool.metadata.name)).toEqual([
+      'http-request',
+    ]);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -904,19 +904,39 @@ Implementation notes:
 **Branch:** `refactor/st-09025-tool-registry-collection-search-extraction`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09025-tool-registry-collection-search-extraction`
-- [ ] Create draft PR with story ID in title
-- [ ] Extract collection and search responsibilities from `packages/core/src/tools/registry.ts`
-- [ ] Preserve current `getAll`, category/tag filter, and text-search behavior
-- [ ] Add/update focused tests for extracted collection and search behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09025-tool-registry-collection-search-extraction.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create branch `refactor/st-09025-tool-registry-collection-search-extraction`
+  - Created as `codex/refactor/st-09025-tool-registry-collection-search-extraction` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #87: https://github.com/TVScoundrel/agentforge/pull/87
+- [x] Extract collection and search responsibilities from `packages/core/src/tools/registry.ts`
+- [x] Preserve current `getAll`, category/tag filter, and text-search behavior
+- [x] Add/update focused tests for extracted collection and search behavior
+  - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts` -> `2 passed` files, `46 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09025-tool-registry-collection-search-extraction.md` (`registry.ts 8 -> 8`, overall `182 -> 182`)
+- [x] Add or update story documentation at `docs/st09025-tool-registry-collection-search-extraction.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused helper coverage in `packages/core/tests/tools/registry-collection.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `157 passed | 16 skipped` files; `2181 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `refactor/st-09025-tool-registry-collection-search-extraction` (workspace branch: `codex/refactor/st-09025-tool-registry-collection-search-extraction`)
+- Draft PR: #87 `refactor(st-09025): extract registry collection and search operations`
+- Implementation commit: `2964a48` `refactor(st-09025): extract registry collection and search helpers`
+- Validation:
+  - `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts`
+  - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts` -> `2 passed` files, `46 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+  - `pnpm test --run` -> `157 passed | 16 skipped` files; `2181 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -922,7 +922,10 @@ Implementation notes:
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
 - [x] Commit completed checklist items as logical commits and push updates
+  - `2964a48` `refactor(st-09025): extract registry collection and search helpers`
+  - `232c0d9` `docs(st-09025): record validation and move story to in-review`
 - [x] Mark PR Ready only after all story tasks are complete
+  - PR #87 marked ready: https://github.com/TVScoundrel/agentforge/pull/87
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1246,7 +1246,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09012
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/registry.ts` extracts collection/search responsibilities such as list, category/tag filtering, and text search into clearer helpers or modules

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,7 +2,7 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-04-08
 **Active Story:** ST-09025 (In Review)
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-04-07
-**Active Story:** ST-09025 (Ready)
+**Active Story:** ST-09025 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,6 +1,6 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-04-08
 
 ## Queue Status Summary
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
+- **Ready:** 1 story
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09025` - Extract Tool Registry Collection and Search Operations
 - `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 
@@ -22,7 +21,7 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09025` - Extract Tool Registry Collection and Search Operations
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09025: Extract Tool Registry Collection and Search Operations

## What Changed
- extracted ordered tool listing, category/tag filtering, and text search into `packages/core/src/tools/registry-collection.ts`
- kept `ToolRegistry` as the stable public entrypoint while delegating `getAll`, `getByCategory`, `getByTag`, `search`, and `getNames`
- added focused runtime coverage in `packages/core/tests/tools/registry-collection.test.ts`
- added story documentation in `docs/st09025-tool-registry-collection-search-extraction.md`

## Acceptance Criteria Coverage
- extracted collection/search responsibilities from `packages/core/src/tools/registry.ts`
- preserved current `getAll`, category/tag filter, and text-search behavior behind the existing registry API
- added focused tests for extracted collection and search behavior
- recorded explicit-`any` warning outcomes in the story doc
- added the story doc at `docs/st09025-tool-registry-collection-search-extraction.md`

## Validation Performed
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts`
- `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts` -> `2 passed` files, `46 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
- `pnpm test --run` -> `157 passed | 16 skipped` files; `2181 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Status
- Ready for review
