### PR TITLE
refactor(st-09026): modularize tool registry prompt rendering and event paths

### DIFF
--- a/docs/st09026-tool-registry-prompt-event-modularization.md
+++ b/docs/st09026-tool-registry-prompt-event-modularization.md
@@ -41,8 +41,8 @@ Extracted the tool registry's prompt-generation, LangChain conversion, and event
 - `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/src/tools/registry-events.ts packages/core/src/tools/registry-prompt.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts`
 - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
 - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
-- `pnpm test --run` -> pending
-- `pnpm lint` -> pending
+- `pnpm test --run` -> `159 passed | 16 skipped` files; `2185 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
 
 ## Test Impact
 

--- a/docs/st09026-tool-registry-prompt-event-modularization.md
+++ b/docs/st09026-tool-registry-prompt-event-modularization.md
@@ -1,0 +1,49 @@
+# ST-09026: Modularize Tool Registry Prompt Rendering and Event Paths
+
+## Summary
+
+Extracted the tool registry's prompt-generation, LangChain conversion, and event-emission logic into focused internal helpers so `ToolRegistry` no longer mixes storage operations with formatting and observer orchestration.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/tools/registry.ts` | Delegated event registration/emission, LangChain conversion, and prompt generation to dedicated helpers while preserving the public `ToolRegistry` API |
+| `packages/core/src/tools/registry-events.ts` | Added focused event helper functions for handler registration, deregistration, and safe event emission with error logging |
+| `packages/core/src/tools/registry-prompt.ts` | Added focused helper functions for LangChain conversion plus grouped/full/minimal prompt generation and relation formatting |
+| `packages/core/tests/tools/registry-events.test.ts` | Added direct runtime coverage for event helper registration/removal and safe emission when handlers throw |
+| `packages/core/tests/tools/registry-prompt.test.ts` | Added direct runtime coverage for grouped prompt output and minimal-mode supplementary content rendering |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/tools/registry.ts`: `8 -> 8` (`0`)
+- `packages/core/src/tools/registry-events.ts`: `0 -> 0` (`0`)
+- `packages/core/src/tools/registry-prompt.ts`: `0 -> 0` (`0`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `182 -> 182` (`0`)
+- `core` package: `63 -> 63` (`0`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-09.)
+
+## Compatibility Notes
+
+- Public `ToolRegistry` behavior remains unchanged for event registration/removal, safe event emission, `toLangChainTools()`, and `generatePrompt()`.
+- Prompt generation still supports grouped category output, minimal supplementary mode, category filtering, relations, examples, notes, and limitations.
+- The extraction is internal only; no new helper APIs were added to the public `@agentforge/core` export surface.
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/src/tools/registry-events.ts packages/core/src/tools/registry-prompt.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts`
+- `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+- `pnpm test --run` -> pending
+- `pnpm lint` -> pending
+
+## Test Impact
+
+Added direct helper coverage for the extracted event and prompt modules while keeping the existing `ToolRegistry` integration suite in place to catch public-surface regressions.

--- a/packages/core/src/tools/registry-events.ts
+++ b/packages/core/src/tools/registry-events.ts
@@ -1,0 +1,51 @@
+import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
+
+const logger = createLogger('agentforge:core:tools:registry', { level: LogLevel.INFO });
+
+export type RegistryEventHandler<TData = unknown> = (data: TData) => void;
+
+export function addRegistryEventHandler<TEvent, TData>(
+  eventHandlers: Map<TEvent, Set<RegistryEventHandler<TData>>>,
+  event: TEvent,
+  handler: RegistryEventHandler<TData>
+): void {
+  if (!eventHandlers.has(event)) {
+    eventHandlers.set(event, new Set());
+  }
+
+  eventHandlers.get(event)!.add(handler);
+}
+
+export function removeRegistryEventHandler<TEvent, TData>(
+  eventHandlers: Map<TEvent, Set<RegistryEventHandler<TData>>>,
+  event: TEvent,
+  handler: RegistryEventHandler<TData>
+): void {
+  const handlers = eventHandlers.get(event);
+  if (handlers) {
+    handlers.delete(handler);
+  }
+}
+
+export function emitRegistryEvent<TEvent>(
+  eventHandlers: Map<TEvent, Set<RegistryEventHandler>>,
+  event: TEvent,
+  data: unknown
+): void {
+  const handlers = eventHandlers.get(event);
+  if (!handlers) {
+    return;
+  }
+
+  handlers.forEach((handler) => {
+    try {
+      handler(data);
+    } catch (error) {
+      logger.error('Event handler error', {
+        event: String(event),
+        error: error instanceof Error ? error.message : String(error),
+        ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+      });
+    }
+  });
+}

--- a/packages/core/src/tools/registry-prompt.ts
+++ b/packages/core/src/tools/registry-prompt.ts
@@ -40,7 +40,9 @@ export function generateRegistryPrompt(
   let toolsToInclude = tools;
 
   if (categories && categories.length > 0) {
-    toolsToInclude = tools.filter((tool) => categories.includes(tool.metadata.category));
+    toolsToInclude = toolsToInclude.filter((tool) =>
+      categories.includes(tool.metadata.category)
+    );
   }
 
   if (toolsToInclude.length === 0) {

--- a/packages/core/src/tools/registry-prompt.ts
+++ b/packages/core/src/tools/registry-prompt.ts
@@ -1,0 +1,234 @@
+import type { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { toLangChainTools as convertToLangChainTools } from '../langchain/converter.js';
+import { Tool, ToolCategory, ToolRelations } from './types.js';
+
+type RegistryTool = Tool<unknown, unknown>;
+
+export interface RegistryPromptOptions {
+  includeExamples?: boolean;
+  includeNotes?: boolean;
+  includeLimitations?: boolean;
+  includeRelations?: boolean;
+  groupByCategory?: boolean;
+  categories?: ToolCategory[];
+  maxExamplesPerTool?: number;
+  minimal?: boolean;
+}
+
+export function convertRegistryToolsToLangChain(
+  tools: RegistryTool[]
+): DynamicStructuredTool[] {
+  return convertToLangChainTools(tools);
+}
+
+export function generateRegistryPrompt(
+  tools: RegistryTool[],
+  options: RegistryPromptOptions = {}
+): string {
+  const {
+    includeExamples = false,
+    includeNotes = false,
+    includeLimitations = false,
+    includeRelations = false,
+    groupByCategory = false,
+    categories,
+    maxExamplesPerTool,
+    minimal = false,
+  } = options;
+
+  let toolsToInclude = tools;
+
+  if (categories && categories.length > 0) {
+    toolsToInclude = tools.filter((tool) => categories.includes(tool.metadata.category));
+  }
+
+  if (toolsToInclude.length === 0) {
+    return 'No tools available.';
+  }
+
+  const lines: string[] = ['Available Tools:', ''];
+
+  if (groupByCategory) {
+    const toolsByCategory = new Map<ToolCategory, RegistryTool[]>();
+
+    for (const tool of toolsToInclude) {
+      const category = tool.metadata.category;
+      if (!toolsByCategory.has(category)) {
+        toolsByCategory.set(category, []);
+      }
+      toolsByCategory.get(category)!.push(tool);
+    }
+
+    for (const [category, categoryTools] of toolsByCategory) {
+      lines.push(`${category.toUpperCase().replace(/-/g, ' ')} TOOLS:`);
+
+      for (const tool of categoryTools) {
+        lines.push(...formatToolForPrompt(tool, {
+          includeExamples,
+          includeNotes,
+          includeLimitations,
+          includeRelations,
+          maxExamplesPerTool,
+          minimal,
+        }));
+      }
+
+      lines.push('');
+    }
+  } else {
+    for (const tool of toolsToInclude) {
+      lines.push(...formatToolForPrompt(tool, {
+        includeExamples,
+        includeNotes,
+        includeLimitations,
+        includeRelations,
+        maxExamplesPerTool,
+        minimal,
+      }));
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatToolForPrompt(
+  tool: RegistryTool,
+  options: RegistryPromptOptions
+): string[] {
+  const { metadata } = tool;
+  const lines: string[] = [];
+
+  if (options.minimal) {
+    lines.push(`## ${metadata.name}`);
+
+    let hasContent = false;
+
+    if (options.includeRelations && metadata.relations) {
+      const relationLines = formatRelations(metadata.relations);
+      if (relationLines.length > 0) {
+        lines.push(...relationLines);
+        hasContent = true;
+      }
+    }
+
+    if (options.includeExamples && metadata.examples && metadata.examples.length > 0) {
+      const maxExamples = options.maxExamplesPerTool || metadata.examples.length;
+      const examples = metadata.examples.slice(0, maxExamples);
+
+      for (const example of examples) {
+        lines.push(`  Example: ${example.description}`);
+        lines.push(`    Input: ${JSON.stringify(example.input)}`);
+        if (example.explanation) {
+          lines.push(`    ${example.explanation}`);
+        }
+        hasContent = true;
+      }
+    }
+
+    if (options.includeNotes && metadata.usageNotes) {
+      lines.push(`  Notes: ${metadata.usageNotes}`);
+      hasContent = true;
+    }
+
+    if (options.includeLimitations && metadata.limitations && metadata.limitations.length > 0) {
+      lines.push('  Limitations:');
+      for (const limitation of metadata.limitations) {
+        lines.push(`    - ${limitation}`);
+      }
+      hasContent = true;
+    }
+
+    if (!hasContent) {
+      return [];
+    }
+
+    return lines;
+  }
+
+  lines.push(`- ${metadata.name}: ${metadata.description}`);
+
+  const schemaShape = getSchemaShape(tool.schema);
+  if (schemaShape) {
+    const params = Object.keys(schemaShape);
+    if (params.length > 0) {
+      const paramDescriptions = params.map((param) => {
+        const field = schemaShape[param];
+        const typeName = field._def.typeName;
+        const type = typeName.replace('Zod', '').toLowerCase();
+        return `${param} (${type})`;
+      });
+      lines.push(`  Parameters: ${paramDescriptions.join(', ')}`);
+    }
+  }
+
+  if (options.includeRelations && metadata.relations) {
+    const relationLines = formatRelations(metadata.relations);
+    if (relationLines.length > 0) {
+      lines.push(...relationLines);
+    }
+  }
+
+  if (options.includeNotes && metadata.usageNotes) {
+    lines.push(`  Notes: ${metadata.usageNotes}`);
+  }
+
+  if (options.includeExamples && metadata.examples && metadata.examples.length > 0) {
+    const maxExamples = options.maxExamplesPerTool || metadata.examples.length;
+    const examples = metadata.examples.slice(0, maxExamples);
+
+    for (const example of examples) {
+      lines.push(`  Example: ${example.description}`);
+      lines.push(`    Input: ${JSON.stringify(example.input)}`);
+      if (example.explanation) {
+        lines.push(`    ${example.explanation}`);
+      }
+    }
+  }
+
+  if (options.includeLimitations && metadata.limitations && metadata.limitations.length > 0) {
+    lines.push('  Limitations:');
+    for (const limitation of metadata.limitations) {
+      lines.push(`    - ${limitation}`);
+    }
+  }
+
+  return lines;
+}
+
+function formatRelations(relations: ToolRelations): string[] {
+  const lines: string[] = [];
+
+  if (relations.requires && relations.requires.length > 0) {
+    lines.push(`  Requires: ${relations.requires.join(', ')}`);
+  }
+
+  if (relations.suggests && relations.suggests.length > 0) {
+    lines.push(`  Suggests: ${relations.suggests.join(', ')}`);
+  }
+
+  if (relations.conflicts && relations.conflicts.length > 0) {
+    lines.push(`  Conflicts: ${relations.conflicts.join(', ')}`);
+  }
+
+  if (relations.follows && relations.follows.length > 0) {
+    lines.push(`  Follows: ${relations.follows.join(', ')}`);
+  }
+
+  if (relations.precedes && relations.precedes.length > 0) {
+    lines.push(`  Precedes: ${relations.precedes.join(', ')}`);
+  }
+
+  return lines;
+}
+
+function getSchemaShape(
+  schema: z.ZodSchema<unknown>
+): z.ZodRawShape | undefined {
+  if (schema instanceof z.ZodObject) {
+    return schema.shape;
+  }
+
+  return undefined;
+}

