### PR TITLE
refactor(st-09027): extract connection manager vendor initialization adapters

### DIFF
--- a/docs/st09027-connection-manager-vendor-initialization-extraction.md
+++ b/docs/st09027-connection-manager-vendor-initialization-extraction.md
@@ -1,0 +1,49 @@
+# ST-09027: Extract Connection Manager Vendor Initialization Adapters
+
+## Summary
+
+Extracted the relational connection manager's PostgreSQL, MySQL, and SQLite initialization paths into focused internal helpers so `ConnectionManager` no longer mixes lifecycle orchestration with vendor-specific pool and driver setup.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/tools/src/data/relational/connection/connection-manager.ts` | Delegated vendor-specific initialization to an internal adapter helper while preserving lifecycle, health-check, cancellation, and reconnection behavior |
+| `packages/tools/src/data/relational/connection/vendor-initialization.ts` | Added focused PostgreSQL, MySQL, and SQLite initialization helpers plus shared pool-config validation and supported initialization error patterns |
+| `packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` | Added direct runtime coverage for vendor-specific connection config mapping, SQLite foreign-key enablement, shared pool validation, and unsupported-vendor rejection |
+| `packages/tools/tests/data/relational/connection/connection-manager.test.ts` | Preserved the broader lifecycle suite over the public `ConnectionManager` surface after the extraction |
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/tools/src/data/relational/connection/connection-manager.ts`: `2 -> 2` (`0`)
+- `packages/tools/src/data/relational/connection/vendor-initialization.ts`: `0 -> 0` (`0`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `182 -> 180` (`-2`)
+- `tools` package: `67 -> 65` (`-2`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-16.)
+
+## Compatibility Notes
+
+- Public `ConnectionManager` behavior remains unchanged for `connect()`, `disconnect()`, `dispose()`, `initialize()`, `close()`, `isHealthy()`, and pool metrics.
+- PostgreSQL pool options still map to `pg.Pool` as `max`, `idleTimeoutMillis`, and `connectionTimeoutMillis`.
+- MySQL pool options still map to `mysql2.createPool()` as `connectionLimit`, `acquireTimeout`, and `idleTimeout`.
+- SQLite still accepts `pool` config for API compatibility, validates it, logs that it is not applied, and enables `PRAGMA foreign_keys = ON` on every connection.
+- The extraction is internal only; no new vendor-initialization APIs were added to the public `@agentforge/tools` export surface.
+
+## Validation
+
+- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/vendor-initialization.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+- `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `2 passed` files, `49 passed` tests
+- `pnpm lint:explicit-any:baseline --silent` -> `180/289` warnings, `tools 65/67`
+- `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
+- `pnpm lint` -> exit `0`; warnings only
+
+## Test Impact
+
+Added a focused vendor-initialization helper suite so pool-config translation and vendor-specific setup behavior are covered directly, while retaining the existing `ConnectionManager` lifecycle suite to catch public-surface regressions.

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -4,7 +4,11 @@
  */
 
 import type { DatabaseConnection, DatabaseVendor } from '../types.js';
-import type { ConnectionConfig, PoolConfig } from './types.js';
+import type { ConnectionConfig } from './types.js';
+import {
+  initializeVendorConnection,
+  SAFE_INITIALIZATION_PATTERNS,
+} from './vendor-initialization.js';
 import { checkPeerDependency } from '../utils/peer-dependency-checker.js';
 import { sql, type SQL } from 'drizzle-orm';
 import { createLogger } from '@agentforge/core';
@@ -41,37 +45,6 @@ export interface ReconnectionConfig {
   /** Maximum delay in milliseconds between reconnection attempts */
   maxDelayMs: number;
 }
-
-/**
- * Validate pool configuration
- * @param poolConfig - Pool configuration to validate
- * @throws {Error} If pool configuration is invalid
- */
-function validatePoolConfig(poolConfig: PoolConfig): void {
-  if (poolConfig.max !== undefined && poolConfig.max < 1) {
-    throw new Error('Pool max connections must be >= 1');
-  }
-
-  if (poolConfig.acquireTimeoutMillis !== undefined && poolConfig.acquireTimeoutMillis < 0) {
-    throw new Error('Pool acquire timeout must be >= 0');
-  }
-
-  if (poolConfig.idleTimeoutMillis !== undefined && poolConfig.idleTimeoutMillis < 0) {
-    throw new Error('Pool idle timeout must be >= 0');
-  }
-}
-
-/**
- * Validation error patterns that should be re-thrown directly from initialize()
- * without wrapping in a generic "Failed to initialize ... connection" message.
- */
-const SAFE_INITIALIZATION_PATTERNS = [
-  'Pool max connections must be',
-  'Pool acquire timeout must be',
-  'Pool idle timeout must be',
-  'connection requires a url property',
-  'Unsupported database vendor',
-] as const;
 
 /**
  * Connection manager that handles database connections for PostgreSQL, MySQL, and SQLite
@@ -258,19 +231,9 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     });
 
     try {
-      switch (this.vendor) {
-        case 'postgresql':
-          await this.initializePostgreSQL();
-          break;
-        case 'mysql':
-          await this.initializeMySQL();
-          break;
-        case 'sqlite':
-          await this.initializeSQLite();
-          break;
-        default:
-          throw new Error(`Unsupported database vendor: ${this.vendor}`);
-      }
+      const initialized = await initializeVendorConnection(this.vendor, this.config.connection);
+      this.client = initialized.client;
+      this.db = initialized.db;
 
       // Check if disconnect() was called during initialization
       if (currentGeneration !== this.connectionGeneration) {
@@ -467,158 +430,6 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
         // The initialize() method will schedule another reconnection if needed
       }
     }, delay);
-  }
-
-  /**
-   * Initialize PostgreSQL connection using Drizzle ORM with node-postgres
-   *
-   * Applies pool configuration options to pg.Pool for connection management.
-   */
-  private async initializePostgreSQL(): Promise<void> {
-    const { drizzle } = await import('drizzle-orm/node-postgres');
-    const { Pool } = await import('pg');
-
-    // Extract pool config and base config separately to avoid passing unknown 'pool' property to pg.Pool
-    const { pool: poolConfig, ...baseConfig } = typeof this.config.connection === 'string'
-      ? { connectionString: this.config.connection }
-      : this.config.connection;
-
-    // Validate pool configuration
-    if (poolConfig) {
-      validatePoolConfig(poolConfig);
-    }
-
-    const connectionConfig = {
-      ...baseConfig,
-      // Map our PoolConfig to pg.Pool options
-      // Note: pg.Pool does not support a `min` option
-      ...(poolConfig?.max !== undefined && { max: poolConfig.max }),
-      ...(poolConfig?.idleTimeoutMillis !== undefined && { idleTimeoutMillis: poolConfig.idleTimeoutMillis }),
-      ...(poolConfig?.acquireTimeoutMillis !== undefined && { connectionTimeoutMillis: poolConfig.acquireTimeoutMillis }),
-    };
-
-    logger.debug('Creating PostgreSQL connection pool', {
-      vendor: this.vendor,
-      poolConfig: {
-        ...(connectionConfig.max !== undefined ? { max: connectionConfig.max } : {}),
-        ...(connectionConfig.idleTimeoutMillis !== undefined
-          ? { idleTimeoutMillis: connectionConfig.idleTimeoutMillis }
-          : {}),
-        ...(connectionConfig.connectionTimeoutMillis !== undefined
-          ? { connectionTimeoutMillis: connectionConfig.connectionTimeoutMillis }
-          : {}),
-      }
-    });
-
-    this.client = new Pool(connectionConfig);
-    this.db = drizzle({ client: this.client });
-  }
-
-  /**
-   * Initialize MySQL connection using Drizzle ORM with mysql2
-   *
-   * Applies pool configuration options to mysql2.createPool for connection management.
-   */
-  private async initializeMySQL(): Promise<void> {
-    const { drizzle } = await import('drizzle-orm/mysql2');
-    const mysql = await import('mysql2/promise');
-
-    // mysql2.createPool accepts both connection strings directly and config objects
-    // When a string is provided, we can't apply pool config (would need to parse URL)
-    let connectionConfig: any;
-
-    if (typeof this.config.connection === 'string') {
-      connectionConfig = this.config.connection;
-      logger.debug('Creating MySQL connection pool from connection string', {
-        vendor: this.vendor,
-      });
-    } else {
-      // Destructure to separate pool config from mysql2 config
-      const { pool: poolConfig, ...baseConfig } = this.config.connection;
-
-      // Validate pool configuration
-      if (poolConfig) {
-        validatePoolConfig(poolConfig);
-      }
-
-      connectionConfig = {
-        ...baseConfig,
-        // Map our PoolConfig to mysql2 pool options
-        ...(poolConfig?.max !== undefined && { connectionLimit: poolConfig.max }),
-        ...(poolConfig?.acquireTimeoutMillis !== undefined && { acquireTimeout: poolConfig.acquireTimeoutMillis }),
-        ...(poolConfig?.idleTimeoutMillis !== undefined && { idleTimeout: poolConfig.idleTimeoutMillis }),
-      };
-
-      logger.debug('Creating MySQL connection pool', {
-        vendor: this.vendor,
-        poolConfig: {
-          ...(connectionConfig.connectionLimit !== undefined
-            ? { connectionLimit: connectionConfig.connectionLimit }
-            : {}),
-          ...(connectionConfig.acquireTimeout !== undefined
-            ? { acquireTimeout: connectionConfig.acquireTimeout }
-            : {}),
-          ...(connectionConfig.idleTimeout !== undefined ? { idleTimeout: connectionConfig.idleTimeout } : {}),
-        }
-      });
-    }
-
-    // createPool is synchronous and returns a Pool instance directly
-    this.client = mysql.createPool(connectionConfig);
-    this.db = drizzle({ client: this.client });
-  }
-
-  /**
-   * Initialize SQLite connection using Drizzle ORM with better-sqlite3
-   *
-   * Note: SQLite uses a single connection. Pool configuration is logged but not applied
-   * as SQLite handles concurrent access through its internal locking mechanism.
-   */
-  private async initializeSQLite(): Promise<void> {
-    const { drizzle } = await import('drizzle-orm/better-sqlite3');
-    const DatabaseModule = await import('better-sqlite3');
-
-    // better-sqlite3 uses CommonJS module.exports, which becomes .default in ESM
-    const Database = DatabaseModule.default;
-
-    const url = typeof this.config.connection === 'string'
-      ? this.config.connection
-      : (this.config.connection as any).url;
-
-    if (!url) {
-      throw new Error('SQLite connection requires a url property');
-    }
-
-    // Validate and log pool config if provided (for awareness, but SQLite doesn't use traditional pooling)
-    if (typeof this.config.connection === 'object' && this.config.connection.pool) {
-      validatePoolConfig(this.config.connection.pool);
-      logger.debug('SQLite pool configuration provided but not applied (SQLite uses single connection)', {
-        vendor: this.vendor,
-        poolConfig: {
-          ...(this.config.connection.pool.max !== undefined ? { max: this.config.connection.pool.max } : {}),
-          ...(this.config.connection.pool.idleTimeoutMillis !== undefined
-            ? { idleTimeoutMillis: this.config.connection.pool.idleTimeoutMillis }
-            : {}),
-          ...(this.config.connection.pool.acquireTimeoutMillis !== undefined
-            ? { acquireTimeoutMillis: this.config.connection.pool.acquireTimeoutMillis }
-            : {}),
-        },
-      });
-    }
-
-    logger.debug('Creating SQLite connection', {
-      vendor: this.vendor,
-      url: url === ':memory:' ? ':memory:' : 'file',
-    });
-
-    this.client = new Database(url);
-
-    // Enable foreign key enforcement for every connection. SQLite disables
-    // foreign keys by default and the PRAGMA is per-connection, so we must
-    // set it immediately after opening.
-    this.client.pragma('foreign_keys = ON');
-
-    this.db = drizzle({ client: this.client });
   }
 
   /**

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -231,7 +231,7 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     });
 
     try {
-      const initialized = await initializeVendorConnection(this.vendor, this.config.connection);
+      const initialized = await initializeVendorConnection(this.config);
       this.client = initialized.client;
       this.db = initialized.db;
 

--- a/packages/tools/src/data/relational/connection/vendor-initialization.ts
+++ b/packages/tools/src/data/relational/connection/vendor-initialization.ts
@@ -8,7 +8,7 @@ import type {
 import type { DatabaseVendor } from '../types.js';
 import { createLogger } from '@agentforge/core';
 
-const logger = createLogger('agentforge:tools:data:relational:connection');
+const logger = createLogger('agentforge:tools:data:relational:connection:vendor-init');
 
 export interface InitializedVendorConnection {
   client: unknown;
@@ -191,9 +191,12 @@ export async function initializeMySQLConnection(
     });
   }
 
-  const client = typeof connectionConfig === 'string'
-    ? mysql.createPool(connectionConfig)
-    : mysql.createPool(connectionConfig);
+  let client;
+  if (typeof connectionConfig === 'string') {
+    client = mysql.createPool(connectionConfig);
+  } else {
+    client = mysql.createPool(connectionConfig);
+  }
   const db = drizzle({ client });
   return { client, db };
 }

--- a/packages/tools/src/data/relational/connection/vendor-initialization.ts
+++ b/packages/tools/src/data/relational/connection/vendor-initialization.ts
@@ -1,0 +1,229 @@
+import type {
+  ConnectionConfig,
+  MySQLConnectionConfig,
+  PoolConfig,
+  PostgreSQLConnectionConfig,
+  SQLiteConnectionConfig,
+} from './types.js';
+import type { DatabaseVendor } from '../types.js';
+import { createLogger } from '@agentforge/core';
+
+const logger = createLogger('agentforge:tools:data:relational:connection');
+
+export interface InitializedVendorConnection {
+  client: unknown;
+  db: unknown;
+}
+
+interface PostgreSQLPoolConnectionConfig extends Omit<PostgreSQLConnectionConfig, 'pool'> {
+  max?: number;
+  idleTimeoutMillis?: number;
+  connectionTimeoutMillis?: number;
+}
+
+interface MySQLPoolConnectionConfig extends Omit<MySQLConnectionConfig, 'pool'> {
+  connectionLimit?: number;
+  acquireTimeout?: number;
+  idleTimeout?: number;
+}
+
+export const SAFE_INITIALIZATION_PATTERNS = [
+  'Pool max connections must be',
+  'Pool acquire timeout must be',
+  'Pool idle timeout must be',
+  'SQLite connection requires a url property',
+  'Unsupported database vendor',
+] as const;
+
+export function validatePoolConfig(poolConfig: PoolConfig): void {
+  if (poolConfig.max !== undefined && poolConfig.max < 1) {
+    throw new Error('Pool max connections must be >= 1');
+  }
+
+  if (poolConfig.acquireTimeoutMillis !== undefined && poolConfig.acquireTimeoutMillis < 0) {
+    throw new Error('Pool acquire timeout must be >= 0');
+  }
+
+  if (poolConfig.idleTimeoutMillis !== undefined && poolConfig.idleTimeoutMillis < 0) {
+    throw new Error('Pool idle timeout must be >= 0');
+  }
+}
+
+function pickConfiguredPoolFields(
+  fields: Record<string, number | undefined>
+): Record<string, number> {
+  const configuredEntries = Object.entries(fields).filter(
+    (entry): entry is [string, number] => entry[1] !== undefined
+  );
+  return Object.fromEntries(configuredEntries);
+}
+
+function normalizePostgreSQLConfig(
+  connection: ConnectionConfig['connection']
+): {
+  connectionConfig: PostgreSQLPoolConnectionConfig;
+  poolConfig?: PoolConfig;
+} {
+  const { pool: poolConfig, ...baseConfig } = typeof connection === 'string'
+    ? { connectionString: connection }
+    : (connection as PostgreSQLConnectionConfig);
+
+  if (poolConfig) {
+    validatePoolConfig(poolConfig);
+  }
+
+  return {
+    poolConfig,
+    connectionConfig: {
+      ...baseConfig,
+      ...(poolConfig?.max !== undefined && { max: poolConfig.max }),
+      ...(poolConfig?.idleTimeoutMillis !== undefined && {
+        idleTimeoutMillis: poolConfig.idleTimeoutMillis,
+      }),
+      ...(poolConfig?.acquireTimeoutMillis !== undefined && {
+        connectionTimeoutMillis: poolConfig.acquireTimeoutMillis,
+      }),
+    },
+  };
+}
+
+function normalizeMySQLConfig(
+  connection: ConnectionConfig['connection']
+): string | MySQLPoolConnectionConfig {
+  if (typeof connection === 'string') {
+    logger.debug('Creating MySQL connection pool from connection string', {
+      vendor: 'mysql',
+    });
+    return connection;
+  }
+
+  const { pool: poolConfig, ...baseConfig } = connection as MySQLConnectionConfig;
+
+  if (poolConfig) {
+    validatePoolConfig(poolConfig);
+  }
+
+  return {
+    ...baseConfig,
+    ...(poolConfig?.max !== undefined && { connectionLimit: poolConfig.max }),
+    ...(poolConfig?.acquireTimeoutMillis !== undefined && {
+      acquireTimeout: poolConfig.acquireTimeoutMillis,
+    }),
+    ...(poolConfig?.idleTimeoutMillis !== undefined && {
+      idleTimeout: poolConfig.idleTimeoutMillis,
+    }),
+  };
+}
+
+function resolveSqliteUrl(connection: ConnectionConfig['connection']): {
+  url: string;
+  poolConfig?: PoolConfig;
+} {
+  if (typeof connection === 'string') {
+    return { url: connection };
+  }
+
+  const { url, pool } = connection as SQLiteConnectionConfig;
+
+  if (!url) {
+    throw new Error('SQLite connection requires a url property');
+  }
+
+  if (pool) {
+    validatePoolConfig(pool);
+  }
+
+  return { url, poolConfig: pool };
+}
+
+export async function initializeVendorConnection(
+  vendor: DatabaseVendor,
+  connection: ConnectionConfig['connection']
+): Promise<InitializedVendorConnection> {
+  switch (vendor) {
+    case 'postgresql':
+      return initializePostgreSQLConnection(connection);
+    case 'mysql':
+      return initializeMySQLConnection(connection);
+    case 'sqlite':
+      return initializeSQLiteConnection(connection);
+    default:
+      throw new Error(`Unsupported database vendor: ${vendor}`);
+  }
+}
+
+export async function initializePostgreSQLConnection(
+  connection: ConnectionConfig['connection']
+): Promise<InitializedVendorConnection> {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const { Pool } = await import('pg');
+  const { connectionConfig } = normalizePostgreSQLConfig(connection);
+
+  logger.debug('Creating PostgreSQL connection pool', {
+    vendor: 'postgresql',
+    poolConfig: pickConfiguredPoolFields({
+      max: connectionConfig.max,
+      idleTimeoutMillis: connectionConfig.idleTimeoutMillis,
+      connectionTimeoutMillis: connectionConfig.connectionTimeoutMillis,
+    }),
+  });
+
+  const client = new Pool(connectionConfig);
+  const db = drizzle({ client });
+  return { client, db };
+}
+
+export async function initializeMySQLConnection(
+  connection: ConnectionConfig['connection']
+): Promise<InitializedVendorConnection> {
+  const { drizzle } = await import('drizzle-orm/mysql2');
+  const mysql = await import('mysql2/promise');
+  const connectionConfig = normalizeMySQLConfig(connection);
+
+  if (typeof connectionConfig !== 'string') {
+    logger.debug('Creating MySQL connection pool', {
+      vendor: 'mysql',
+      poolConfig: pickConfiguredPoolFields({
+        connectionLimit: connectionConfig.connectionLimit,
+        acquireTimeout: connectionConfig.acquireTimeout,
+        idleTimeout: connectionConfig.idleTimeout,
+      }),
+    });
+  }
+
+  const client = typeof connectionConfig === 'string'
+    ? mysql.createPool(connectionConfig)
+    : mysql.createPool(connectionConfig);
+  const db = drizzle({ client });
+  return { client, db };
+}
+
+export async function initializeSQLiteConnection(
+  connection: ConnectionConfig['connection']
+): Promise<InitializedVendorConnection> {
+  const { drizzle } = await import('drizzle-orm/better-sqlite3');
+  const DatabaseModule = await import('better-sqlite3');
+  const Database = DatabaseModule.default;
+  const { url, poolConfig } = resolveSqliteUrl(connection);
+
+  if (poolConfig) {
+    logger.debug('SQLite pool configuration provided but not applied (SQLite uses single connection)', {
+      vendor: 'sqlite',
+      poolConfig: pickConfiguredPoolFields({
+        max: poolConfig.max,
+        idleTimeoutMillis: poolConfig.idleTimeoutMillis,
+        acquireTimeoutMillis: poolConfig.acquireTimeoutMillis,
+      }),
+    });
+  }
+
+  logger.debug('Creating SQLite connection', {
+    vendor: 'sqlite',
+    url: url === ':memory:' ? ':memory:' : 'file',
+  });
+
+  const client = new Database(url);
+  client.pragma('foreign_keys = ON');
+  const db = drizzle({ client });
+  return { client, db };
+}

--- a/packages/tools/src/data/relational/connection/vendor-initialization.ts
+++ b/packages/tools/src/data/relational/connection/vendor-initialization.ts
@@ -1,11 +1,9 @@
 import type {
   ConnectionConfig,
-  MySQLConnectionConfig,
   PoolConfig,
   PostgreSQLConnectionConfig,
-  SQLiteConnectionConfig,
+  MySQLConnectionConfig,
 } from './types.js';
-import type { DatabaseVendor } from '../types.js';
 import { createLogger } from '@agentforge/core';
 
 const logger = createLogger('agentforge:tools:data:relational:connection:vendor-init');
@@ -26,6 +24,10 @@ interface MySQLPoolConnectionConfig extends Omit<MySQLConnectionConfig, 'pool'> 
   acquireTimeout?: number;
   idleTimeout?: number;
 }
+
+type PostgreSQLVendorConnection = Extract<ConnectionConfig, { vendor: 'postgresql' }>['connection'];
+type MySQLVendorConnection = Extract<ConnectionConfig, { vendor: 'mysql' }>['connection'];
+type SQLiteVendorConnection = Extract<ConnectionConfig, { vendor: 'sqlite' }>['connection'];
 
 export const SAFE_INITIALIZATION_PATTERNS = [
   'Pool max connections must be',
@@ -59,14 +61,13 @@ function pickConfiguredPoolFields(
 }
 
 function normalizePostgreSQLConfig(
-  connection: ConnectionConfig['connection']
+  connection: PostgreSQLVendorConnection
 ): {
   connectionConfig: PostgreSQLPoolConnectionConfig;
   poolConfig?: PoolConfig;
 } {
-  const { pool: poolConfig, ...baseConfig } = typeof connection === 'string'
-    ? { connectionString: connection }
-    : (connection as PostgreSQLConnectionConfig);
+  const { pool: poolConfig, ...baseConfig } =
+    typeof connection === 'string' ? { connectionString: connection } : connection;
 
   if (poolConfig) {
     validatePoolConfig(poolConfig);
@@ -88,7 +89,7 @@ function normalizePostgreSQLConfig(
 }
 
 function normalizeMySQLConfig(
-  connection: ConnectionConfig['connection']
+  connection: MySQLVendorConnection
 ): string | MySQLPoolConnectionConfig {
   if (typeof connection === 'string') {
     logger.debug('Creating MySQL connection pool from connection string', {
@@ -97,7 +98,7 @@ function normalizeMySQLConfig(
     return connection;
   }
 
-  const { pool: poolConfig, ...baseConfig } = connection as MySQLConnectionConfig;
+  const { pool: poolConfig, ...baseConfig } = connection;
 
   if (poolConfig) {
     validatePoolConfig(poolConfig);
@@ -115,7 +116,7 @@ function normalizeMySQLConfig(
   };
 }
 
-function resolveSqliteUrl(connection: ConnectionConfig['connection']): {
+function resolveSqliteUrl(connection: SQLiteVendorConnection): {
   url: string;
   poolConfig?: PoolConfig;
 } {
@@ -123,7 +124,7 @@ function resolveSqliteUrl(connection: ConnectionConfig['connection']): {
     return { url: connection };
   }
 
-  const { url, pool } = connection as SQLiteConnectionConfig;
+  const { url, pool } = connection;
 
   if (!url) {
     throw new Error('SQLite connection requires a url property');
@@ -137,23 +138,22 @@ function resolveSqliteUrl(connection: ConnectionConfig['connection']): {
 }
 
 export async function initializeVendorConnection(
-  vendor: DatabaseVendor,
-  connection: ConnectionConfig['connection']
+  config: ConnectionConfig
 ): Promise<InitializedVendorConnection> {
-  switch (vendor) {
+  switch (config.vendor) {
     case 'postgresql':
-      return initializePostgreSQLConnection(connection);
+      return initializePostgreSQLConnection(config.connection);
     case 'mysql':
-      return initializeMySQLConnection(connection);
+      return initializeMySQLConnection(config.connection);
     case 'sqlite':
-      return initializeSQLiteConnection(connection);
+      return initializeSQLiteConnection(config.connection);
     default:
-      throw new Error(`Unsupported database vendor: ${vendor}`);
+      throw new Error(`Unsupported database vendor: ${(config as { vendor: string }).vendor}`);
   }
 }
 
 export async function initializePostgreSQLConnection(
-  connection: ConnectionConfig['connection']
+  connection: PostgreSQLVendorConnection
 ): Promise<InitializedVendorConnection> {
   const { drizzle } = await import('drizzle-orm/node-postgres');
   const { Pool } = await import('pg');
@@ -174,7 +174,7 @@ export async function initializePostgreSQLConnection(
 }
 
 export async function initializeMySQLConnection(
-  connection: ConnectionConfig['connection']
+  connection: MySQLVendorConnection
 ): Promise<InitializedVendorConnection> {
   const { drizzle } = await import('drizzle-orm/mysql2');
   const mysql = await import('mysql2/promise');
@@ -202,7 +202,7 @@ export async function initializeMySQLConnection(
 }
 
 export async function initializeSQLiteConnection(
-  connection: ConnectionConfig['connection']
+  connection: SQLiteVendorConnection
 ): Promise<InitializedVendorConnection> {
   const { drizzle } = await import('drizzle-orm/better-sqlite3');
   const DatabaseModule = await import('better-sqlite3');

--- a/packages/tools/tests/data/relational/connection/vendor-initialization.test.ts
+++ b/packages/tools/tests/data/relational/connection/vendor-initialization.test.ts
@@ -173,13 +173,19 @@ describe('vendor-initialization helpers', () => {
 
   describe('initializeVendorConnection', () => {
     it('routes vendor initialization to the selected adapter', async () => {
-      const initialized = await initializeVendorConnection('sqlite', ':memory:');
+      const initialized = await initializeVendorConnection({
+        vendor: 'sqlite',
+        connection: ':memory:',
+      });
       expect(initialized.client).toEqual(expect.objectContaining({ kind: 'sqlite-client' }));
     });
 
     it('rejects unsupported vendors', async () => {
       await expect(
-        initializeVendorConnection('oracle' as never, 'oracle://localhost/test')
+        initializeVendorConnection({
+          vendor: 'oracle' as never,
+          connection: 'oracle://localhost/test',
+        })
       ).rejects.toThrow('Unsupported database vendor: oracle');
     });
   });

--- a/packages/tools/tests/data/relational/connection/vendor-initialization.test.ts
+++ b/packages/tools/tests/data/relational/connection/vendor-initialization.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPool = vi.fn();
+const mockPgDrizzle = vi.fn();
+const mockMysqlCreatePool = vi.fn();
+const mockMysqlDrizzle = vi.fn();
+const mockDatabase = vi.fn();
+const mockSqliteDrizzle = vi.fn();
+const mockSqlitePragma = vi.fn();
+
+vi.mock('pg', () => ({
+  Pool: mockPool,
+}));
+
+vi.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: mockPgDrizzle,
+}));
+
+vi.mock('mysql2/promise', () => ({
+  createPool: mockMysqlCreatePool,
+}));
+
+vi.mock('drizzle-orm/mysql2', () => ({
+  drizzle: mockMysqlDrizzle,
+}));
+
+vi.mock('better-sqlite3', () => ({
+  default: mockDatabase,
+}));
+
+vi.mock('drizzle-orm/better-sqlite3', () => ({
+  drizzle: mockSqliteDrizzle,
+}));
+
+import {
+  initializeMySQLConnection,
+  initializePostgreSQLConnection,
+  initializeSQLiteConnection,
+  initializeVendorConnection,
+  validatePoolConfig,
+} from '../../../../src/data/relational/connection/vendor-initialization.js';
+
+describe('vendor-initialization helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPool.mockImplementation((config) => ({ kind: 'pg-client', config }));
+    mockPgDrizzle.mockImplementation(({ client }) => ({ kind: 'pg-db', client }));
+
+    mockMysqlCreatePool.mockImplementation((config) => ({ kind: 'mysql-client', config }));
+    mockMysqlDrizzle.mockImplementation(({ client }) => ({ kind: 'mysql-db', client }));
+
+    mockDatabase.mockImplementation((url) => ({
+      kind: 'sqlite-client',
+      url,
+      pragma: mockSqlitePragma,
+    }));
+    mockSqliteDrizzle.mockImplementation(({ client }) => ({ kind: 'sqlite-db', client }));
+  });
+
+  describe('validatePoolConfig', () => {
+    it('rejects invalid max connections', () => {
+      expect(() => validatePoolConfig({ max: 0 })).toThrow('Pool max connections must be >= 1');
+    });
+
+    it('rejects negative acquire timeout', () => {
+      expect(() => validatePoolConfig({ acquireTimeoutMillis: -1 })).toThrow(
+        'Pool acquire timeout must be >= 0'
+      );
+    });
+
+    it('rejects negative idle timeout', () => {
+      expect(() => validatePoolConfig({ idleTimeoutMillis: -1 })).toThrow(
+        'Pool idle timeout must be >= 0'
+      );
+    });
+  });
+
+  describe('initializePostgreSQLConnection', () => {
+    it('maps pool config fields for object connections', async () => {
+      const initialized = await initializePostgreSQLConnection({
+        host: 'localhost',
+        database: 'app',
+        user: 'user',
+        password: 'secret',
+        pool: {
+          max: 5,
+          idleTimeoutMillis: 30000,
+          acquireTimeoutMillis: 10000,
+        },
+      });
+
+      expect(mockPool).toHaveBeenCalledWith({
+        host: 'localhost',
+        database: 'app',
+        user: 'user',
+        password: 'secret',
+        max: 5,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 10000,
+      });
+      expect(initialized).toEqual({
+        client: expect.objectContaining({ kind: 'pg-client' }),
+        db: expect.objectContaining({ kind: 'pg-db' }),
+      });
+    });
+
+    it('passes connection strings through as connectionString config', async () => {
+      await initializePostgreSQLConnection('postgresql://localhost/test');
+
+      expect(mockPool).toHaveBeenCalledWith({
+        connectionString: 'postgresql://localhost/test',
+      });
+    });
+  });
+
+  describe('initializeMySQLConnection', () => {
+    it('maps pool config fields for object connections', async () => {
+      const initialized = await initializeMySQLConnection({
+        host: 'localhost',
+        database: 'app',
+        user: 'user',
+        password: 'secret',
+        pool: {
+          max: 7,
+          idleTimeoutMillis: 45000,
+          acquireTimeoutMillis: 8000,
+        },
+      });
+
+      expect(mockMysqlCreatePool).toHaveBeenCalledWith({
+        host: 'localhost',
+        database: 'app',
+        user: 'user',
+        password: 'secret',
+        connectionLimit: 7,
+        acquireTimeout: 8000,
+        idleTimeout: 45000,
+      });
+      expect(initialized).toEqual({
+        client: expect.objectContaining({ kind: 'mysql-client' }),
+        db: expect.objectContaining({ kind: 'mysql-db' }),
+      });
+    });
+
+    it('passes connection strings directly to mysql2.createPool', async () => {
+      await initializeMySQLConnection('mysql://localhost/test');
+      expect(mockMysqlCreatePool).toHaveBeenCalledWith('mysql://localhost/test');
+    });
+  });
+
+  describe('initializeSQLiteConnection', () => {
+    it('creates a sqlite client, enables foreign keys, and wires drizzle', async () => {
+      const initialized = await initializeSQLiteConnection({
+        url: ':memory:',
+        pool: { max: 3, idleTimeoutMillis: 2000 },
+      });
+
+      expect(mockDatabase).toHaveBeenCalledWith(':memory:');
+      expect(mockSqlitePragma).toHaveBeenCalledWith('foreign_keys = ON');
+      expect(initialized).toEqual({
+        client: expect.objectContaining({ kind: 'sqlite-client', url: ':memory:' }),
+        db: expect.objectContaining({ kind: 'sqlite-db' }),
+      });
+    });
+
+    it('requires a sqlite url in object config', async () => {
+      await expect(
+        initializeSQLiteConnection({ pool: { max: 1 } } as never)
+      ).rejects.toThrow('SQLite connection requires a url property');
+    });
+  });
+
+  describe('initializeVendorConnection', () => {
+    it('routes vendor initialization to the selected adapter', async () => {
+      const initialized = await initializeVendorConnection('sqlite', ':memory:');
+      expect(initialized.client).toEqual(expect.objectContaining({ kind: 'sqlite-client' }));
+    });
+
+    it('rejects unsupported vendors', async () => {
+      await expect(
+        initializeVendorConnection('oracle' as never, 'oracle://localhost/test')
+      ).rejects.toThrow('Unsupported database vendor: oracle');
+    });
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1000,19 +1000,39 @@ Implementation notes:
 **Branch:** `refactor/st-09027-connection-manager-vendor-initialization-extraction`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09027-connection-manager-vendor-initialization-extraction`
