### PR TITLE
refactor(st-09028): modularize connection manager lifecycle

### DIFF
--- a/docs/st09028-connection-manager-lifecycle-modularization.md
+++ b/docs/st09028-connection-manager-lifecycle-modularization.md
@@ -1,0 +1,34 @@
+# ST-09028: Connection Manager Lifecycle and Reconnection Control
+
+## Summary
+
+`packages/tools/src/data/relational/connection/connection-manager.ts` was still carrying the relational connection lifecycle orchestration after vendor initialization moved out in `ST-09027`. This story extracted the shared lifecycle and reconnection control flow into focused helpers while keeping the public `ConnectionManager` behavior unchanged.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/tools/src/data/relational/connection/lifecycle.ts` | Added shared lifecycle helpers for connection state, reconnection scheduling, pending-timer cancellation, in-flight connect waiting, and client shutdown. |
+| `packages/tools/src/data/relational/connection/connection-manager.ts` | Delegated lifecycle and reconnection orchestration to the extracted helper module while preserving the public `ConnectionState` and `ReconnectionConfig` exports. |
+| `packages/tools/tests/data/relational/connection/connection-manager.test.ts` | Added focused regressions for disconnecting during in-flight initialization and for canceling pending reconnection during close. |
+
+## Compatibility Notes
+
+- `ConnectionManager` remains the public lifecycle entrypoint.
+- `ConnectionState` and `ReconnectionConfig` are still exported from `connection-manager.ts`.
+- Public runtime behavior for `connect()`, `initialize()`, `disconnect()`, `close()`, `dispose()`, and reconnection scheduling is preserved.
+
+## Explicit-`any` Notes
+
+- `packages/tools/src/data/relational/connection/connection-manager.ts`: `2 -> 2`
+- `packages/tools/src/data/relational/connection/lifecycle.ts`: `0 -> 0`
+- Workspace baseline after implementation check: `180/289`
+- `tools` package baseline after implementation check: `65/67`
+
+## Validation
+
+- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+  - passed with existing warnings only in `connection-manager.ts` and the existing test file warnings
+- `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+  - `2 passed` files, `51 passed` tests

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -362,11 +362,9 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
           this.emit('reconnecting', payload);
         },
         initialize: () => this.initialize(),
-        connectPromise: this.connectPromise,
         setConnectPromise: (promise) => {
           this.connectPromise = promise;
         },