--- a/packages/core/src/tools/registry.ts
+++ b/packages/core/src/tools/registry.ts
@@ -16,11 +16,8 @@
  * ```
  */
 
-import { Tool, ToolCategory, ToolRelations } from './types.js';
-import { toLangChainTools as convertToLangChainTools } from '../langchain/converter.js';
+import { Tool, ToolCategory } from './types.js';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
-import { z } from 'zod';
-import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 import {
   getAllRegistryTools,
   getRegistryToolNames,
@@ -28,8 +25,17 @@ import {
   getRegistryToolsByTag,
   searchRegistryTools,
 } from './registry-collection.js';
-
-const logger = createLogger('agentforge:core:tools:registry', { level: LogLevel.INFO });
+import {
+  addRegistryEventHandler,
+  emitRegistryEvent,
+  removeRegistryEventHandler,
+  type RegistryEventHandler,
+} from './registry-events.js';
+import {
+  convertRegistryToolsToLangChain,
+  generateRegistryPrompt,
+  type RegistryPromptOptions,
+} from './registry-prompt.js';
 
 /**
  * Registry events
@@ -44,7 +50,7 @@ export enum RegistryEvent {
 /**
  * Event handler type
  */
-export type EventHandler = (data: unknown) => void;
+export type EventHandler = RegistryEventHandler;
 
 // Use `never` for erased input so heterogeneous Tool<TInput, TOutput> values
 // remain assignable through the contravariant invoke parameter.
@@ -58,7 +64,7 @@ function eraseToolType<TInput, TOutput>(tool: Tool<TInput, TOutput>): RegistryTo
 /**
  * Options for generating tool prompts
  */
-export interface PromptOptions {
+export interface PromptOptions extends RegistryPromptOptions {
   /** Include usage examples in the prompt */
   includeExamples?: boolean;
   /** Include usage notes in the prompt */
@@ -410,10 +416,7 @@ export class ToolRegistry {
    * ```
    */
   on(event: RegistryEvent, handler: EventHandler): void {
-    if (!this.eventHandlers.has(event)) {
-      this.eventHandlers.set(event, new Set());
-    }
-    this.eventHandlers.get(event)!.add(handler);
+    addRegistryEventHandler(this.eventHandlers, event, handler);
   }
 
   /**
@@ -430,10 +433,7 @@ export class ToolRegistry {
    * ```
    */
   off(event: RegistryEvent, handler: EventHandler): void {
-    const handlers = this.eventHandlers.get(event);
-    if (handlers) {
-      handlers.delete(handler);
-    }
+    removeRegistryEventHandler(this.eventHandlers, event, handler);
   }
 
   /**
@@ -444,21 +444,7 @@ export class ToolRegistry {
    * @private
    */
   private emit(event: RegistryEvent, data: unknown): void {
-    const handlers = this.eventHandlers.get(event);
-    if (handlers) {
-      handlers.forEach((handler) => {
-        try {
-          handler(data);
-        } catch (error) {
-          // Log error but don't throw to prevent one handler from breaking others
-          logger.error('Event handler error', {
-            event,
-            error: error instanceof Error ? error.message : String(error),
-            ...(error instanceof Error && error.stack ? { stack: error.stack } : {})
-          });
-        }
-      });
-    }
+    emitRegistryEvent(this.eventHandlers, event, data);
   }
 
   /**
@@ -482,7 +468,7 @@ export class ToolRegistry {
    * ```
    */
   toLangChainTools(): DynamicStructuredTool[] {
-    return convertToLangChainTools(this.getAll());
+    return convertRegistryToolsToLangChain(this.getAll());
   }
 
   /**
@@ -514,252 +500,6 @@ export class ToolRegistry {
    * ```
    */
   generatePrompt(options: PromptOptions = {}): string {
-    const {
-      includeExamples = false,
-      includeNotes = false,
-      includeLimitations = false,
-      includeRelations = false,
-      groupByCategory = false,
-      categories,
-      maxExamplesPerTool,
-      minimal = false,
-    } = options;
-
-    // Get tools to include
-    let tools = this.getAll();
-
-    // Filter by categories if specified
-    if (categories && categories.length > 0) {
-      tools = tools.filter((tool) => categories.includes(tool.metadata.category));
-    }
-
-    if (tools.length === 0) {
-      return 'No tools available.';
-    }
-
-    const lines: string[] = ['Available Tools:', ''];
-
-    if (groupByCategory) {
-      // Group tools by category
-      const toolsByCategory = new Map<ToolCategory, RegistryTool[]>();
-
-      for (const tool of tools) {
-        const category = tool.metadata.category;
-        if (!toolsByCategory.has(category)) {
-          toolsByCategory.set(category, []);
-        }
-        toolsByCategory.get(category)!.push(tool);
-      }
-
-      // Generate prompt for each category
-      for (const [category, categoryTools] of toolsByCategory) {
-        lines.push(`${category.toUpperCase().replace(/-/g, ' ')} TOOLS:`);
-
-        for (const tool of categoryTools) {
-          lines.push(...this.formatToolForPrompt(tool, {
-            includeExamples,
-            includeNotes,
-            includeLimitations,
-            includeRelations,
-            maxExamplesPerTool,
-            minimal,
-          }));
-        }
-
-        lines.push('');
-      }
-    } else {
-      // List all tools without grouping
-      for (const tool of tools) {
-        lines.push(...this.formatToolForPrompt(tool, {
-          includeExamples,
-          includeNotes,
-          includeLimitations,
-          includeRelations,
-          maxExamplesPerTool,
-          minimal,
-        }));
-        lines.push('');
-      }
-    }
-
-    return lines.join('\n').trim();
-  }
-
-  /**
-   * Format a single tool for inclusion in a prompt
-   *
-   * @param tool - The tool to format
-   * @param options - Formatting options
-   * @returns Array of formatted lines
-   * @private
-   */
-  private formatToolForPrompt(
-    tool: RegistryTool,
-    options: {
-      includeExamples?: boolean;
-      includeNotes?: boolean;
-      includeLimitations?: boolean;
-      includeRelations?: boolean;
-      maxExamplesPerTool?: number;
-      minimal?: boolean;
-    }
-  ): string[] {
-    const { metadata } = tool;
-    const lines: string[] = [];
-
-    // In minimal mode, only include supplementary context
-    if (options.minimal) {
-      // Tool name as header for matching with API-provided definitions
-      lines.push(`## ${metadata.name}`);
-
-      // Only include supplementary information not in the API definition
-      let hasContent = false;
-
-      // Relations
-      if (options.includeRelations && metadata.relations) {
-        const relationLines = this.formatRelations(metadata.relations);
-        if (relationLines.length > 0) {
-          lines.push(...relationLines);
-          hasContent = true;
-        }
-      }
-
-      // Examples
-      if (options.includeExamples && metadata.examples && metadata.examples.length > 0) {
-        const maxExamples = options.maxExamplesPerTool || metadata.examples.length;
-        const examples = metadata.examples.slice(0, maxExamples);
-
-        for (const example of examples) {
-          lines.push(`  Example: ${example.description}`);
-          lines.push(`    Input: ${JSON.stringify(example.input)}`);
-          if (example.explanation) {
-            lines.push(`    ${example.explanation}`);
-          }
-          hasContent = true;
-        }
-      }
-
-      // Usage notes
-      if (options.includeNotes && metadata.usageNotes) {
-        lines.push(`  Notes: ${metadata.usageNotes}`);
-        hasContent = true;
-      }
-
-      // Limitations
-      if (options.includeLimitations && metadata.limitations && metadata.limitations.length > 0) {
-        lines.push(`  Limitations:`);
-        for (const limitation of metadata.limitations) {
-          lines.push(`    - ${limitation}`);
-        }
-        hasContent = true;
-      }
-
-      // If no supplementary content, don't include this tool
-      if (!hasContent) {
-        return [];
-      }
-
-      return lines;
-    }
-
-    // Full mode: include complete tool definition
-    // Tool name and description
-    lines.push(`- ${metadata.name}: ${metadata.description}`);
-
-    // Get schema properties
-    const schemaShape = this.getSchemaShape(tool.schema);
-    if (schemaShape) {
-      const params = Object.keys(schemaShape);
-      if (params.length > 0) {
-        const paramDescriptions = params.map((param) => {
-          const field = schemaShape[param];
-          const typeName = field._def.typeName;
-          const type = typeName.replace('Zod', '').toLowerCase();
-          return `${param} (${type})`;
-        });
-        lines.push(`  Parameters: ${paramDescriptions.join(', ')}`);
-      }
-    }
-
-    // Relations
-    if (options.includeRelations && metadata.relations) {
-      const relationLines = this.formatRelations(metadata.relations);
-      if (relationLines.length > 0) {
-        lines.push(...relationLines);
-      }
-    }
-
-    // Usage notes
-    if (options.includeNotes && metadata.usageNotes) {
-      lines.push(`  Notes: ${metadata.usageNotes}`);
-    }
-
-    // Examples
-    if (options.includeExamples && metadata.examples && metadata.examples.length > 0) {
-      const maxExamples = options.maxExamplesPerTool || metadata.examples.length;
-      const examples = metadata.examples.slice(0, maxExamples);
-
-      for (const example of examples) {
-        lines.push(`  Example: ${example.description}`);
-        lines.push(`    Input: ${JSON.stringify(example.input)}`);
-        if (example.explanation) {
-          lines.push(`    ${example.explanation}`);
-        }
-      }
-    }
-
-    // Limitations
-    if (options.includeLimitations && metadata.limitations && metadata.limitations.length > 0) {
-      lines.push(`  Limitations:`);
-      for (const limitation of metadata.limitations) {
-        lines.push(`    - ${limitation}`);
-      }
-    }
-
-    return lines;
-  }
-
-  /**
-   * Format tool relations for inclusion in a prompt
-   *
-   * @param relations - The relations to format
-   * @returns Array of formatted lines
-   * @private
-   */
-  private formatRelations(relations: ToolRelations): string[] {
-    const lines: string[] = [];
-
-    if (relations.requires && relations.requires.length > 0) {
-      lines.push(`  Requires: ${relations.requires.join(', ')}`);
-    }
-
-    if (relations.suggests && relations.suggests.length > 0) {
-      lines.push(`  Suggests: ${relations.suggests.join(', ')}`);
-    }
-
-    if (relations.conflicts && relations.conflicts.length > 0) {
-      lines.push(`  Conflicts: ${relations.conflicts.join(', ')}`);
-    }
-
-    if (relations.follows && relations.follows.length > 0) {
-      lines.push(`  Follows: ${relations.follows.join(', ')}`);
-    }
-
-    if (relations.precedes && relations.precedes.length > 0) {
-      lines.push(`  Precedes: ${relations.precedes.join(', ')}`);
-    }
-
-    return lines;
-  }
-
-  private getSchemaShape(
-    schema: z.ZodSchema<unknown>
-  ): z.ZodRawShape | undefined {
-    if (schema instanceof z.ZodObject) {
-      return schema.shape;
-    }
-
-    return undefined;
+    return generateRegistryPrompt(this.getAll(), options);
   }
 }

