### PR TITLE
ST-09030: Extract connection manager query/session helpers

### DIFF
--- a/docs/st09030-connection-manager-query-session-extraction.md
+++ b/docs/st09030-connection-manager-query-session-extraction.md
@@ -1,0 +1,57 @@
+# ST-09030: Extract Connection Manager Query Execution and Session Adapters
+
+## Summary
+
+`packages/tools/src/data/relational/connection/connection-manager.ts` was still mixing lifecycle concerns with vendor-specific SQL result normalization and dedicated-session execution branches after the earlier lifecycle and vendor-initialization splits. This story extracted those query and session responsibilities into focused internal helpers while keeping `ConnectionManager` as the stable public façade.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/tools/src/data/relational/connection/connection-manager.ts` | Delegated direct SQL execution and dedicated-session handling to focused internal helpers while preserving the public `execute(...)` and `executeInConnection(...)` entrypoints. |
+| `packages/tools/src/data/relational/connection/query-execution.ts` | Added vendor-aware query execution helpers for PostgreSQL/MySQL/SQLite, including SQLite non-query normalization and MySQL tuple unwrapping. |
+| `packages/tools/src/data/relational/connection/session-adapters.ts` | Added dedicated-session helpers for PostgreSQL/MySQL pooled connections and the direct SQLite session path. |
+| `packages/tools/tests/data/relational/connection/query-session-extraction.test.ts` | Added focused helper coverage for MySQL row normalization, SQLite DML normalization, and dedicated-session release behavior. |
+| `packages/tools/tests/data/relational/connection/connection-manager.test.ts` | Preserved the broader lifecycle and public-surface coverage over `ConnectionManager` after the extraction. |
+
+## Compatibility Notes
+
+- `ConnectionManager` remains the public query-execution façade.
+- Public runtime behavior for `execute(...)` remains unchanged across PostgreSQL, MySQL, and SQLite.
+- Public runtime behavior for `executeInConnection(...)` remains unchanged for dedicated PostgreSQL/MySQL sessions and the direct SQLite path.
+- MySQL still unwraps drizzle/mysql2 `[rows, fields]` tuples to return only the result payload.
+- SQLite still normalizes `.run()` results to include `affectedRows` when the statement does not return data.
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/tools/src/data/relational/connection/connection-manager.ts`: `2 -> 2` (`0`)
+- `packages/tools/src/data/relational/connection/query-execution.ts`: `0 -> 0` (`0`)
+- `packages/tools/src/data/relational/connection/session-adapters.ts`: `0 -> 0` (`0`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `180 -> 180` (`0`)
+- `tools` package: `65 -> 65` (`0`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-22.)
+
+## Validation
+
+- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/query-execution.ts packages/tools/src/data/relational/connection/session-adapters.ts packages/tools/tests/data/relational/connection/query-session-extraction.test.ts`
+  - passed with the existing `connection-manager.ts` warnings only
+- `pnpm test --run packages/tools/tests/data/relational/connection/query-session-extraction.test.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
+  - `3 passed` files, `57 passed` tests
+- `pnpm lint:explicit-any:baseline --silent`
+  - `180/289` warnings, `tools 65/67`
+- `pnpm test --run`
+  - `161 passed | 16 skipped` files
+  - `2216 passed | 286 skipped` tests
+- `pnpm lint`
+  - exit `0`; warnings only
+
+## Test Impact
+
+Added a focused query/session helper suite so vendor-specific result normalization and dedicated-session release behavior are covered directly, while retaining the existing `ConnectionManager` lifecycle suite to catch public-surface regressions.

--- a/packages/tools/src/data/relational/connection/connection-manager.ts
+++ b/packages/tools/src/data/relational/connection/connection-manager.ts
@@ -17,6 +17,8 @@ import {
   initializeVendorConnection,
   SAFE_INITIALIZATION_PATTERNS,
 } from './vendor-initialization.js';
+import { executeQuery } from './query-execution.js';
+import { executeInDedicatedConnection } from './session-adapters.js';
 import { checkPeerDependency } from '../utils/peer-dependency-checker.js';
 import { sql, type SQL } from 'drizzle-orm';
 import { createLogger } from '@agentforge/core';
@@ -416,45 +418,15 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
       throw new Error('Database not initialized. Call initialize() first.');
     }
 