-- [ ] Create draft PR with story ID in title
-- [ ] Extract PostgreSQL/MySQL/SQLite initialization and pool-configuration logic from `packages/tools/src/data/relational/connection/connection-manager.ts`
-- [ ] Preserve current vendor initialization behavior and validation
-- [ ] Add/update focused tests for vendor initialization and pool configuration behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09027-connection-manager-vendor-initialization-extraction.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `refactor/st-09027-connection-manager-vendor-initialization-extraction`
+  - Created as `codex/refactor/st-09027-connection-manager-vendor-initialization-extraction` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #89: https://github.com/TVScoundrel/agentforge/pull/89
+- [x] Extract PostgreSQL/MySQL/SQLite initialization and pool-configuration logic from `packages/tools/src/data/relational/connection/connection-manager.ts`
+- [x] Preserve current vendor initialization behavior and validation
+- [x] Add/update focused tests for vendor initialization and pool configuration behavior
+  - `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `2 passed` files, `49 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09027-connection-manager-vendor-initialization-extraction.md` (`connection-manager.ts 2 -> 2`, overall `182 -> 180`)
+- [x] Add or update story documentation at `docs/st09027-connection-manager-vendor-initialization-extraction.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused helper coverage in `packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `refactor/st-09027-connection-manager-vendor-initialization-extraction` (workspace branch: `codex/refactor/st-09027-connection-manager-vendor-initialization-extraction`)
+- Draft PR: #89 `refactor(st-09027): extract connection manager vendor initialization adapters`
+- Implementation commit: `bdf3e5d` `refactor(st-09027): extract vendor initialization helpers`
+- Validation so far:
+  - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/vendor-initialization.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+  - `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `2 passed` files, `49 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `180/289` warnings, `tools 65/67`
+  - `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1036,6 +1036,7 @@ Implementation notes:
   - `pnpm lint:explicit-any:baseline --silent` -> `180/289` warnings, `tools 65/67`
   - `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0`; warnings only