--- a/packages/core/tests/tools/registry-events.test.ts
+++ b/packages/core/tests/tools/registry-events.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  addRegistryEventHandler,
+  emitRegistryEvent,
+  removeRegistryEventHandler,
+  type RegistryEventHandler,
+} from '../../src/tools/registry-events.js';
+
+describe('registry-events helpers', () => {
+  it('registers, emits, and removes handlers', () => {
+    const handlers = new Map<string, Set<RegistryEventHandler>>();
+    const handler = vi.fn();
+
+    addRegistryEventHandler(handlers, 'tool:registered', handler);
+    emitRegistryEvent(handlers, 'tool:registered', { name: 'test-tool' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ name: 'test-tool' });
+
+    removeRegistryEventHandler(handlers, 'tool:registered', handler);
+    emitRegistryEvent(handlers, 'tool:registered', { name: 'test-tool-2' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues emitting when one handler throws', () => {
+    const handlers = new Map<string, Set<RegistryEventHandler>>();
+    const badHandler = vi.fn(() => {
+      throw new Error('Handler error');
+    });
+    const goodHandler = vi.fn();
+
+    addRegistryEventHandler(handlers, 'tool:registered', badHandler);
+    addRegistryEventHandler(handlers, 'tool:registered', goodHandler);
+
+    expect(() => {
+      emitRegistryEvent(handlers, 'tool:registered', { name: 'safe-tool' });
+    }).not.toThrow();
+
+    expect(badHandler).toHaveBeenCalledTimes(1);
+    expect(goodHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/tests/tools/registry-prompt.test.ts
+++ b/packages/core/tests/tools/registry-prompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { generateRegistryPrompt } from '../../src/tools/registry-prompt.js';
+import { ToolCategory, toolBuilder } from '../../src/index.js';
+
+describe('registry-prompt helpers', () => {
+  const readFileTool = toolBuilder()
+    .name('read-file')
+    .description('Read a file from disk')
+    .category(ToolCategory.FILE_SYSTEM)
+    .usageNotes('Paths are relative to the cwd')
+    .example({
+      description: 'Read a markdown file',
+      input: { path: './README.md' },
+    })
+    .schema(z.object({
+      path: z.string().describe('File path'),
+    }))
+    .implement(async ({ path }) => path)
+    .build();
+
+  const httpTool = toolBuilder()
+    .name('http-request')
+    .description('Make an HTTP request')
+    .category(ToolCategory.WEB)
+    .schema(z.object({
+      url: z.string().describe('Target URL'),
+    }))
+    .implement(async ({ url }) => url)
+    .build();
+
+  it('groups prompt output by category when requested', () => {
+    const prompt = generateRegistryPrompt([readFileTool, httpTool], {
+      groupByCategory: true,
+    });
+
+    expect(prompt).toContain('FILE SYSTEM TOOLS:');
+    expect(prompt).toContain('WEB TOOLS:');
+    expect(prompt).toContain('read-file');
+    expect(prompt).toContain('http-request');
+  });
+
+  it('renders minimal prompt output from supplementary content only', () => {
+    const prompt = generateRegistryPrompt([readFileTool, httpTool], {
+      minimal: true,
+      includeExamples: true,
+      includeNotes: true,
+    });
+
+    expect(prompt).toContain('## read-file');
+    expect(prompt).toContain('Example: Read a markdown file');
+    expect(prompt).toContain('Notes: Paths are relative to the cwd');
+    expect(prompt).not.toContain('Read a file from disk');
+    expect(prompt).not.toContain('## http-request');
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -968,8 +968,12 @@ Implementation notes:
   - `pnpm test --run` -> `159 passed | 16 skipped` files; `2185 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `86a3842` `refactor(st-09026): extract registry prompt and event helpers`
+  - `44b24ff` `docs(st-09026): record progress and move story to in-progress`
+  - `42eab78` `docs(st-09026): record validation and move story to in-review`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #88 marked ready: https://github.com/TVScoundrel/agentforge/pull/88
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -953,7 +953,8 @@ Implementation notes:
 ### Checklist
 - [x] Create branch `refactor/st-09026-tool-registry-prompt-event-modularization`
   - Created as `codex/refactor/st-09026-tool-registry-prompt-event-modularization` (workspace branch-prefix policy)
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #88: https://github.com/TVScoundrel/agentforge/pull/88
 - [x] Extract prompt-rendering and event-emission responsibilities from `packages/core/src/tools/registry.ts`
 - [x] Preserve current prompt-generation, LangChain conversion, and registry event behavior
 - [x] Add/update focused tests for prompt rendering and event behavior after the split
@@ -963,8 +964,10 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09026-tool-registry-prompt-event-modularization.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Added focused helper coverage in `packages/core/tests/tools/registry-events.test.ts` and `packages/core/tests/tools/registry-prompt.test.ts`
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `159 passed | 16 skipped` files; `2185 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
@@ -972,11 +975,14 @@ Implementation notes:
 ### Notes
 
 - Created branch: `refactor/st-09026-tool-registry-prompt-event-modularization` (workspace branch: `codex/refactor/st-09026-tool-registry-prompt-event-modularization`)
+- Draft PR: #88 `refactor(st-09026): modularize tool registry prompt rendering and event paths`
 - Validation so far:
   - `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/src/tools/registry-events.ts packages/core/src/tools/registry-prompt.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts`
   - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
   - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
+  - `pnpm test --run` -> `159 passed | 16 skipped` files; `2185 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -951,19 +951,32 @@ Implementation notes:
 **Branch:** `refactor/st-09026-tool-registry-prompt-event-modularization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09026-tool-registry-prompt-event-modularization`
+- [x] Create branch `refactor/st-09026-tool-registry-prompt-event-modularization`
+  - Created as `codex/refactor/st-09026-tool-registry-prompt-event-modularization` (workspace branch-prefix policy)
 - [ ] Create draft PR with story ID in title
-- [ ] Extract prompt-rendering and event-emission responsibilities from `packages/core/src/tools/registry.ts`
-- [ ] Preserve current prompt-generation, LangChain conversion, and registry event behavior
-- [ ] Add/update focused tests for prompt rendering and event behavior after the split
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09026-tool-registry-prompt-event-modularization.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Extract prompt-rendering and event-emission responsibilities from `packages/core/src/tools/registry.ts`
+- [x] Preserve current prompt-generation, LangChain conversion, and registry event behavior
+- [x] Add/update focused tests for prompt rendering and event behavior after the split
+  - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09026-tool-registry-prompt-event-modularization.md` (`registry.ts 8 -> 8`, overall `182 -> 182`)
+- [x] Add or update story documentation at `docs/st09026-tool-registry-prompt-event-modularization.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused helper coverage in `packages/core/tests/tools/registry-events.test.ts` and `packages/core/tests/tools/registry-prompt.test.ts`
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `refactor/st-09026-tool-registry-prompt-event-modularization` (workspace branch: `codex/refactor/st-09026-tool-registry-prompt-event-modularization`)
+- Validation so far:
+  - `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/src/tools/registry-events.ts packages/core/src/tools/registry-prompt.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts`
+  - `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1263,7 +1263,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09025
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/registry.ts` extracts prompt-rendering and event-emission responsibilities into clearer helpers or modules

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1263,7 +1263,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09025
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/registry.ts` extracts prompt-rendering and event-emission responsibilities into clearer helpers or modules

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-04-09
-**Active Story:** ST-09026 (In Progress)
+**Active Story:** ST-09026 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-08
-**Active Story:** ST-09026 (Ready)
+**Last Updated:** 2026-04-09
+**Active Story:** ST-09026 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
 
@@ -21,13 +21,13 @@
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09026` - Modularize Tool Registry Prompt Rendering and Event Paths
 
 ---
 
 ## In Progress
 
-- `ST-09026` - Modularize Tool Registry Prompt Rendering and Event Paths
+_No stories currently in progress_
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-08
+**Last Updated:** 2026-04-09
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09026` - Modularize Tool Registry Prompt Rendering and Event Paths
 - `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 
@@ -28,7 +27,7 @@ _No stories currently in review_
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09026` - Modularize Tool Registry Prompt Rendering and Event Paths
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09026: Modularize Tool Registry Prompt Rendering and Event Paths

## What Changed
- extracted registry event-handler registration/emission into `packages/core/src/tools/registry-events.ts`
- extracted LangChain conversion and prompt-generation logic into `packages/core/src/tools/registry-prompt.ts`
- kept `ToolRegistry` as the stable public entrypoint while delegating prompt and event responsibilities
- added focused helper coverage in `packages/core/tests/tools/registry-events.test.ts` and `packages/core/tests/tools/registry-prompt.test.ts`
- added story documentation in `docs/st09026-tool-registry-prompt-event-modularization.md`

## Acceptance Criteria Coverage
- extracted prompt-rendering and event-emission responsibilities from `packages/core/src/tools/registry.ts`
- preserved current prompt-generation, LangChain conversion, and registry event behavior behind the existing public API
- added focused tests for prompt rendering and event behavior after the split
- recorded explicit-`any` warning outcomes in the story doc
- added the story doc at `docs/st09026-tool-registry-prompt-event-modularization.md`

## Validation Performed
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec eslint packages/core/src/tools/registry.ts packages/core/src/tools/registry-collection.ts packages/core/src/tools/registry-events.ts packages/core/src/tools/registry-prompt.ts packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts`
- `pnpm test --run packages/core/tests/tools/registry.test.ts packages/core/tests/tools/registry-collection.test.ts packages/core/tests/tools/registry-events.test.ts packages/core/tests/tools/registry-prompt.test.ts` -> `4 passed` files, `50 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `182/289` warnings, `core 63/119`
- `pnpm test --run` -> `159 passed | 16 skipped` files; `2185 passed | 286 skipped` tests
- `pnpm lint` -> exit `0`; warnings only

## Status
- Ready for review