-        reconnectionTimer: this.reconnectionTimer,
         setReconnectionTimer: (timer) => {
           this.reconnectionTimer = timer;
         },

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -8,7 +8,7 @@ import type { ConnectionConfig } from './types.js';
 import {
   cancelPendingReconnection,
   ConnectionState,
-  scheduleReconnection,
+  scheduleReconnection as scheduleReconnectionHelper,
   shutdownClient,
   waitForInFlightConnection,
   type ReconnectionConfig,
@@ -347,7 +347,7 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
    * @private
    */
   private scheduleReconnection(): void {
-    scheduleReconnection(
+    scheduleReconnectionHelper(
       {
         vendor: this.vendor,
         reconnectionConfig: this.reconnectionConfig,

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -6,6 +6,14 @@
 import type { DatabaseConnection, DatabaseVendor } from '../types.js';
 import type { ConnectionConfig } from './types.js';
 import {
+  cancelPendingReconnection,
+  ConnectionState,
+  scheduleReconnection,
+  shutdownClient,
+  waitForInFlightConnection,
+  type ReconnectionConfig,
+} from './lifecycle.js';
+import {
   initializeVendorConnection,
   SAFE_INITIALIZATION_PATTERNS,
 } from './vendor-initialization.js';
@@ -17,34 +25,11 @@ import { EventEmitter } from 'events';
 const logger = createLogger('agentforge:tools:data:relational:connection');
 
 /**
- * Connection state enum
- */
-export enum ConnectionState {
-  DISCONNECTED = 'disconnected',
-  CONNECTING = 'connecting',
-  CONNECTED = 'connected',
-  RECONNECTING = 'reconnecting',
-  ERROR = 'error',
-}
-
-/**
  * Connection lifecycle events
  */
 export type ConnectionEvent = 'connected' | 'disconnected' | 'error' | 'reconnecting';
-
-/**
- * Reconnection configuration
- */
-export interface ReconnectionConfig {
-  /** Enable automatic reconnection on connection loss */
-  enabled: boolean;
-  /** Maximum number of reconnection attempts (0 = infinite) */
-  maxAttempts: number;
-  /** Base delay in milliseconds for exponential backoff */
-  baseDelayMs: number;
-  /** Maximum delay in milliseconds between reconnection attempts */
-  maxDelayMs: number;
-}
+export { ConnectionState } from './lifecycle.js';
+export type { ReconnectionConfig } from './lifecycle.js';
 
 /**
  * Connection manager that handles database connections for PostgreSQL, MySQL, and SQLite
@@ -109,13 +94,12 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     }
 
     // If a reconnection has been scheduled, cancel it before starting a new connection attempt
-    if (this.reconnectionTimer) {
-      logger.debug('Clearing pending reconnection timer before manual connect', {
-        vendor: this.vendor,
-      });
-      clearTimeout(this.reconnectionTimer);
-      this.reconnectionTimer = null;
-    }
+    this.reconnectionTimer = cancelPendingReconnection(
+      this.reconnectionTimer,
+      logger,
+      this.vendor,
+      'Clearing pending reconnection timer before manual connect'
+    );
 
     // Track the connection promise so concurrent callers can await it
     this.connectPromise = this.initialize().finally(() => {
@@ -137,28 +121,24 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     this.connectionGeneration++;
 
     // Cancel any pending reconnection
-    if (this.reconnectionTimer) {
-      clearTimeout(this.reconnectionTimer);
-      this.reconnectionTimer = null;
-    }
+    this.reconnectionTimer = cancelPendingReconnection(
+      this.reconnectionTimer,
+      logger,
+      this.vendor,
+      'Clearing pending reconnection timer before disconnect'
+    );
 
     // Reset reconnection attempts
     this.reconnectionAttempts = 0;
 
     // Wait for any in-flight connection attempt to complete before closing
     // This prevents race conditions where initialize() completes after disconnect()
-    if (this.connectPromise) {
-      logger.debug('Waiting for in-flight connection attempt to complete before disconnect', {
-        vendor: this.vendor,
-      });
-      try {
-        await this.connectPromise;
-      } catch {
-        // Ignore errors from the connection attempt - we're disconnecting anyway
-      }
-      // Clear the promise reference
-      this.connectPromise = null;
-    }
+    this.connectPromise = await waitForInFlightConnection(
+      this.connectPromise,
+      logger,
+      this.vendor,
+      'disconnect'
+    );
 
     // Close the connection
     await this.close();
@@ -367,69 +347,32 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
    * @private
    */
   private scheduleReconnection(): void {
-    // Check if we've exceeded max attempts
-    if (
-      this.reconnectionConfig.maxAttempts > 0 &&
-      this.reconnectionAttempts >= this.reconnectionConfig.maxAttempts
-    ) {
-      logger.error('Max reconnection attempts reached', {
+    scheduleReconnection(
+      {
         vendor: this.vendor,
-        attempts: this.reconnectionAttempts,
-        maxAttempts: this.reconnectionConfig.maxAttempts,
-      });
-      return;
-    }
-
-    // Calculate delay with exponential backoff
-    const delay = Math.min(
-      this.reconnectionConfig.baseDelayMs * Math.pow(2, this.reconnectionAttempts),
-      this.reconnectionConfig.maxDelayMs
+        reconnectionConfig: this.reconnectionConfig,
+        reconnectionAttempts: this.reconnectionAttempts,
+        setReconnectionAttempts: (attempts) => {
+          this.reconnectionAttempts = attempts;
+        },
+        setState: (state) => {
+          this.setState(state);
+        },
+        emitReconnecting: (payload) => {
+          this.emit('reconnecting', payload);
+        },
+        initialize: () => this.initialize(),
+        connectPromise: this.connectPromise,
+        setConnectPromise: (promise) => {
+          this.connectPromise = promise;
+        },
+        reconnectionTimer: this.reconnectionTimer,
+        setReconnectionTimer: (timer) => {
+          this.reconnectionTimer = timer;
+        },
+      },
+      logger
     );
-
-    this.reconnectionAttempts++;
-
-    // Set state to reconnecting
-    this.setState(ConnectionState.RECONNECTING);
-
-    logger.info('Scheduling reconnection attempt', {
-      vendor: this.vendor,
-      attempt: this.reconnectionAttempts,
-      maxAttempts: this.reconnectionConfig.maxAttempts,
-      delayMs: delay,
-    });
-
-    this.emit('reconnecting', {
-      attempt: this.reconnectionAttempts,
-      maxAttempts: this.reconnectionConfig.maxAttempts,
-      delayMs: delay,
-    });
-
-    // Schedule reconnection
-    this.reconnectionTimer = setTimeout(async () => {
-      this.reconnectionTimer = null;
-
-      try {
-        logger.info('Attempting reconnection', {
-          vendor: this.vendor,
-          attempt: this.reconnectionAttempts,
-        });
-
-        // Track the reconnection promise so concurrent connect() calls can await it
-        this.connectPromise = this.initialize().finally(() => {
-          this.connectPromise = null;
-        });
-
-        await this.connectPromise;
-      } catch (error) {
-        logger.error('Reconnection attempt failed', {
-          vendor: this.vendor,
-          attempt: this.reconnectionAttempts,
-          error: error instanceof Error ? error.message : String(error),
-        });
-
-        // The initialize() method will schedule another reconnection if needed
-      }
-    }, delay);
   }
 
   /**
@@ -650,26 +593,20 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
     this.connectionGeneration++;
 
     // Cancel any pending reconnection to prevent unexpected reconnection after close
-    if (this.reconnectionTimer) {
-      logger.debug('Canceling pending reconnection timer during close', {
-        vendor: this.vendor,
-      });
-      clearTimeout(this.reconnectionTimer);
-      this.reconnectionTimer = null;
-    }
+    this.reconnectionTimer = cancelPendingReconnection(
+      this.reconnectionTimer,
+      logger,
+      this.vendor,
+      'Canceling pending reconnection timer during close'
+    );
 
     // Wait for any in-flight connection attempt to complete before closing
-    if (this.connectPromise) {
-      logger.debug('Waiting for in-flight connection attempt to complete before close', {
-        vendor: this.vendor,
-      });
-      try {
-        await this.connectPromise;
-      } catch {
-        // Ignore errors from the connection attempt - we're closing anyway
-      }
-      this.connectPromise = null;
-    }
+    this.connectPromise = await waitForInFlightConnection(
+      this.connectPromise,
+      logger,
+      this.vendor,
+      'close'
+    );
 
     // Now perform the actual close operation
     if (this.client) {
@@ -679,11 +616,7 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
       });
 
       try {
-        if (this.vendor === 'postgresql' || this.vendor === 'mysql') {
-          await this.client.end();
-        } else if (this.vendor === 'sqlite') {
-          this.client.close();
-        }
+        await shutdownClient(this.vendor, this.client);
 
         // Set state to disconnected and emit event
         this.setState(ConnectionState.DISCONNECTED);
@@ -734,11 +667,7 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
 
     try {
       // Close the client connection
-      if (this.vendor === 'postgresql' || this.vendor === 'mysql') {
-        await this.client.end();
-      } else if (this.vendor === 'sqlite') {
-        this.client.close();
-      }
+      await shutdownClient(this.vendor, this.client);
     } catch (error) {
       // Log but don't throw - we're cleaning up a cancelled connection
       logger.debug('Error during cancelled connection cleanup', {

--- a/packages/tools/src/data/relational/connection/lifecycle.ts
+++ b/packages/tools/src/data/relational/connection/lifecycle.ts
@@ -9,9 +9,13 @@ export enum ConnectionState {
 }
 
 export interface ReconnectionConfig {
+  /** Enable automatic reconnection on connection loss. */
   enabled: boolean;
+  /** Maximum number of reconnection attempts (0 = infinite). */
   maxAttempts: number;
+  /** Base delay in milliseconds for exponential backoff. */
   baseDelayMs: number;
+  /** Maximum delay in milliseconds between reconnection attempts. */
   maxDelayMs: number;
 }
 

--- a/packages/tools/src/data/relational/connection/lifecycle.ts
+++ b/packages/tools/src/data/relational/connection/lifecycle.ts
@@ -1,0 +1,156 @@
+import type { DatabaseVendor } from '../types.js';
+
+export enum ConnectionState {
+  DISCONNECTED = 'disconnected',
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  RECONNECTING = 'reconnecting',
+  ERROR = 'error',
+}
+
+export interface ReconnectionConfig {
+  enabled: boolean;
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface ReconnectingEventPayload {
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+}
+
+export interface ConnectionLifecycleLogger {
+  debug(message: string, metadata?: unknown): void;
+  info(message: string, metadata?: unknown): void;
+  error(message: string, metadata?: unknown): void;
+}
+
+export interface ScheduledReconnectionContext {
+  vendor: DatabaseVendor;
+  reconnectionConfig: ReconnectionConfig;
+  reconnectionAttempts: number;
+  setReconnectionAttempts(attempts: number): void;
+  setState(state: ConnectionState): void;
+  emitReconnecting(payload: ReconnectingEventPayload): void;
+  initialize(): Promise<void>;
+  connectPromise: Promise<void> | null;
+  setConnectPromise(promise: Promise<void> | null): void;
+  reconnectionTimer: NodeJS.Timeout | null;
+  setReconnectionTimer(timer: NodeJS.Timeout | null): void;
+}
+
+export function cancelPendingReconnection(
+  timer: NodeJS.Timeout | null,
+  logger: ConnectionLifecycleLogger,
+  vendor: DatabaseVendor,
+  message: string
+): NodeJS.Timeout | null {
+  if (!timer) {
+    return null;
+  }
+
+  logger.debug(message, { vendor });
+  clearTimeout(timer);
+  return null;
+}
+
+export async function waitForInFlightConnection(
+  promise: Promise<void> | null,
+  logger: ConnectionLifecycleLogger,
+  vendor: DatabaseVendor,
+  phase: 'disconnect' | 'close'
+): Promise<null> {
+  if (!promise) {
+    return null;
+  }
+
+  logger.debug(`Waiting for in-flight connection attempt to complete before ${phase}`, {
+    vendor,
+  });
+  try {
+    await promise;
+  } catch {
+    // Ignore in-flight connection errors during shutdown paths.
+  }
+  return null;
+}
+
+export function shutdownClient(
+  vendor: DatabaseVendor,
+  client: unknown
+): Promise<void> | void {
+  if (vendor === 'postgresql' || vendor === 'mysql') {
+    return (client as { end(): Promise<void> }).end();
+  }
+
+  if (vendor === 'sqlite') {
+    (client as { close(): void }).close();
+  }
+}
+
+export function scheduleReconnection(
+  context: ScheduledReconnectionContext,
+  logger: ConnectionLifecycleLogger
+): void {
+  if (
+    context.reconnectionConfig.maxAttempts > 0 &&
+    context.reconnectionAttempts >= context.reconnectionConfig.maxAttempts
+  ) {
+    logger.error('Max reconnection attempts reached', {
+      vendor: context.vendor,
+      attempts: context.reconnectionAttempts,
+      maxAttempts: context.reconnectionConfig.maxAttempts,
+    });
+    return;
+  }
+
+  const delay = Math.min(
+    context.reconnectionConfig.baseDelayMs * Math.pow(2, context.reconnectionAttempts),
+    context.reconnectionConfig.maxDelayMs
+  );
+
+  const nextAttempt = context.reconnectionAttempts + 1;
+  context.setReconnectionAttempts(nextAttempt);
+  context.setState(ConnectionState.RECONNECTING);
+
+  logger.info('Scheduling reconnection attempt', {
+    vendor: context.vendor,
+    attempt: nextAttempt,
+    maxAttempts: context.reconnectionConfig.maxAttempts,
+    delayMs: delay,
+  });
+
+  context.emitReconnecting({
+    attempt: nextAttempt,
+    maxAttempts: context.reconnectionConfig.maxAttempts,
+    delayMs: delay,
+  });
+
+  const timer = setTimeout(async () => {
+    context.setReconnectionTimer(null);
+
+    try {
+      logger.info('Attempting reconnection', {
+        vendor: context.vendor,
+        attempt: context.reconnectionAttempts,
+      });
+
+      const promise = context.initialize().finally(() => {
+        context.setConnectPromise(null);
+      });
+
+      context.setConnectPromise(promise);
+      await promise;
+    } catch (error) {
+      logger.error('Reconnection attempt failed', {
+        vendor: context.vendor,
+        attempt: context.reconnectionAttempts,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, delay);
+
+  context.setReconnectionTimer(timer);
+}

--- a/packages/tools/src/data/relational/connection/lifecycle.ts
+++ b/packages/tools/src/data/relational/connection/lifecycle.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from '@agentforge/core';
+
 import type { DatabaseVendor } from '../types.js';
 
 export enum ConnectionState {
@@ -26,9 +28,9 @@ export interface ReconnectingEventPayload {
 }
 
 export interface ConnectionLifecycleLogger {
-  debug(message: string, metadata?: unknown): void;
-  info(message: string, metadata?: unknown): void;
-  error(message: string, metadata?: unknown): void;
+  debug(message: string, metadata?: JsonValue): void;
+  info(message: string, metadata?: JsonValue): void;
+  error(message: string, metadata?: JsonValue): void;
 }
 
 export interface ScheduledReconnectionContext {
@@ -39,9 +41,7 @@ export interface ScheduledReconnectionContext {
   setState(state: ConnectionState): void;
   emitReconnecting(payload: ReconnectingEventPayload): void;
   initialize(): Promise<void>;
-  connectPromise: Promise<void> | null;
   setConnectPromise(promise: Promise<void> | null): void;
-  reconnectionTimer: NodeJS.Timeout | null;
   setReconnectionTimer(timer: NodeJS.Timeout | null): void;
 }
 
@@ -138,7 +138,7 @@ export function scheduleReconnection(
     try {
       logger.info('Attempting reconnection', {
         vendor: context.vendor,
-        attempt: context.reconnectionAttempts,
+        attempt: nextAttempt,
       });
 
       const promise = context.initialize().finally(() => {
@@ -150,7 +150,7 @@ export function scheduleReconnection(
     } catch (error) {
       logger.error('Reconnection attempt failed', {
         vendor: context.vendor,
-        attempt: context.reconnectionAttempts,
+        attempt: nextAttempt,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/packages/tools/tests/data/relational/connection/connection-manager.test.ts
+++ b/packages/tools/tests/data/relational/connection/connection-manager.test.ts
@@ -286,6 +286,30 @@ describe('ConnectionManager', () => {
       await manager.disconnect();
       expect(disconnectedFn).toHaveBeenCalledOnce();
     });
+
+    it('cancels an in-flight initialize during disconnect', async () => {
+      let resolveHealthCheck: ((value: Array<{ '?column?': number }>) => void) | undefined;
+      const healthCheckPromise = new Promise<Array<{ '?column?': number }>>((resolve) => {
+        resolveHealthCheck = resolve;
+      });
+      mockPgExecute.mockReturnValueOnce(healthCheckPromise);
+
+      const manager = new ConnectionManager({
+        vendor: 'postgresql',
+        connection: 'postgresql://localhost/test',
+      });
+
+      const connectPromise = manager.connect();
+      const disconnectPromise = manager.disconnect();
+
+      resolveHealthCheck?.([{ '?column?': 1 }]);
+
+      await expect(connectPromise).rejects.toThrow('Failed to initialize postgresql connection');
+      await disconnectPromise;
+
+      expect(manager.getState()).toBe(ConnectionState.DISCONNECTED);
+      expect(mockPoolEnd).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('dispose', () => {
@@ -582,6 +606,30 @@ describe('ConnectionManager', () => {
       (manager as any).state = ConnectionState.ERROR;
       await manager.close();
       expect(manager.getState()).toBe(ConnectionState.DISCONNECTED);
+    });
+
+    it('cancels a pending reconnection timer during close', async () => {
+      vi.useFakeTimers();
+      mockPgExecute.mockRejectedValue(new Error('Health check failed'));
+
+      const manager = new ConnectionManager(
+        { vendor: 'postgresql', connection: 'postgresql://localhost/test' },
+        { enabled: true, maxAttempts: 1, baseDelayMs: 10, maxDelayMs: 100 }
+      );
+
+      const errorFn = vi.fn();
+      manager.on('error', errorFn);
+
+      await expect(manager.connect()).rejects.toThrow('Failed to initialize postgresql connection');
+      expect(manager.getState()).toBe(ConnectionState.RECONNECTING);
+
+      await manager.close();
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(manager.getState()).toBe(ConnectionState.DISCONNECTED);
+      expect(mockPool).toHaveBeenCalledTimes(1);
+      expect(errorFn).toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 

--- a/packages/tools/tests/data/relational/connection/connection-manager.test.ts
+++ b/packages/tools/tests/data/relational/connection/connection-manager.test.ts
@@ -610,26 +610,29 @@ describe('ConnectionManager', () => {
 
     it('cancels a pending reconnection timer during close', async () => {
       vi.useFakeTimers();
-      mockPgExecute.mockRejectedValue(new Error('Health check failed'));
+      try {
+        mockPgExecute.mockRejectedValue(new Error('Health check failed'));
 
-      const manager = new ConnectionManager(
-        { vendor: 'postgresql', connection: 'postgresql://localhost/test' },
-        { enabled: true, maxAttempts: 1, baseDelayMs: 10, maxDelayMs: 100 }
-      );
+        const manager = new ConnectionManager(
+          { vendor: 'postgresql', connection: 'postgresql://localhost/test' },
+          { enabled: true, maxAttempts: 1, baseDelayMs: 10, maxDelayMs: 100 }
+        );
 
-      const errorFn = vi.fn();
-      manager.on('error', errorFn);
+        const errorFn = vi.fn();
+        manager.on('error', errorFn);
 
-      await expect(manager.connect()).rejects.toThrow('Failed to initialize postgresql connection');
-      expect(manager.getState()).toBe(ConnectionState.RECONNECTING);
+        await expect(manager.connect()).rejects.toThrow('Failed to initialize postgresql connection');
+        expect(manager.getState()).toBe(ConnectionState.RECONNECTING);
 
-      await manager.close();
-      await vi.advanceTimersByTimeAsync(20);
+        await manager.close();
+        await vi.advanceTimersByTimeAsync(20);
 
-      expect(manager.getState()).toBe(ConnectionState.DISCONNECTED);
-      expect(mockPool).toHaveBeenCalledTimes(1);
-      expect(errorFn).toHaveBeenCalled();
-      vi.useRealTimers();
+        expect(manager.getState()).toBe(ConnectionState.DISCONNECTED);
+        expect(mockPool).toHaveBeenCalledTimes(1);
+        expect(errorFn).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1053,19 +1053,38 @@ Implementation notes:
 **Branch:** `refactor/st-09028-connection-manager-lifecycle-modularization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09028-connection-manager-lifecycle-modularization`
-- [ ] Create draft PR with story ID in title
-- [ ] Extract lifecycle and reconnection orchestration from `packages/tools/src/data/relational/connection/connection-manager.ts`
-- [ ] Preserve current connect/initialize/disconnect/close/reconnection behavior
-- [ ] Add/update focused tests for cancellation, reconnection scheduling, and lifecycle cleanup behavior
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09028-connection-manager-lifecycle-modularization.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `refactor/st-09028-connection-manager-lifecycle-modularization`
+  - Created as `codex/refactor/st-09028-connection-manager-lifecycle-modularization` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #90: https://github.com/TVScoundrel/agentforge/pull/90
+- [x] Extract lifecycle and reconnection orchestration from `packages/tools/src/data/relational/connection/connection-manager.ts`
+- [x] Preserve current connect/initialize/disconnect/close/reconnection behavior
+- [x] Add/update focused tests for cancellation, reconnection scheduling, and lifecycle cleanup behavior
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09028-connection-manager-lifecycle-modularization.md` (`connection-manager.ts 2 -> 2`, workspace `180 -> 180`)
+- [x] Add or update story documentation at `docs/st09028-connection-manager-lifecycle-modularization.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused lifecycle regressions in `packages/tools/tests/data/relational/connection/connection-manager.test.ts` for disconnect-during-initialize cancellation and canceling a pending reconnection timer during close
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `160 passed | 16 skipped` files; `2198 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Created branch: `refactor/st-09028-connection-manager-lifecycle-modularization` (workspace branch: `codex/refactor/st-09028-connection-manager-lifecycle-modularization`)
+- Draft PR: #90 `refactor(st-09028): modularize connection manager lifecycle`
+- Implementation commit: `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
+- Validation:
+  - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+  - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+  - `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `2 passed` files, `51 passed` tests
+  - `pnpm lint:explicit-any:baseline --silent` -> `180/289` warnings, `tools 65/67`
+  - `pnpm test --run` -> `160 passed | 16 skipped` files; `2198 passed | 286 skipped` tests
+  - `pnpm lint` -> exit `0`; warnings only
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1069,8 +1069,11 @@ Implementation notes:
   - `pnpm test --run` -> `160 passed | 16 skipped` files; `2198 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
+  - `a2b75fc` `docs(st-09028): track lifecycle modularization progress`
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #90 marked ready: https://github.com/TVScoundrel/agentforge/pull/90
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1072,7 +1072,7 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
   - `a2b75fc` `docs(st-09028): track lifecycle modularization progress`
-  - review-fix commit pending below
+  - `41498e5` `fix(st-09028): address lifecycle review feedback`
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #90 marked ready: https://github.com/TVScoundrel/agentforge/pull/90
 - [ ] Wait for merge; do not merge directly from local branch
@@ -1082,7 +1082,7 @@ Implementation notes:
 - Created branch: `refactor/st-09028-connection-manager-lifecycle-modularization` (workspace branch: `codex/refactor/st-09028-connection-manager-lifecycle-modularization`)
 - Draft PR: #90 `refactor(st-09028): modularize connection manager lifecycle`
 - Implementation commit: `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
-- Review-fix commit: pending
+- Review-fix commit: `41498e5` `fix(st-09028): address lifecycle review feedback`
 - Validation:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1073,6 +1073,7 @@ Implementation notes:
   - `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
   - `a2b75fc` `docs(st-09028): track lifecycle modularization progress`
   - `41498e5` `fix(st-09028): address lifecycle review feedback`
+  - `f2eb2ce` `chore(st-09028): record review-fix commit`
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #90 marked ready: https://github.com/TVScoundrel/agentforge/pull/90
 - [ ] Wait for merge; do not merge directly from local branch
@@ -1083,6 +1084,7 @@ Implementation notes:
 - Draft PR: #90 `refactor(st-09028): modularize connection manager lifecycle`
 - Implementation commit: `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
 - Review-fix commit: `41498e5` `fix(st-09028): address lifecycle review feedback`
+- Review-fix commit: `f2eb2ce` `chore(st-09028): record review-fix commit`
 - Validation:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1072,6 +1072,7 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
   - `a2b75fc` `docs(st-09028): track lifecycle modularization progress`
+  - review-fix commit pending below
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #90 marked ready: https://github.com/TVScoundrel/agentforge/pull/90
 - [ ] Wait for merge; do not merge directly from local branch
@@ -1081,6 +1082,7 @@ Implementation notes:
 - Created branch: `refactor/st-09028-connection-manager-lifecycle-modularization` (workspace branch: `codex/refactor/st-09028-connection-manager-lifecycle-modularization`)
 - Draft PR: #90 `refactor(st-09028): modularize connection manager lifecycle`
 - Implementation commit: `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
+- Review-fix commit: pending
 - Validation:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1074,6 +1074,7 @@ Implementation notes:
   - `a2b75fc` `docs(st-09028): track lifecycle modularization progress`
   - `41498e5` `fix(st-09028): address lifecycle review feedback`
   - `f2eb2ce` `chore(st-09028): record review-fix commit`
+  - `82921ad` `fix(st-09028): tighten lifecycle helper contracts`
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #90 marked ready: https://github.com/TVScoundrel/agentforge/pull/90
 - [ ] Wait for merge; do not merge directly from local branch
@@ -1085,6 +1086,7 @@ Implementation notes:
 - Implementation commit: `7aff487` `refactor(st-09028): extract connection lifecycle helpers`
 - Review-fix commit: `41498e5` `fix(st-09028): address lifecycle review feedback`
 - Review-fix commit: `f2eb2ce` `chore(st-09028): record review-fix commit`
+- Review-fix commit: `82921ad` `fix(st-09028): tighten lifecycle helper contracts`
 - Validation:
   - `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
   - `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1297,7 +1297,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09027
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/relational/connection/connection-manager.ts` extracts lifecycle/reconnection concerns such as state transitions, cancellation, reconnection scheduling, and close/dispose orchestration into clearer helpers or modules

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-16
-**Active Story:** ST-09028 (Ready)
+**Last Updated:** 2026-04-17
+**Active Story:** ST-09028 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-16
+**Last Updated:** 2026-04-17
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
+- **Ready:** 4 stories
 - **In Progress:** 0 stories
+- **In Review:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
@@ -26,6 +27,11 @@
 
 _No stories currently in progress_
 
+---
+
+## In Review
+
+- `ST-09028` - Modularize Connection Manager Lifecycle and Reconnection Control
 ---
 
 ## Blocked

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -7,7 +7,6 @@
 - **Ready:** 4 stories
 - **In Progress:** 0 stories
 - **In Review:** 1 story
-- **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
 
@@ -15,7 +14,6 @@
 
 ## Ready
 
-- `ST-09028` - Modularize Connection Manager Lifecycle and Reconnection Control
 - `ST-09029` - Modularize Plan-Execute Node Responsibilities
 - `ST-09030` - Extract Connection Manager Query Execution and Session Adapters
 - `ST-09031` - Extract Tool Registry Registration and Mutation Paths
@@ -32,6 +30,7 @@ _No stories currently in progress_
 ## In Review
 
 - `ST-09028` - Modularize Connection Manager Lifecycle and Reconnection Control
+
 ---
 
 ## Blocked


### PR DESCRIPTION
## Story
- ST-09028 - Modularize Connection Manager Lifecycle and Reconnection Control

## What Changed
- extracted shared lifecycle and reconnection helpers into `packages/tools/src/data/relational/connection/lifecycle.ts`
- slimmed `ConnectionManager` by delegating pending-timer cancellation, in-flight connect waiting, reconnection scheduling, and client shutdown cleanup
- preserved the public `ConnectionState` and `ReconnectionConfig` exports from `connection-manager.ts`
- added focused lifecycle regressions for disconnect-during-initialize cancellation and close canceling a pending reconnection timer
- documented the story outcome in `docs/st09028-connection-manager-lifecycle-modularization.md`
- updated Epic 9 trackers and checklist state for the review handoff

## Acceptance Criteria Coverage
- extracted lifecycle/reconnection concerns from `connection-manager.ts` into clearer helper boundaries
- preserved public lifecycle behavior for `connect`, `initialize`, `disconnect`, `close`, and reconnection flows through focused regression coverage
- added focused tests for cancellation, reconnection scheduling, and lifecycle cleanup behavior
- maintained the explicit-`any` warning floor for touched runtime files
- added the required story documentation

## Validation Performed
- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/lifecycle.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
- `pnpm test --run packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
- `pnpm lint:explicit-any:baseline --silent`
- `pnpm test --run`
  - `160 passed | 16 skipped` files
  - `2198 passed | 286 skipped` tests
- `pnpm lint`
  - exit `0`; warnings only

## Status
- Ready for review