+- Review fix commit: `1a0fc22` `fix(st-09027): tighten vendor initialization review fixes`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1037,6 +1037,7 @@ Implementation notes:
   - `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
   - `pnpm lint` -> exit `0`; warnings only
 - Review fix commit: `1a0fc22` `fix(st-09027): tighten vendor initialization review fixes`
+- Review fix commit: `57bedb4` `fix(st-09027): tighten vendor helper type pairing`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1017,8 +1017,11 @@ Implementation notes:
   - `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `bdf3e5d` `refactor(st-09027): extract vendor initialization helpers`
+  - `5d0aae0` `docs(st-09027): record validation and move story to in-review`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #89 marked ready: https://github.com/TVScoundrel/agentforge/pull/89
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1280,7 +1280,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09012
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/relational/connection/connection-manager.ts` extracts PostgreSQL, MySQL, and SQLite initialization/pool-configuration logic into clearer helpers or modules

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-09
-**Active Story:** ST-09027 (Ready)
+**Last Updated:** 2026-04-16
+**Active Story:** ST-09027 (In Review)
 
 ---
 
@@ -32,10 +32,10 @@
 
 ## Current Hotspot Snapshot
 
-Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-04-07):
+Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-04-16):
 
-- Total: `182` warnings (`src/**`)
-- By package: `core 63`, `tools 67`, `testing 31`, `patterns 15`, `cli 6`
+- Total: `180` warnings (`src/**`)
+- By package: `core 63`, `tools 65`, `testing 31`, `patterns 15`, `cli 6`
 
 Top runtime hotspots informing this feature slice:
 
@@ -44,7 +44,7 @@ Top runtime hotspots informing this feature slice:
 3. `packages/patterns/src/multi-agent/nodes.ts` was split behind the stable public entrypoint in `ST-09015`, with follow-up hardening landed for log redaction, workload invariants, interrupt propagation, and model-content serialization
 4. `ST-09017` has centralized repeated CLI command-level `catch (error: any)` handling behind a shared helper and is now merged
 5. `ST-09018` has tightened `packages/testing/src/helpers/assertions.ts` and `packages/testing/src/helpers/state-builder.ts`, reducing the `testing` package warning floor from `51` to `31` and is now merged
-6. `ST-09026` has now merged after extracting `packages/core/src/tools/registry.ts` prompt-rendering, LangChain conversion, and event-emission responsibilities into focused helpers; `ST-09027` is now the next small core runtime slice
+6. `ST-09027` is now in review after extracting `packages/tools/src/data/relational/connection/connection-manager.ts` vendor-specific initialization and pool-configuration logic into focused helpers while preserving the public connection lifecycle surface
 7. `packages/core/src/tools/registry.ts` and `packages/tools/src/data/relational/connection/connection-manager.ts` remain larger SRP targets that need multi-story decomposition rather than one oversized cleanup
 8. `packages/patterns/src/plan-execute/nodes.ts` has grown into a larger mixed-responsibility module and has become the next plan-execute modularization target after the ST-09014 shared contract cleanup
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-09
+**Last Updated:** 2026-04-16
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
+- **Ready:** 1 story
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
 
@@ -14,14 +14,13 @@
 
 ## Ready
 
-- `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09027` - Extract Connection Manager Vendor Initialization Adapters
 
 ---
 
@@ -116,4 +115,4 @@ _No stories currently blocked_
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded again on 2026-03-23 with daily hardening stories ST-09013 through ST-09018
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a third time on 2026-03-23 with daily hardening stories ST-09019 through ST-09028
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a fourth time on 2026-03-24 with the plan-execute node modularization follow-up story ST-09029
-- Current measured `no-explicit-any` baseline is `201` warnings (`cli 6`, `core 82`, `patterns 15`, `testing 31`, `tools 67`)
+- Current measured `no-explicit-any` baseline is `180` warnings (`cli 6`, `core 63`, `patterns 15`, `testing 31`, `tools 65`)


### PR DESCRIPTION
## Story
- ST-09027: Extract Connection Manager Vendor Initialization Adapters

## What Changed
- extracted PostgreSQL, MySQL, and SQLite initialization and pool-configuration logic from `packages/tools/src/data/relational/connection/connection-manager.ts`
- added the internal helper module `packages/tools/src/data/relational/connection/vendor-initialization.ts`
- added focused helper coverage in `packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
- preserved the public `ConnectionManager` lifecycle surface and existing lifecycle coverage in `packages/tools/tests/data/relational/connection/connection-manager.test.ts`

## Acceptance Criteria Coverage
- [x] `packages/tools/src/data/relational/connection/connection-manager.ts` extracts PostgreSQL, MySQL, and SQLite initialization/pool-configuration logic into clearer helpers or modules
- [x] Vendor-specific connection setup preserves current runtime behavior and validation
- [x] Focused tests are added or updated for vendor initialization and pool configuration behavior
- [x] Touched files do not regress on explicit-`any` warning counts and the outcome is recorded in story documentation
- [x] Add or update story documentation at `docs/st09027-connection-manager-vendor-initialization-extraction.md`

## Validation Performed
- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/vendor-initialization.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
- `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `2 passed` files, `49 passed` tests
- `pnpm lint:explicit-any:baseline --silent` -> `180/289` warnings, `tools 65/67`
- `pnpm lint` -> exit `0`; warnings only
- `pnpm test --run` -> `160 passed | 16 skipped` files; `2196 passed | 286 skipped` tests

## Status
- Ready for review