-    logger.debug('Executing SQL query', {
-      vendor: this.vendor
-    });
-
-    // drizzle-orm's better-sqlite3 adapter does not expose an .execute() method.
-    // It uses .all() for SELECT (returns row arrays) and .run() for DML/DDL
-    // (returns { changes, lastInsertRowid }). Try .all() first and fall back
-    // to .run() when better-sqlite3 throws a SqliteError indicating the
-    // statement does not return data.
-    if (this.vendor === 'sqlite') {
-      try {
-        return this.db.all(query);
-      } catch (error: unknown) {
-        if (this.isSqliteNonQueryError(error)) {
-          // .run() returns { changes, lastInsertRowid }. Normalize by mapping
-          // `changes` to `affectedRows` so executeQuery() can derive rowCount
-          // consistently across vendors.
-          const runResult = this.db.run(query) as { changes?: number; lastInsertRowid?: number };
-          return { ...runResult, affectedRows: runResult.changes ?? 0 };
-        }
-        throw error;
-      }
-    }
-
-    // drizzle-orm's mysql2 adapter returns [rows, fields] from execute().
-    // Normalize by extracting just the rows array so callers can treat the
-    // result identically to PostgreSQL (which returns rows directly).
-    if (this.vendor === 'mysql') {
-      const raw = await this.db.execute(query);
-      // mysql2 returns [rows, fields] for SELECTs and [ResultSetHeader, fields]
-      // for INSERT/UPDATE/DELETE. Unwrap the first element in both cases so
-      // callers get a consistent shape matching PostgreSQL / SQLite.
-      if (Array.isArray(raw) && raw.length === 2) {
-        return raw[0];
-      }
-      return raw;
-    }
-
-    return this.db.execute(query);
+    return executeQuery(
+      {
+        vendor: this.vendor,
+        db: this.db,
+        isSqliteNonQueryError: (error) => this.isSqliteNonQueryError(error),
+      },
+      query,
+      logger
+    );
   }
 
   /**
@@ -470,52 +442,15 @@ export class ConnectionManager extends EventEmitter implements DatabaseConnectio
       throw new Error('Database not initialized. Call connect() first.');
     }
 
-    if (this.vendor === 'sqlite') {
-      return callback(async (query) => {
-        try {
-          return this.db.all(query);
-        } catch (error: unknown) {
-          if (this.isSqliteNonQueryError(error)) {
-            // Normalize .run() result — see execute() for details.
-            const runResult = this.db.run(query) as { changes?: number; lastInsertRowid?: number };
-            return { ...runResult, affectedRows: runResult.changes ?? 0 };
-          }
-          throw error;
-        }
-      });
-    }
-
-    if (this.vendor === 'postgresql') {
-      const poolClient = await this.client.connect();
-      try {
-        const { drizzle } = await import('drizzle-orm/node-postgres');
-        const sessionDb = drizzle({ client: poolClient });
-        return await callback(async (query) => sessionDb.execute(query));
-      } finally {
-        poolClient.release();
-      }
-    }
-
-    if (this.vendor === 'mysql') {
-      const mysqlConnection = await this.client.getConnection();
-      try {
-        const { drizzle } = await import('drizzle-orm/mysql2');
-        const sessionDb = drizzle({ client: mysqlConnection });
-        return await callback(async (query) => {
-          const raw = await sessionDb.execute(query);
-          // mysql2 returns [rows, fields] for SELECTs and [ResultSetHeader, fields]
-          // for INSERT/UPDATE/DELETE. Unwrap the first element in both cases.
-          if (Array.isArray(raw) && raw.length === 2) {
-            return raw[0];
-          }
-          return raw;
-        });
-      } finally {
-        mysqlConnection.release();
-      }
-    }
-
-    throw new Error(`Unsupported database vendor: ${this.vendor}`);
+    return executeInDedicatedConnection(
+      {
+        vendor: this.vendor,
+        client: this.client,
+        db: this.db,
+        isSqliteNonQueryError: (error) => this.isSqliteNonQueryError(error),
+      },
+      callback
+    );
   }
 
   /**

--- a/packages/tools/src/data/relational/connection/query-execution.ts
+++ b/packages/tools/src/data/relational/connection/query-execution.ts
@@ -1,0 +1,70 @@
+import type { SQL } from 'drizzle-orm';
+import type { JsonValue } from '@agentforge/core';
+
+import type { DatabaseVendor } from '../types.js';
+
+export interface SqliteQueryAdapter {
+  all(query: SQL): unknown;
+  run(query: SQL): { changes?: number; lastInsertRowid?: number };
+}
+
+export interface QueryExecutionLogger {
+  debug(message: string, metadata?: JsonValue): void;
+}
+
+export interface QueryExecutionContext {
+  vendor: DatabaseVendor;
+  db: unknown;
+  isSqliteNonQueryError(error: unknown): boolean;
+}
+
+export async function executeQuery(
+  context: QueryExecutionContext,
+  query: SQL,
+  logger: QueryExecutionLogger
+): Promise<unknown> {
+  logger.debug('Executing SQL query', {
+    vendor: context.vendor,
+  });
+
+  if (context.vendor === 'sqlite') {
+    return executeSqliteQuery(
+      context.db as SqliteQueryAdapter,
+      query,
+      context.isSqliteNonQueryError
+    );
+  }
+
+  if (context.vendor === 'mysql') {
+    return normalizeMySqlResult(
+      await (context.db as { execute(query: SQL): Promise<unknown> }).execute(query)
+    );
+  }
+
+  return (context.db as { execute(query: SQL): Promise<unknown> }).execute(query);
+}
+
+export async function executeSqliteQuery(
+  db: SqliteQueryAdapter,
+  query: SQL,
+  isSqliteNonQueryError: (error: unknown) => boolean
+): Promise<unknown> {
+  try {
+    return db.all(query);
+  } catch (error: unknown) {
+    if (isSqliteNonQueryError(error)) {
+      const runResult = db.run(query);
+      return { ...runResult, affectedRows: runResult.changes ?? 0 };
+    }
+
+    throw error;
+  }
+}
+
+export function normalizeMySqlResult(raw: unknown): unknown {
+  if (Array.isArray(raw) && raw.length === 2) {
+    return raw[0];
+  }
+
+  return raw;
+}

--- a/packages/tools/src/data/relational/connection/session-adapters.ts
+++ b/packages/tools/src/data/relational/connection/session-adapters.ts
@@ -1,4 +1,6 @@
 import type { SQL } from 'drizzle-orm';
+import type { PoolConnection as MySqlPoolConnection } from 'mysql2/promise';
+import type { NodePgClient } from 'drizzle-orm/node-postgres';
 
 import type { DatabaseVendor } from '../types.js';
 import {
@@ -35,7 +37,7 @@ export async function executeInDedicatedConnection<T>(
 
     try {
       const { drizzle } = await import('drizzle-orm/node-postgres');
-      const sessionDb = drizzle({ client: poolClient } as never);
+      const sessionDb = drizzle({ client: poolClient as NodePgClient });
       return await callback((query) => sessionDb.execute(query));
     } finally {
       poolClient.release();
@@ -44,12 +46,12 @@ export async function executeInDedicatedConnection<T>(
 
   if (context.vendor === 'mysql') {
     const mysqlConnection = await (context.client as {
-      getConnection(): Promise<{ release(): void }>;
+      getConnection(): Promise<MySqlPoolConnection>;
     }).getConnection();
 
     try {
       const { drizzle } = await import('drizzle-orm/mysql2');
-      const sessionDb = drizzle({ client: mysqlConnection } as never);
+      const sessionDb = drizzle({ client: mysqlConnection });
       return await callback(async (query) =>
         normalizeMySqlResult(await sessionDb.execute(query))
       );

--- a/packages/tools/src/data/relational/connection/session-adapters.ts
+++ b/packages/tools/src/data/relational/connection/session-adapters.ts
@@ -1,0 +1,62 @@
+import type { SQL } from 'drizzle-orm';
+
+import type { DatabaseVendor } from '../types.js';
+import {
+  executeSqliteQuery,
+  normalizeMySqlResult,
+  type SqliteQueryAdapter,
+} from './query-execution.js';
+
+export interface SessionExecutionContext {
+  vendor: DatabaseVendor;
+  client: unknown;
+  db: unknown;
+  isSqliteNonQueryError(error: unknown): boolean;
+}
+
+export async function executeInDedicatedConnection<T>(
+  context: SessionExecutionContext,
+  callback: (execute: (query: SQL) => Promise<unknown>) => Promise<T>
+): Promise<T> {
+  if (context.vendor === 'sqlite') {
+    return callback((query) =>
+      executeSqliteQuery(
+        context.db as SqliteQueryAdapter,
+        query,
+        context.isSqliteNonQueryError
+      )
+    );
+  }
+
+  if (context.vendor === 'postgresql') {
+    const poolClient = await (context.client as {
+      connect(): Promise<{ release(): void }>;
+    }).connect();
+
+    try {
+      const { drizzle } = await import('drizzle-orm/node-postgres');
+      const sessionDb = drizzle({ client: poolClient } as never);
+      return await callback((query) => sessionDb.execute(query));
+    } finally {
+      poolClient.release();
+    }
+  }
+
+  if (context.vendor === 'mysql') {
+    const mysqlConnection = await (context.client as {
+      getConnection(): Promise<{ release(): void }>;
+    }).getConnection();
+
+    try {
+      const { drizzle } = await import('drizzle-orm/mysql2');
+      const sessionDb = drizzle({ client: mysqlConnection } as never);
+      return await callback(async (query) =>
+        normalizeMySqlResult(await sessionDb.execute(query))
+      );
+    } finally {
+      mysqlConnection.release();
+    }
+  }
+
+  throw new Error(`Unsupported database vendor: ${context.vendor}`);
+}

--- a/packages/tools/tests/data/relational/connection/query-session-extraction.test.ts
+++ b/packages/tools/tests/data/relational/connection/query-session-extraction.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+
+const mockPgSessionExecute = vi.fn();
+const mockPgDrizzle = vi.fn(() => ({
+  execute: mockPgSessionExecute,
+}));
+vi.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: mockPgDrizzle,
+}));
+
+const mockMysqlSessionExecute = vi.fn();
+const mockMysqlDrizzle = vi.fn(() => ({
+  execute: mockMysqlSessionExecute,
+}));
+vi.mock('drizzle-orm/mysql2', () => ({
+  drizzle: mockMysqlDrizzle,
+}));
+
+import {
+  executeQuery,
+  normalizeMySqlResult,
+} from '../../../../src/data/relational/connection/query-execution.js';
+import { executeInDedicatedConnection } from '../../../../src/data/relational/connection/session-adapters.js';
+
+describe('connection query/session extraction helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('executeQuery', () => {
+    it('normalizes mysql tuple results to rows', async () => {
+      const result = await executeQuery(
+        {
+          vendor: 'mysql',
+          db: {
+            execute: vi.fn().mockResolvedValue([[{ id: 1 }], ['fields']]),
+          },
+          isSqliteNonQueryError: () => false,
+        },
+        sql`SELECT 1`,
+        { debug: vi.fn() }
+      );
+
+      expect(result).toEqual([{ id: 1 }]);
+    });
+
+    it('normalizes sqlite non-query run results to affectedRows', async () => {
+      const sqliteError = new Error('This statement does not return data');
+      sqliteError.name = 'SqliteError';
+
+      const result = await executeQuery(
+        {
+          vendor: 'sqlite',
+          db: {
+            all: vi.fn().mockImplementation(() => {
+              throw sqliteError;
+            }),
+            run: vi.fn().mockReturnValue({ changes: 2, lastInsertRowid: 5 }),
+          },
+          isSqliteNonQueryError: (error) => error === sqliteError,
+        },
+        sql`UPDATE test SET name = 'x'`,
+        { debug: vi.fn() }
+      );
+
+      expect(result).toEqual({
+        changes: 2,
+        lastInsertRowid: 5,
+        affectedRows: 2,
+      });
+    });
+  });
+
+  describe('executeInDedicatedConnection', () => {
+    it('uses a dedicated postgresql session and releases it', async () => {
+      const release = vi.fn();
+      const connect = vi.fn().mockResolvedValue({ release });
+      mockPgSessionExecute.mockResolvedValue([{ ok: true }]);
+
+      const result = await executeInDedicatedConnection(
+        {
+          vendor: 'postgresql',
+          client: { connect },
+          db: {},
+          isSqliteNonQueryError: () => false,
+        },
+        async (execute) => execute(sql`SELECT 1`)
+      );
+
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(mockPgDrizzle).toHaveBeenCalledTimes(1);
+      expect(mockPgSessionExecute).toHaveBeenCalledTimes(1);
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ ok: true }]);
+    });
+
+    it('uses a dedicated mysql session, unwraps rows, and releases it', async () => {
+      const release = vi.fn();
+      const getConnection = vi.fn().mockResolvedValue({ release });
+      mockMysqlSessionExecute.mockResolvedValue([[{ ok: true }], ['fields']]);
+
+      const result = await executeInDedicatedConnection(
+        {
+          vendor: 'mysql',
+          client: { getConnection },
+          db: {},
+          isSqliteNonQueryError: () => false,
+        },
+        async (execute) => execute(sql`SELECT 1`)
+      );
+
+      expect(getConnection).toHaveBeenCalledTimes(1);
+      expect(mockMysqlDrizzle).toHaveBeenCalledTimes(1);
+      expect(mockMysqlSessionExecute).toHaveBeenCalledTimes(1);
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ ok: true }]);
+    });
+
+    it('reuses the sqlite adapter directly for dedicated execution', async () => {
+      const result = await executeInDedicatedConnection(
+        {
+          vendor: 'sqlite',
+          client: {},
+          db: {
+            all: vi.fn().mockReturnValue([{ ok: true }]),
+            run: vi.fn(),
+          },
+          isSqliteNonQueryError: () => false,
+        },
+        async (execute) => execute(sql`SELECT 1`)
+      );
+
+      expect(result).toEqual([{ ok: true }]);
+    });
+  });
+
+  describe('normalizeMySqlResult', () => {
+    it('returns non-tuple mysql results unchanged', () => {
+      expect(normalizeMySqlResult({ affectedRows: 1 })).toEqual({ affectedRows: 1 });
+    });
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1173,8 +1173,11 @@ Implementation notes:
   - `pnpm test --run` -> `161 passed | 16 skipped` files; `2216 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `0eb485d` refactor(st-09030): extract query and session helpers
+  - `097b0a9` docs(st-09030): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #93 marked ready: https://github.com/TVScoundrel/agentforge/pull/93
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1155,16 +1155,24 @@ Implementation notes:
 **Branch:** `refactor/st-09030-connection-manager-query-session-extraction`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09030-connection-manager-query-session-extraction`
-- [ ] Create draft PR with story ID in title
-- [ ] Extract query execution and `executeInConnection(...)` vendor branches from `packages/tools/src/data/relational/connection/connection-manager.ts`
-- [ ] Preserve current PostgreSQL/MySQL/SQLite result normalization and dedicated-session behavior
-- [ ] Add/update focused tests for vendor-specific query execution and session handling
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09030-connection-manager-query-session-extraction.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `refactor/st-09030-connection-manager-query-session-extraction`
+- [x] Create draft PR with story ID in title
+  - Draft PR #93: https://github.com/TVScoundrel/agentforge/pull/93
+- [x] Extract query execution and `executeInConnection(...)` vendor branches from `packages/tools/src/data/relational/connection/connection-manager.ts`
+  - Extracted focused helpers into `query-execution.ts` and `session-adapters.ts` while keeping `ConnectionManager` as the public façade
+- [x] Preserve current PostgreSQL/MySQL/SQLite result normalization and dedicated-session behavior
+  - MySQL tuple unwrapping, SQLite `affectedRows` normalization, and dedicated PostgreSQL/MySQL session release behavior are preserved by focused helper coverage
+- [x] Add/update focused tests for vendor-specific query execution and session handling
+  - `pnpm test --run packages/tools/tests/data/relational/connection/query-session-extraction.test.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts` -> `3 passed` files, `57 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09030-connection-manager-query-session-extraction.md`; workspace baseline remains `180/289`, `tools` remains `65/67`
+- [x] Add or update story documentation at `docs/st09030-connection-manager-query-session-extraction.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused helper coverage in `packages/tools/tests/data/relational/connection/query-session-extraction.test.ts`
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `161 passed | 16 skipped` files; `2216 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1176,6 +1176,7 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `0eb485d` refactor(st-09030): extract query and session helpers
   - `097b0a9` docs(st-09030): record validation and move story to in-review
+  - `3395cf4` chore(st-09030): finalize checklist and ready status
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #93 marked ready: https://github.com/TVScoundrel/agentforge/pull/93
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1360,7 +1360,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** ST-09028
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/relational/connection/connection-manager.ts` extracts query execution and `executeInConnection(...)` vendor branches into focused helpers or modules

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-21
-**Active Story:** ST-09030 (Ready)
+**Last Updated:** 2026-04-22
+**Active Story:** ST-09030 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-21
+**Last Updated:** 2026-04-22
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories
+- **Ready:** 3 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 7 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09030` - Extract Connection Manager Query Execution and Session Adapters
 - `ST-09031` - Extract Tool Registry Registration and Mutation Paths
 - `ST-09032` - Tighten Managed Tool Lifecycle Contracts
 - `ST-10001` - Audit Markdown Emoji Usage Across Project-Owned Docs
@@ -29,7 +28,7 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09030` - Extract Connection Manager Query Execution and Session Adapters
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09030: Extract Connection Manager Query Execution and Session Adapters

## What Changed
- extracted vendor-aware SQL execution into `packages/tools/src/data/relational/connection/query-execution.ts`
- extracted dedicated-session adapter handling into `packages/tools/src/data/relational/connection/session-adapters.ts`
- kept `packages/tools/src/data/relational/connection/connection-manager.ts` as the public façade for `execute(...)` and `executeInConnection(...)`
- added focused helper coverage for MySQL result unwrapping, SQLite DML normalization, and dedicated-session release behavior
- added story documentation in `docs/st09030-connection-manager-query-session-extraction.md`
- updated Epic 9 tracker/checklist state to `In Review`

## Acceptance Criteria Coverage
- `connection-manager.ts` now delegates query execution and `executeInConnection(...)` vendor branches to focused internal helpers
- PostgreSQL/MySQL/SQLite execution behavior remains unchanged for direct and dedicated-session execution paths
- focused tests cover vendor-specific query normalization and dedicated-session handling
- explicit-`any` warning counts did not regress in touched `src/**` files and are recorded in the story doc
- story documentation is included

## Validation Performed
- `pnpm exec tsc -p packages/tools/tsconfig.json --noEmit`
- `pnpm exec eslint packages/tools/src/data/relational/connection/connection-manager.ts packages/tools/src/data/relational/connection/query-execution.ts packages/tools/src/data/relational/connection/session-adapters.ts packages/tools/tests/data/relational/connection/query-session-extraction.test.ts`
- `pnpm test --run packages/tools/tests/data/relational/connection/query-session-extraction.test.ts packages/tools/tests/data/relational/connection/connection-manager.test.ts packages/tools/tests/data/relational/connection/vendor-initialization.test.ts`
- `pnpm lint:explicit-any:baseline --silent`
- `pnpm test --run`
- `pnpm lint`

## Status
- Ready for review
