### PR TITLE
fix(st-09032): tighten managed tool lifecycle contracts

### DIFF
--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made initialization, auto-cleanup listeners, and health-check teardown safer under repeated instance creation, long-running checks, concurrent initialization/cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made initialization, cleanup, auto-cleanup listeners, and health-check teardown safer under repeated instance creation, long-running checks, concurrent initialization/cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, single-flight initialization behavior, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, single-flight initialization behavior, cleanup during in-flight initialization, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
 
 ## Compatibility Notes
 
@@ -24,6 +24,7 @@
 - Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
 - Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
 - Initialization is now single-flight, so concurrent callers share one setup pass and cannot double-run `initializeFn()` or leak duplicate periodic health-check intervals.
+- Cleanup now waits for any in-flight initialization attempt before tearing down, so `cleanup()` cannot return while the tool later becomes initialized from a pending setup.
 - Auto-cleanup registration is restored on re-initialization, so reusable managed tools still clean up on `beforeExit` after a manual `cleanup()` / `initialize()` cycle.
 - Manual and periodic health checks now capture a lifecycle generation, so late results from an earlier init cycle cannot overwrite health stats after a cleanup/reinitialize boundary.
 
@@ -47,7 +48,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `17 passed` tests
+  - `1 passed` file, `18 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made initialization, auto-cleanup listeners, and health-check teardown safer under repeated instance creation, long-running checks, concurrent initialization/cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, single-flight initialization behavior, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
 
 ## Compatibility Notes
 
@@ -23,6 +23,7 @@
 - Auto-cleanup listeners are now removed during teardown even if `cleanup()` is called before `initialize()`.
 - Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
 - Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
+- Initialization is now single-flight, so concurrent callers share one setup pass and cannot double-run `initializeFn()` or leak duplicate periodic health-check intervals.
 - Auto-cleanup registration is restored on re-initialization, so reusable managed tools still clean up on `beforeExit` after a manual `cleanup()` / `initialize()` cycle.
 - Manual and periodic health checks now capture a lifecycle generation, so late results from an earlier init cycle cannot overwrite health stats after a cleanup/reinitialize boundary.
 
@@ -46,7 +47,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `16 passed` tests
+  - `1 passed` file, `17 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, and concurrent cleanup. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, and repeated teardown calls. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, and health-check races during teardown. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, and single-flight cleanup behavior. |
 
 ## Compatibility Notes
 
@@ -22,6 +22,7 @@
 - Periodic health checks now run single-flight, so long-running checks do not overlap and race the stored health status.
 - Auto-cleanup listeners are now removed during teardown even if `cleanup()` is called before `initialize()`.
 - Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
+- Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
 
 ## Explicit `any` Warning Delta
 
@@ -43,7 +44,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `12 passed` tests
+  - `1 passed` file, `13 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,13 +8,14 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, tightened the LangChain interop return type, and normalized unknown error handling without changing runtime behavior. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, and normalized unknown error handling without changing runtime behavior. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
 | `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, and LangChain-style invocation. |
 
 ## Compatibility Notes
 
 - Managed-tool initialization, execution, cleanup, and health-check runtime behavior remain unchanged.
+- `ManagedTool.context` is now typed as `TContext | undefined`, matching the existing runtime possibility when no initial context is provided.
 - `healthCheck()` still returns `{ healthy: true, metadata: { message: 'No health check configured' } }` when no health check is configured.
 - `toLangChainTool()` still returns the same runtime shape with `name`, `description`, and `invoke(...)`.
 - Process-exit auto-cleanup registration remains enabled by default when `autoCleanup` is not disabled.

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -1,0 +1,53 @@
+# ST-09032: Tighten Managed Tool Lifecycle Contracts
+
+## Summary
+
+`packages/core/src/tools/lifecycle.ts` still relied on broad `any` defaults across the managed-tool lifecycle surface, including context, execute input/output, and health-check metadata. This story tightened those contracts to unknown-first or more accurate defaults, aligned health metadata with the shared JSON-safe payload types, and added direct lifecycle coverage for initialization, execution, cleanup, health checks, process-exit cleanup registration, and LangChain interop.
+
+## What Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, tightened the LangChain interop return type, and normalized unknown error handling without changing runtime behavior. |
+| `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, and LangChain-style invocation. |
+
+## Compatibility Notes
+
+- Managed-tool initialization, execution, cleanup, and health-check runtime behavior remain unchanged.
+- `healthCheck()` still returns `{ healthy: true, metadata: { message: 'No health check configured' } }` when no health check is configured.
+- `toLangChainTool()` still returns the same runtime shape with `name`, `description`, and `invoke(...)`.
+- Process-exit auto-cleanup registration remains enabled by default when `autoCleanup` is not disabled.
+
+## Explicit `any` Warning Delta
+
+### Story scope hotspot
+
+- `packages/core/src/tools/lifecycle.ts`: `10 -> 0` (`-10`)
+- `packages/core/src/tools/lifecycle.typecheck.ts`: `0 -> 0` (`0`)
+
+### Baseline gate snapshot
+
+- `@typescript-eslint/no-explicit-any` (`packages/**/src/**/*.ts`): `180 -> 170` (`-10`)
+- `core` package: `63 -> 53` (`-10`)
+
+(Captured with `pnpm lint:explicit-any:baseline --silent` on 2026-04-24.)
+
+## Validation
+
+- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
+- `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
+  - passed cleanly
+- `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
+  - `1 passed` file, `7 passed` tests
+- `pnpm lint:explicit-any:baseline --silent`
+  - `170/289` warnings, `core 53/119`
+- `pnpm test --run`
+  - `163 passed | 16 skipped` files
+  - `2233 passed | 286 skipped` tests
+- `pnpm lint`
+  - exit `0`; warnings only
+
+## Test Impact
+
+Added a dedicated lifecycle suite so the managed-tool contract now has direct coverage for lifecycle hooks, execution stats, periodic health checks, process-exit cleanup registration, and LangChain-style invocation instead of relying on indirect transitive coverage.

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, and repeated teardown calls. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, repeated teardown calls, and cleanup/reinitialize reuse cycles. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, and single-flight cleanup behavior. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, and auto-cleanup reuse after re-initialization. |
 
 ## Compatibility Notes
 
@@ -23,6 +23,7 @@
 - Auto-cleanup listeners are now removed during teardown even if `cleanup()` is called before `initialize()`.
 - Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
 - Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
+- Auto-cleanup registration is restored on re-initialization, so reusable managed tools still clean up on `beforeExit` after a manual `cleanup()` / `initialize()` cycle.
 
 ## Explicit `any` Warning Delta
 
@@ -44,7 +45,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `13 passed` tests
+  - `1 passed` file, `14 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, repeated teardown calls, and cleanup/reinitialize reuse cycles. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, concurrent cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, and auto-cleanup reuse after re-initialization. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
 
 ## Compatibility Notes
 
@@ -24,6 +24,7 @@
 - Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
 - Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
 - Auto-cleanup registration is restored on re-initialization, so reusable managed tools still clean up on `beforeExit` after a manual `cleanup()` / `initialize()` cycle.
+- Manual and periodic health checks now capture a lifecycle generation, so late results from an earlier init cycle cannot overwrite health stats after a cleanup/reinitialize boundary.
 
 ## Explicit `any` Warning Delta
 
@@ -45,7 +46,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `14 passed` tests
+  - `1 passed` file, `16 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and periodic health checks safer under repeated instance creation and long-running checks. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and health-check teardown safer under repeated instance creation, long-running checks, and concurrent cleanup. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, and late health-check completion after cleanup. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, and health-check races during teardown. |
 
 ## Compatibility Notes
 
@@ -21,6 +21,7 @@
 - Process-exit auto-cleanup registration remains enabled by default when `autoCleanup` is not disabled.
 - Periodic health checks now run single-flight, so long-running checks do not overlap and race the stored health status.
 - Auto-cleanup listeners are now removed during teardown even if `cleanup()` is called before `initialize()`.
+- Cleanup now marks the tool unavailable before awaiting teardown hooks, so manual and periodic health checks do not write stale status after teardown starts.
 
 ## Explicit `any` Warning Delta
 
@@ -42,7 +43,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `10 passed` tests
+  - `1 passed` file, `12 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`
@@ -53,4 +54,4 @@
 
 ## Test Impact
 
-Added a dedicated lifecycle suite so the managed-tool contract now has direct coverage for lifecycle hooks, execution stats, periodic health checks, process-exit cleanup registration, and LangChain-style invocation instead of relying on indirect transitive coverage.
+Added a dedicated lifecycle suite so the managed-tool contract now has direct coverage for lifecycle hooks, execution stats, periodic health checks, process-exit cleanup registration, LangChain-style invocation, and teardown race handling instead of relying on indirect transitive coverage.

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -10,7 +10,7 @@
 |------|--------|
 | `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and periodic health checks safer under repeated instance creation and long-running checks. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, and LangChain-style invocation. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, and late health-check completion after cleanup. |
 
 ## Compatibility Notes
 
@@ -20,6 +20,7 @@
 - `toLangChainTool()` still returns the same runtime shape with `name`, `description`, and `invoke(...)`.
 - Process-exit auto-cleanup registration remains enabled by default when `autoCleanup` is not disabled.
 - Periodic health checks now run single-flight, so long-running checks do not overlap and race the stored health status.
+- Auto-cleanup listeners are now removed during teardown even if `cleanup()` is called before `initialize()`.
 
 ## Explicit `any` Warning Delta
 
@@ -41,7 +42,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `8 passed` tests
+  - `1 passed` file, `10 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -14,7 +14,7 @@
 
 ## Compatibility Notes
 
-- Managed-tool initialization, execution, cleanup, and health-check runtime behavior remain unchanged.
+- The public managed-tool surface and core lifecycle flow remain stable, while the latest review-fix rounds tighten background-hook and teardown behavior in edge cases.
 - `ManagedTool.context` is now typed as `TContext | undefined`, matching the existing runtime possibility when no initial context is provided.
 - `healthCheck()` still returns `{ healthy: true, metadata: { message: 'No health check configured' } }` when no health check is configured.
 - `toLangChainTool()` still returns the same runtime shape with `name`, `description`, and `invoke(...)`.

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,7 +8,7 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, and normalized unknown error handling without changing runtime behavior. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made auto-cleanup listeners and periodic health checks safer under repeated instance creation and long-running checks. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
 | `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, and LangChain-style invocation. |
 
@@ -19,6 +19,7 @@
 - `healthCheck()` still returns `{ healthy: true, metadata: { message: 'No health check configured' } }` when no health check is configured.
 - `toLangChainTool()` still returns the same runtime shape with `name`, `description`, and `invoke(...)`.
 - Process-exit auto-cleanup registration remains enabled by default when `autoCleanup` is not disabled.
+- Periodic health checks now run single-flight, so long-running checks do not overlap and race the stored health status.
 
 ## Explicit `any` Warning Delta
 
@@ -40,7 +41,7 @@
 - `pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts`
   - passed cleanly
 - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts`
-  - `1 passed` file, `7 passed` tests
+  - `1 passed` file, `8 passed` tests
 - `pnpm lint:explicit-any:baseline --silent`
   - `170/289` warnings, `core 53/119`
 - `pnpm test --run`

--- a/docs/st09032-managed-tool-lifecycle-contracts.md
+++ b/docs/st09032-managed-tool-lifecycle-contracts.md
@@ -8,9 +8,9 @@
 
 | File | Change |
 |------|--------|
-| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made initialization, cleanup, auto-cleanup listeners, and health-check teardown safer under repeated instance creation, long-running checks, concurrent initialization/cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, and late health-check completions from prior lifecycles. |
+| `packages/core/src/tools/lifecycle.ts` | Replaced broad lifecycle generic defaults with safer defaults, aligned health-check metadata with shared JSON-safe payload contracts, exposed `context` as optionally present to match runtime reality, tightened the LangChain interop return type, normalized unknown error handling, and made initialization, cleanup, auto-cleanup listeners, and health-check teardown safer under repeated instance creation, long-running checks, concurrent initialization/cleanup, repeated teardown calls, cleanup/reinitialize reuse cycles, initialize-during-cleanup calls, and late health-check completions from prior lifecycles. |
 | `packages/core/src/tools/lifecycle.typecheck.ts` | Added source-included type regressions covering typed context access, execute input/output inference, JSON-safe health metadata, and the unknown-first default surface. |
-| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, single-flight initialization behavior, cleanup during in-flight initialization, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
+| `packages/core/tests/tools/lifecycle.test.ts` | Added focused lifecycle coverage for initialization, execution stats, default and periodic health checks, cleanup, process-exit cleanup registration, LangChain-style invocation, pre-initialize cleanup, late health-check completion after cleanup, health-check races during teardown, single-flight cleanup behavior, single-flight initialization behavior, cleanup during in-flight initialization, initialize waiting on in-flight cleanup, auto-cleanup reuse after re-initialization, and stale health-check results across lifecycle reuse. |
 
 ## Compatibility Notes
 
@@ -25,6 +25,7 @@
 - Cleanup is now single-flight, so repeated `cleanup()` calls cannot clear teardown state early or allow `initialize()` to race ahead of an in-progress teardown.
 - Initialization is now single-flight, so concurrent callers share one setup pass and cannot double-run `initializeFn()` or leak duplicate periodic health-check intervals.
 - Cleanup now waits for any in-flight initialization attempt before tearing down, so `cleanup()` cannot return while the tool later becomes initialized from a pending setup.
+- Initialization now waits for any in-flight cleanup attempt before reinitializing, so `initialize()` cannot silently resolve while teardown leaves the tool uninitialized.
 - Auto-cleanup registration is restored on re-initialization, so reusable managed tools still clean up on `beforeExit` after a manual `cleanup()` / `initialize()` cycle.
 - Manual and periodic health checks now capture a lifecycle generation, so late results from an earlier init cycle cannot overwrite health stats after a cleanup/reinitialize boundary.
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -118,7 +118,16 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
       return;
     }
 
-    if (this._initialized || this._cleaningUp) {
+    if (this._cleanupPromise) {
+      await this._cleanupPromise;
+
+      if (this._initializePromise) {
+        await this._initializePromise;
+        return;
+      }
+    }
+
+    if (this._initialized) {
       return;
     }
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -70,6 +70,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   private _beforeExitHandler?: () => void;
   private _healthCheckInFlight = false;
   private _cleaningUp = false;
+  private _cleanupPromise?: Promise<void>;
 
   constructor(config: ManagedToolConfig<TContext, TInput, TOutput>) {
     this.name = config.name;
@@ -168,6 +169,22 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
    * Cleanup the tool
    */
   async cleanup(): Promise<void> {
+    if (this._cleanupPromise) {
+      await this._cleanupPromise;
+      return;
+    }
+
+    const cleanupPromise = this.performCleanup();
+    this._cleanupPromise = cleanupPromise;
+
+    try {
+      await cleanupPromise;
+    } finally {
+      this._cleanupPromise = undefined;
+    }
+  }
+
+  private async performCleanup(): Promise<void> {
     this._cleaningUp = true;
 
     // Stop health check timer

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -167,10 +167,6 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
    * Cleanup the tool
    */
   async cleanup(): Promise<void> {
-    if (!this._initialized) {
-      return;
-    }
-
     // Stop health check timer
     if (this._healthCheckTimer) {
       clearInterval(this._healthCheckTimer);
@@ -180,6 +176,10 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     if (this._beforeExitHandler) {
       process.off('beforeExit', this._beforeExitHandler);
       this._beforeExitHandler = undefined;
+    }
+
+    if (!this._initialized) {
+      return;
     }
 
     if (this.cleanupFn) {
@@ -259,7 +259,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   }
 
   private async runPeriodicHealthCheck(): Promise<void> {
-    if (!this.healthCheckFn || this._healthCheckInFlight) {
+    if (!this.healthCheckFn || this._healthCheckInFlight || !this._initialized) {
       return;
     }
 
@@ -267,9 +267,15 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
 
     try {
       const result = await this.healthCheckFn();
+      if (!this._initialized) {
+        return;
+      }
       this._stats.lastHealthCheck = result;
       this._stats.lastHealthCheckTime = Date.now();
     } catch (error) {
+      if (!this._initialized) {
+        return;
+      }
       this._stats.lastHealthCheck = {
         healthy: false,
         error: getErrorMessage(error),

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -30,10 +30,10 @@ interface ManagedToolConfigBase<TContext, TInput, TOutput> {
   healthCheckInterval?: number;
 }
 
-export type ManagedToolConfig<TContext = undefined, TInput = unknown, TOutput = unknown> =
-  ManagedToolConfigBase<TContext, TInput, TOutput> & {
-    context?: TContext;
-  };
+export interface ManagedToolConfig<TContext = undefined, TInput = unknown, TOutput = unknown>
+  extends ManagedToolConfigBase<TContext, TInput, TOutput> {
+  context?: TContext;
+}
 
 export interface ManagedToolStats {
   initialized: boolean;

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -3,6 +3,7 @@
  * @module tools/lifecycle
  */
 
+import type { JsonObject } from '../langgraph/observability/payload.js';
 import { createLogger, LogLevel } from '../langgraph/observability/logger.js';
 
 const logger = createLogger('agentforge:core:tools:lifecycle', { level: LogLevel.INFO });
@@ -10,10 +11,10 @@ const logger = createLogger('agentforge:core:tools:lifecycle', { level: LogLevel
 export interface ToolHealthCheckResult {
   healthy: boolean;
   error?: string;
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 }
 
-export interface ManagedToolConfig<TContext = any, TInput = any, TOutput = any> {
+export interface ManagedToolConfig<TContext = undefined, TInput = unknown, TOutput = unknown> {
   name: string;
   description: string;
   initialize?: (this: ManagedTool<TContext, TInput, TOutput>) => Promise<void>;
@@ -43,7 +44,7 @@ export interface ManagedToolStats {
 /**
  * Managed tool with lifecycle hooks
  */
-export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
+export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unknown> {
   public readonly name: string;
   public readonly description: string;
   private readonly initializeFn?: () => Promise<void>;
@@ -80,7 +81,7 @@ export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
         this.cleanup().catch(err =>
           logger.error('Cleanup failed', {
             toolName: this.name,
-            error: err instanceof Error ? err.message : String(err),
+            error: getErrorMessage(err),
             ...(err instanceof Error && err.stack ? { stack: err.stack } : {})
           })
         );
@@ -134,7 +135,7 @@ export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
         } catch (error) {
           this._stats.lastHealthCheck = {
             healthy: false,
-            error: (error as Error).message,
+            error: getErrorMessage(error),
           };
           this._stats.lastHealthCheckTime = Date.now();
         }
@@ -213,7 +214,7 @@ export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
     } catch (error) {
       const result: ToolHealthCheckResult = {
         healthy: false,
-        error: (error as Error).message,
+        error: getErrorMessage(error),
       };
       this._stats.lastHealthCheck = result;
       this._stats.lastHealthCheckTime = Date.now();
@@ -241,7 +242,11 @@ export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
   /**
    * Convert to LangChain tool format
    */
-  toLangChainTool() {
+  toLangChainTool(): {
+    name: string;
+    description: string;
+    invoke: (input: TInput) => Promise<TOutput>;
+  } {
     return {
       name: this.name,
       description: this.description,
@@ -255,8 +260,12 @@ export class ManagedTool<TContext = any, TInput = any, TOutput = any> {
 /**
  * Create a managed tool
  */
-export function createManagedTool<TContext = any, TInput = any, TOutput = any>(
+export function createManagedTool<TContext = undefined, TInput = unknown, TOutput = unknown>(
   config: ManagedToolConfig<TContext, TInput, TOutput>
 ): ManagedTool<TContext, TInput, TOutput> {
   return new ManagedTool(config);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -67,6 +67,8 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     failedExecutions: 0,
   };
   private _healthCheckTimer?: NodeJS.Timeout;
+  private _beforeExitHandler?: () => void;
+  private _healthCheckInFlight = false;
 
   constructor(config: ManagedToolConfig<TContext, TInput, TOutput>) {
     this.name = config.name;
@@ -79,9 +81,9 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     this.healthCheckInterval = config.healthCheckInterval;
     this._context = config.context;
 
-    // Setup auto-cleanup on process exit
+    // Register auto-cleanup on process exit so instances can release resources.
     if (this.autoCleanup) {
-      process.on('beforeExit', () => {
+      this._beforeExitHandler = () => {
         this.cleanup().catch(err =>
           logger.error('Cleanup failed', {
             toolName: this.name,
@@ -89,7 +91,8 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
             ...(err instanceof Error && err.stack ? { stack: err.stack } : {})
           })
         );
-      });
+      };
+      process.on('beforeExit', this._beforeExitHandler);
     }
   }
 
@@ -131,18 +134,8 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
 
     // Start periodic health checks if configured
     if (this.healthCheckInterval && this.healthCheckFn) {
-      this._healthCheckTimer = setInterval(async () => {
-        try {
-          const result = await this.healthCheckFn!();
-          this._stats.lastHealthCheck = result;
-          this._stats.lastHealthCheckTime = Date.now();
-        } catch (error) {
-          this._stats.lastHealthCheck = {
-            healthy: false,
-            error: getErrorMessage(error),
-          };
-          this._stats.lastHealthCheckTime = Date.now();
-        }
+      this._healthCheckTimer = setInterval(() => {
+        void this.runPeriodicHealthCheck();
       }, this.healthCheckInterval);
     }
   }
@@ -182,6 +175,11 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     if (this._healthCheckTimer) {
       clearInterval(this._healthCheckTimer);
       this._healthCheckTimer = undefined;
+    }
+
+    if (this._beforeExitHandler) {
+      process.off('beforeExit', this._beforeExitHandler);
+      this._beforeExitHandler = undefined;
     }
 
     if (this.cleanupFn) {
@@ -258,6 +256,28 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
         return await this.execute(input);
       },
     };
+  }
+
+  private async runPeriodicHealthCheck(): Promise<void> {
+    if (!this.healthCheckFn || this._healthCheckInFlight) {
+      return;
+    }
+
+    this._healthCheckInFlight = true;
+
+    try {
+      const result = await this.healthCheckFn();
+      this._stats.lastHealthCheck = result;
+      this._stats.lastHealthCheckTime = Date.now();
+    } catch (error) {
+      this._stats.lastHealthCheck = {
+        healthy: false,
+        error: getErrorMessage(error),
+      };
+      this._stats.lastHealthCheckTime = Date.now();
+    } finally {
+      this._healthCheckInFlight = false;
+    }
   }
 }
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -164,6 +164,14 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
       return;
     }
 
+    if (this._initializePromise) {
+      try {
+        await this._initializePromise;
+      } catch {
+        // Cleanup should still settle lifecycle hooks if initialization fails.
+      }
+    }
+
     const cleanupPromise = this.performCleanup();
     this._cleanupPromise = cleanupPromise;
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -71,6 +71,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   private _healthCheckInFlight = false;
   private _cleaningUp = false;
   private _cleanupPromise?: Promise<void>;
+  private _initializePromise?: Promise<void>;
   private _lifecycleGeneration = 0;
 
   constructor(config: ManagedToolConfig<TContext, TInput, TOutput>) {
@@ -112,25 +113,22 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
    * Initialize the tool
    */
   async initialize(): Promise<void> {
+    if (this._initializePromise) {
+      await this._initializePromise;
+      return;
+    }
+
     if (this._initialized || this._cleaningUp) {
       return;
     }
 
-    this.ensureBeforeExitHandler();
-    this._lifecycleGeneration++;
+    const initializePromise = this.performInitialize();
+    this._initializePromise = initializePromise;
 
-    if (this.initializeFn) {
-      await this.initializeFn();
-    }
-
-    this._initialized = true;
-    this._stats.initialized = true;
-
-    // Start periodic health checks if configured
-    if (this.healthCheckInterval && this.healthCheckFn) {
-      this._healthCheckTimer = setInterval(() => {
-        void this.runPeriodicHealthCheck();
-      }, this.healthCheckInterval);
+    try {
+      await initializePromise;
+    } finally {
+      this._initializePromise = undefined;
     }
   }
 
@@ -335,6 +333,25 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
       this._stats.lastHealthCheckTime = Date.now();
     } finally {
       this._healthCheckInFlight = false;
+    }
+  }
+
+  private async performInitialize(): Promise<void> {
+    this.ensureBeforeExitHandler();
+    this._lifecycleGeneration++;
+
+    if (this.initializeFn) {
+      await this.initializeFn();
+    }
+
+    this._initialized = true;
+    this._stats.initialized = true;
+
+    // Start periodic health checks if configured.
+    if (this.healthCheckInterval && this.healthCheckFn) {
+      this._healthCheckTimer = setInterval(() => {
+        void this.runPeriodicHealthCheck();
+      }, this.healthCheckInterval);
     }
   }
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -83,19 +83,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     this.healthCheckInterval = config.healthCheckInterval;
     this._context = config.context;
 
-    // Register auto-cleanup on process exit so instances can release resources.
-    if (this.autoCleanup) {
-      this._beforeExitHandler = () => {
-        this.cleanup().catch(err =>
-          logger.error('Cleanup failed', {
-            toolName: this.name,
-            error: getErrorMessage(err),
-            ...(err instanceof Error && err.stack ? { stack: err.stack } : {})
-          })
-        );
-      };
-      process.on('beforeExit', this._beforeExitHandler);
-    }
+    this.ensureBeforeExitHandler();
   }
 
   /**
@@ -126,6 +114,8 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     if (this._initialized || this._cleaningUp) {
       return;
     }
+
+    this.ensureBeforeExitHandler();
 
     if (this.initializeFn) {
       await this.initializeFn();
@@ -325,6 +315,24 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     } finally {
       this._healthCheckInFlight = false;
     }
+  }
+
+  private ensureBeforeExitHandler(): void {
+    if (!this.autoCleanup || this._beforeExitHandler) {
+      return;
+    }
+
+    // Register auto-cleanup on process exit so instances can release resources.
+    this._beforeExitHandler = () => {
+      this.cleanup().catch(err =>
+        logger.error('Cleanup failed', {
+          toolName: this.name,
+          error: getErrorMessage(err),
+          ...(err instanceof Error && err.stack ? { stack: err.stack } : {})
+        })
+      );
+    };
+    process.on('beforeExit', this._beforeExitHandler);
   }
 }
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -14,7 +14,7 @@ export interface ToolHealthCheckResult {
   metadata?: JsonObject;
 }
 
-export interface ManagedToolConfig<TContext = undefined, TInput = unknown, TOutput = unknown> {
+interface ManagedToolConfigBase<TContext, TInput, TOutput> {
   name: string;
   description: string;
   initialize?: (this: ManagedTool<TContext, TInput, TOutput>) => Promise<void>;
@@ -26,10 +26,14 @@ export interface ManagedToolConfig<TContext = undefined, TInput = unknown, TOutp
   healthCheck?: (
     this: ManagedTool<TContext, TInput, TOutput>
   ) => Promise<ToolHealthCheckResult>;
-  context?: TContext;
   autoCleanup?: boolean;
   healthCheckInterval?: number;
 }
+
+export type ManagedToolConfig<TContext = undefined, TInput = unknown, TOutput = unknown> =
+  ManagedToolConfigBase<TContext, TInput, TOutput> & {
+    context?: TContext;
+  };
 
 export interface ManagedToolStats {
   initialized: boolean;
@@ -55,7 +59,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   private readonly healthCheckInterval?: number;
 
   private _initialized = false;
-  private _context: TContext;
+  private _context: TContext | undefined;
   private _stats: ManagedToolStats = {
     initialized: false,
     totalExecutions: 0,
@@ -73,7 +77,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     this.healthCheckFn = config.healthCheck?.bind(this);
     this.autoCleanup = config.autoCleanup ?? true;
     this.healthCheckInterval = config.healthCheckInterval;
-    this._context = config.context as TContext;
+    this._context = config.context;
 
     // Setup auto-cleanup on process exit
     if (this.autoCleanup) {
@@ -92,14 +96,14 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   /**
    * Get the tool context (e.g., connection pool, API client)
    */
-  get context(): TContext {
+  get context(): TContext | undefined {
     return this._context;
   }
 
   /**
    * Set the tool context
    */
-  set context(value: TContext) {
+  set context(value: TContext | undefined) {
     this._context = value;
   }
 

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -71,6 +71,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   private _healthCheckInFlight = false;
   private _cleaningUp = false;
   private _cleanupPromise?: Promise<void>;
+  private _lifecycleGeneration = 0;
 
   constructor(config: ManagedToolConfig<TContext, TInput, TOutput>) {
     this.name = config.name;
@@ -116,6 +117,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     }
 
     this.ensureBeforeExitHandler();
+    this._lifecycleGeneration++;
 
     if (this.initializeFn) {
       await this.initializeFn();
@@ -227,9 +229,15 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
       };
     }
 
+    const lifecycleGeneration = this._lifecycleGeneration;
+
     try {
       const result = await this.healthCheckFn();
-      if (!this._initialized || this._cleaningUp) {
+      if (
+        !this._initialized ||
+        this._cleaningUp ||
+        this._lifecycleGeneration !== lifecycleGeneration
+      ) {
         return {
           healthy: false,
           error: 'Tool is not initialized',
@@ -239,7 +247,11 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
       this._stats.lastHealthCheckTime = Date.now();
       return result;
     } catch (error) {
-      if (!this._initialized || this._cleaningUp) {
+      if (
+        !this._initialized ||
+        this._cleaningUp ||
+        this._lifecycleGeneration !== lifecycleGeneration
+      ) {
         return {
           healthy: false,
           error: 'Tool is not initialized',
@@ -295,16 +307,25 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     }
 
     this._healthCheckInFlight = true;
+    const lifecycleGeneration = this._lifecycleGeneration;
 
     try {
       const result = await this.healthCheckFn();
-      if (!this._initialized || this._cleaningUp) {
+      if (
+        !this._initialized ||
+        this._cleaningUp ||
+        this._lifecycleGeneration !== lifecycleGeneration
+      ) {
         return;
       }
       this._stats.lastHealthCheck = result;
       this._stats.lastHealthCheckTime = Date.now();
     } catch (error) {
-      if (!this._initialized || this._cleaningUp) {
+      if (
+        !this._initialized ||
+        this._cleaningUp ||
+        this._lifecycleGeneration !== lifecycleGeneration
+      ) {
         return;
       }
       this._stats.lastHealthCheck = {

--- a/packages/core/src/tools/lifecycle.ts
+++ b/packages/core/src/tools/lifecycle.ts
@@ -69,6 +69,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   private _healthCheckTimer?: NodeJS.Timeout;
   private _beforeExitHandler?: () => void;
   private _healthCheckInFlight = false;
+  private _cleaningUp = false;
 
   constructor(config: ManagedToolConfig<TContext, TInput, TOutput>) {
     this.name = config.name;
@@ -121,7 +122,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
    * Initialize the tool
    */
   async initialize(): Promise<void> {
-    if (this._initialized) {
+    if (this._initialized || this._cleaningUp) {
       return;
     }
 
@@ -167,6 +168,8 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
    * Cleanup the tool
    */
   async cleanup(): Promise<void> {
+    this._cleaningUp = true;
+
     // Stop health check timer
     if (this._healthCheckTimer) {
       clearInterval(this._healthCheckTimer);
@@ -179,22 +182,31 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
     }
 
     if (!this._initialized) {
+      this._cleaningUp = false;
       return;
-    }
-
-    if (this.cleanupFn) {
-      await this.cleanupFn();
     }
 
     this._initialized = false;
     this._stats.initialized = false;
+
+    if (this.cleanupFn) {
+      try {
+        await this.cleanupFn();
+      } finally {
+        this._cleaningUp = false;
+      }
+
+      return;
+    }
+
+    this._cleaningUp = false;
   }
 
   /**
    * Run health check
    */
   async healthCheck(): Promise<ToolHealthCheckResult> {
-    if (!this._initialized) {
+    if (!this._initialized || this._cleaningUp) {
       return {
         healthy: false,
         error: 'Tool is not initialized',
@@ -210,10 +222,22 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
 
     try {
       const result = await this.healthCheckFn();
+      if (!this._initialized || this._cleaningUp) {
+        return {
+          healthy: false,
+          error: 'Tool is not initialized',
+        };
+      }
       this._stats.lastHealthCheck = result;
       this._stats.lastHealthCheckTime = Date.now();
       return result;
     } catch (error) {
+      if (!this._initialized || this._cleaningUp) {
+        return {
+          healthy: false,
+          error: 'Tool is not initialized',
+        };
+      }
       const result: ToolHealthCheckResult = {
         healthy: false,
         error: getErrorMessage(error),
@@ -259,7 +283,7 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
   }
 
   private async runPeriodicHealthCheck(): Promise<void> {
-    if (!this.healthCheckFn || this._healthCheckInFlight || !this._initialized) {
+    if (!this.healthCheckFn || this._healthCheckInFlight || !this._initialized || this._cleaningUp) {
       return;
     }
 
@@ -267,13 +291,13 @@ export class ManagedTool<TContext = undefined, TInput = unknown, TOutput = unkno
 
     try {
       const result = await this.healthCheckFn();
-      if (!this._initialized) {
+      if (!this._initialized || this._cleaningUp) {
         return;
       }
       this._stats.lastHealthCheck = result;
       this._stats.lastHealthCheckTime = Date.now();
     } catch (error) {
-      if (!this._initialized) {
+      if (!this._initialized || this._cleaningUp) {
         return;
       }
       this._stats.lastHealthCheck = {

--- a/packages/core/src/tools/lifecycle.typecheck.ts
+++ b/packages/core/src/tools/lifecycle.typecheck.ts
@@ -10,6 +10,7 @@ const managedTool = createManagedTool<
 >({
   name: 'managed-tool',
   description: 'Lifecycle typecheck fixture',
+  autoCleanup: false,
   context: {
     requestId: 'req-123',
   },
@@ -62,6 +63,7 @@ void explicitHealthResult;
 const unknownTool = createManagedTool({
   name: 'unknown-tool',
   description: 'Unknown defaults fixture',
+  autoCleanup: false,
   execute: async (input: unknown) => input,
 });
 

--- a/packages/core/src/tools/lifecycle.typecheck.ts
+++ b/packages/core/src/tools/lifecycle.typecheck.ts
@@ -1,0 +1,60 @@
+import {
+  createManagedTool,
+  type ToolHealthCheckResult,
+} from './lifecycle.js';
+
+const managedTool = createManagedTool<
+  { requestId: string },
+  { count: number },
+  { doubled: number; requestId: string }
+>({
+  name: 'managed-tool',
+  description: 'Lifecycle typecheck fixture',
+  context: {
+    requestId: 'req-123',
+  },
+  initialize: async function () {
+    const requestId: string = this.context.requestId;
+    void requestId;
+  },
+  execute: async function (input: { count: number }) {
+    return {
+      doubled: input.count * 2,
+      requestId: this.context.requestId,
+    };
+  },
+  healthCheck: async () => ({
+    healthy: true,
+    metadata: {
+      status: 'ready',
+      counts: [1, 2, 3],
+    },
+  }),
+});
+
+void managedTool.toLangChainTool().invoke({ count: 2 }).then((result) => {
+  const doubled: number = result.doubled;
+  const requestId: string = result.requestId;
+  void doubled;
+  void requestId;
+});
+
+const explicitHealthResult: ToolHealthCheckResult = {
+  healthy: true,
+  metadata: {
+    message: 'ok',
+    nested: {
+      attempts: 1,
+    },
+  },
+};
+
+void explicitHealthResult;
+
+const unknownTool = createManagedTool({
+  name: 'unknown-tool',
+  description: 'Unknown defaults fixture',
+  execute: async (input: unknown) => input,
+});
+
+void unknownTool;

--- a/packages/core/src/tools/lifecycle.typecheck.ts
+++ b/packages/core/src/tools/lifecycle.typecheck.ts
@@ -14,10 +14,18 @@ const managedTool = createManagedTool<
     requestId: 'req-123',
   },
   initialize: async function () {
+    if (!this.context) {
+      throw new Error('Context missing');
+    }
+
     const requestId: string = this.context.requestId;
     void requestId;
   },
   execute: async function (input: { count: number }) {
+    if (!this.context) {
+      throw new Error('Context missing');
+    }
+
     return {
       doubled: input.count * 2,
       requestId: this.context.requestId,

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -198,6 +198,32 @@ describe('ManagedTool lifecycle', () => {
     expect(processOff).toHaveBeenCalledWith('beforeExit', expect.any(Function));
   });
 
+  it('re-registers beforeExit cleanup after cleanup and reinitialize', async () => {
+    const processOn = vi.spyOn(process, 'on').mockImplementation(() => process);
+    const processOff = vi.spyOn(process, 'off').mockImplementation(() => process);
+    const cleanup = vi.fn(async () => {});
+
+    const tool = createManagedTool({
+      name: 'managed-auto-cleanup-reinit',
+      description: 'Managed auto cleanup reinit fixture',
+      execute: async () => 'ok',
+      cleanup,
+    });
+
+    await tool.initialize();
+    await tool.cleanup();
+    await tool.initialize();
+
+    expect(processOn).toHaveBeenCalledTimes(2);
+    expect(processOff).toHaveBeenCalledTimes(1);
+
+    const latestBeforeExitHandler = processOn.mock.calls.at(-1)?.[1];
+    expect(latestBeforeExitHandler).toBeTypeOf('function');
+
+    latestBeforeExitHandler?.();
+    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledTimes(2));
+  });
+
   it('removes the beforeExit listener even if cleanup happens before initialize', async () => {
     const processOn = vi.spyOn(process, 'on').mockImplementation(() => process);
     const processOff = vi.spyOn(process, 'off').mockImplementation(() => process);

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createManagedTool } from '../../src/tools/lifecycle.js';
+
+describe('ManagedTool lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('initializes once and executes through the managed wrapper', async () => {
+    const initialize = vi.fn(async function () {
+      this.context = { token: 'ready' };
+    });
+
+    const tool = createManagedTool({
+      name: 'managed-init',
+      description: 'Managed init fixture',
+      context: { token: 'pending' },
+      initialize,
+      execute: async function (input: { count: number }) {
+        return `${this.context.token}:${input.count}`;
+      },
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await tool.initialize();
+
+    await expect(tool.execute({ count: 3 })).resolves.toBe('ready:3');
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(tool.getStats().initialized).toBe(true);
+  });
+
+  it('tracks successful and failed executions', async () => {
+    const tool = createManagedTool({
+      name: 'managed-stats',
+      description: 'Managed stats fixture',
+      execute: async ({ shouldFail }: { shouldFail: boolean }) => {
+        if (shouldFail) {
+          throw new Error('boom');
+        }
+
+        return 'ok';
+      },
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+
+    await expect(tool.execute({ shouldFail: false })).resolves.toBe('ok');
+    await expect(tool.execute({ shouldFail: true })).rejects.toThrow('boom');
+
+    expect(tool.getStats()).toMatchObject({
+      totalExecutions: 2,
+      successfulExecutions: 1,
+      failedExecutions: 1,
+    });
+    expect(tool.getStats().lastExecutionTime).toBeTypeOf('number');
+  });
+
+  it('returns default health metadata when no health check is configured', async () => {
+    const tool = createManagedTool({
+      name: 'managed-default-health',
+      description: 'Managed default health fixture',
+      execute: async () => 'ok',
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+
+    await expect(tool.healthCheck()).resolves.toEqual({
+      healthy: true,
+      metadata: { message: 'No health check configured' },
+    });
+  });
+
+  it('records configured health checks and periodic updates', async () => {
+    vi.useFakeTimers();
+
+    const healthCheck = vi
+      .fn<() => Promise<{ healthy: boolean; metadata: { run: number } }>>()
+      .mockResolvedValueOnce({ healthy: true, metadata: { run: 1 } })
+      .mockResolvedValueOnce({ healthy: true, metadata: { run: 2 } });
+
+    const tool = createManagedTool({
+      name: 'managed-health',
+      description: 'Managed health fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await expect(tool.healthCheck()).resolves.toEqual({
+      healthy: true,
+      metadata: { run: 1 },
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(tool.getStats().lastHealthCheck).toEqual({
+      healthy: true,
+      metadata: { run: 2 },
+    });
+    expect(tool.getStats().lastHealthCheckTime).toBeTypeOf('number');
+  });
+
+  it('stops periodic health checks during cleanup and runs cleanup hooks', async () => {
+    vi.useFakeTimers();
+
+    const cleanup = vi.fn(async () => {});
+    const healthCheck = vi.fn(async () => ({ healthy: true }));
+
+    const tool = createManagedTool({
+      name: 'managed-cleanup',
+      description: 'Managed cleanup fixture',
+      execute: async () => 'ok',
+      cleanup,
+      healthCheck,
+      healthCheckInterval: 25,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await vi.advanceTimersByTimeAsync(25);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+
+    await tool.cleanup();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+    expect(tool.initialized).toBe(false);
+  });
+
+  it('registers beforeExit cleanup when autoCleanup is enabled', async () => {
+    const processOn = vi.spyOn(process, 'on');
+    const cleanup = vi.fn(async () => {});
+
+    const tool = createManagedTool({
+      name: 'managed-auto-cleanup',
+      description: 'Managed auto cleanup fixture',
+      execute: async () => 'ok',
+      cleanup,
+    });
+
+    const beforeExitHandler = processOn.mock.calls.find(([event]) => event === 'beforeExit')?.[1];
+
+    expect(beforeExitHandler).toBeTypeOf('function');
+
+    await tool.initialize();
+    beforeExitHandler?.();
+    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledTimes(1));
+  });
+
+  it('exposes a LangChain-style invoke wrapper around execute', async () => {
+    const tool = createManagedTool({
+      name: 'managed-langchain',
+      description: 'Managed langchain fixture',
+      execute: async ({ value }: { value: string }) => value.toUpperCase(),
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+
+    await expect(tool.toLangChainTool().invoke({ value: 'mixed' })).resolves.toBe('MIXED');
+  });
+});

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createManagedTool } from '../../src/tools/lifecycle.js';
+import { createManagedTool, type ToolHealthCheckResult } from '../../src/tools/lifecycle.js';
 
 describe('ManagedTool lifecycle', () => {
   afterEach(() => {
@@ -198,6 +198,22 @@ describe('ManagedTool lifecycle', () => {
     expect(processOff).toHaveBeenCalledWith('beforeExit', expect.any(Function));
   });
 
+  it('removes the beforeExit listener even if cleanup happens before initialize', async () => {
+    const processOn = vi.spyOn(process, 'on').mockImplementation(() => process);
+    const processOff = vi.spyOn(process, 'off').mockImplementation(() => process);
+
+    const tool = createManagedTool({
+      name: 'managed-preinit-cleanup',
+      description: 'Managed preinit cleanup fixture',
+      execute: async () => 'ok',
+    });
+
+    await tool.cleanup();
+
+    expect(processOn).toHaveBeenCalledWith('beforeExit', expect.any(Function));
+    expect(processOff).toHaveBeenCalledWith('beforeExit', expect.any(Function));
+  });
+
   it('exposes a LangChain-style invoke wrapper around execute', async () => {
     const tool = createManagedTool({
       name: 'managed-langchain',
@@ -209,5 +225,38 @@ describe('ManagedTool lifecycle', () => {
     await tool.initialize();
 
     await expect(tool.toLangChainTool().invoke({ value: 'mixed' })).resolves.toBe('MIXED');
+  });
+
+  it('does not update health stats after cleanup if a periodic health check resolves late', async () => {
+    vi.useFakeTimers();
+
+    let resolveHealthCheck: (() => void) | undefined;
+    const healthCheck = vi.fn(
+      () =>
+        new Promise<ToolHealthCheckResult>((resolve) => {
+          resolveHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+        })
+    );
+
+    const tool = createManagedTool({
+      name: 'managed-health-cleanup-race',
+      description: 'Managed health cleanup race fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+
+    await tool.cleanup();
+    resolveHealthCheck?.();
+    await vi.runAllTicks();
+
+    expect(tool.initialized).toBe(false);
+    expect(tool.getStats().lastHealthCheck).toBeUndefined();
+    expect(tool.getStats().lastHealthCheckTime).toBeUndefined();
   });
 });

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -69,6 +69,46 @@ describe('ManagedTool lifecycle', () => {
     await tool.cleanup();
   });
 
+  it('waits for in-flight initialize before cleanup completes', async () => {
+    vi.useFakeTimers();
+
+    let resolveInitialize: (() => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInitialize = resolve;
+        })
+    );
+    const cleanup = vi.fn(async () => {});
+    const healthCheck = vi.fn(async () => ({ healthy: true }));
+
+    const tool = createManagedTool({
+      name: 'managed-init-cleanup-race',
+      description: 'Managed init cleanup race fixture',
+      initialize,
+      execute: async () => 'ok',
+      cleanup,
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    const initializePromise = tool.initialize();
+    const cleanupPromise = tool.cleanup();
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    resolveInitialize?.();
+    await Promise.all([initializePromise, cleanupPromise]);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(tool.initialized).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).not.toHaveBeenCalled();
+  });
+
   it('tracks successful and failed executions', async () => {
     const tool = createManagedTool({
       name: 'managed-stats',

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -372,6 +372,47 @@ describe('ManagedTool lifecycle', () => {
     await cleanupPromise;
   });
 
+  it('ignores a late manual health-check result from a prior lifecycle after reinitialize', async () => {
+    let resolveFirstHealthCheck: (() => void) | undefined;
+    const healthCheck = vi
+      .fn<() => Promise<ToolHealthCheckResult>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<ToolHealthCheckResult>((resolve) => {
+            resolveFirstHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+          })
+      )
+      .mockResolvedValueOnce({ healthy: true, metadata: { run: 2 } });
+
+    const tool = createManagedTool({
+      name: 'managed-manual-health-lifecycle-generation',
+      description: 'Managed manual health generation fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    const firstHealthCheck = tool.healthCheck();
+    await tool.cleanup();
+    await tool.initialize();
+
+    resolveFirstHealthCheck?.();
+    await expect(firstHealthCheck).resolves.toEqual({
+      healthy: false,
+      error: 'Tool is not initialized',
+    });
+
+    await expect(tool.healthCheck()).resolves.toEqual({
+      healthy: true,
+      metadata: { run: 2 },
+    });
+    expect(tool.getStats().lastHealthCheck).toEqual({
+      healthy: true,
+      metadata: { run: 2 },
+    });
+  });
+
   it('treats cleanup as single-flight while teardown is still awaiting', async () => {
     let resolveCleanup: (() => void) | undefined;
     const cleanup = vi.fn(
@@ -405,5 +446,47 @@ describe('ManagedTool lifecycle', () => {
 
     await tool.initialize();
     expect(tool.initialized).toBe(true);
+  });
+
+  it('ignores a late periodic health-check result from a prior lifecycle after reinitialize', async () => {
+    vi.useFakeTimers();
+
+    let resolveFirstHealthCheck: (() => void) | undefined;
+    const healthCheck = vi
+      .fn<() => Promise<ToolHealthCheckResult>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<ToolHealthCheckResult>((resolve) => {
+            resolveFirstHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+          })
+      )
+      .mockResolvedValueOnce({ healthy: true, metadata: { run: 2 } });
+
+    const tool = createManagedTool({
+      name: 'managed-periodic-health-lifecycle-generation',
+      description: 'Managed periodic health generation fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+
+    await tool.cleanup();
+    await tool.initialize();
+
+    resolveFirstHealthCheck?.();
+    await vi.runAllTicks();
+    expect(tool.getStats().lastHealthCheck).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).toHaveBeenCalledTimes(2);
+    expect(tool.getStats().lastHealthCheck).toEqual({
+      healthy: true,
+      metadata: { run: 2 },
+    });
   });
 });

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -18,7 +18,7 @@ describe('ManagedTool lifecycle', () => {
       context: { token: 'pending' },
       initialize,
       execute: async function (input: { count: number }) {
-        return `${this.context.token}:${input.count}`;
+        return `${this.context!.token}:${input.count}`;
       },
       autoCleanup: false,
     });

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -345,4 +345,39 @@ describe('ManagedTool lifecycle', () => {
     resolveCleanup?.();
     await cleanupPromise;
   });
+
+  it('treats cleanup as single-flight while teardown is still awaiting', async () => {
+    let resolveCleanup: (() => void) | undefined;
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        })
+    );
+
+    const tool = createManagedTool({
+      name: 'managed-single-flight-cleanup',
+      description: 'Managed single-flight cleanup fixture',
+      execute: async () => 'ok',
+      cleanup,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+
+    const firstCleanup = tool.cleanup();
+    const secondCleanup = tool.cleanup();
+
+    expect(tool.initialized).toBe(false);
+
+    await tool.initialize();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(tool.initialized).toBe(false);
+
+    resolveCleanup?.();
+    await Promise.all([firstCleanup, secondCleanup]);
+
+    await tool.initialize();
+    expect(tool.initialized).toBe(true);
+  });
 });

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -259,4 +259,90 @@ describe('ManagedTool lifecycle', () => {
     expect(tool.getStats().lastHealthCheck).toBeUndefined();
     expect(tool.getStats().lastHealthCheckTime).toBeUndefined();
   });
+
+  it('does not update periodic health stats while cleanup is awaiting teardown', async () => {
+    vi.useFakeTimers();
+
+    let resolveHealthCheck: (() => void) | undefined;
+    let resolveCleanup: (() => void) | undefined;
+    const healthCheck = vi.fn(
+      () =>
+        new Promise<ToolHealthCheckResult>((resolve) => {
+          resolveHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+        })
+    );
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        })
+    );
+
+    const tool = createManagedTool({
+      name: 'managed-health-cleanup-await-race',
+      description: 'Managed health cleanup await race fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      cleanup,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+
+    const cleanupPromise = tool.cleanup();
+    resolveHealthCheck?.();
+    await vi.runAllTicks();
+
+    expect(tool.initialized).toBe(false);
+    expect(tool.getStats().lastHealthCheck).toBeUndefined();
+    expect(tool.getStats().lastHealthCheckTime).toBeUndefined();
+
+    resolveCleanup?.();
+    await cleanupPromise;
+  });
+
+  it('does not update manual health-check stats if cleanup starts before it resolves', async () => {
+    let resolveHealthCheck: (() => void) | undefined;
+    let resolveCleanup: (() => void) | undefined;
+    const healthCheck = vi.fn(
+      () =>
+        new Promise<ToolHealthCheckResult>((resolve) => {
+          resolveHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+        })
+    );
+    const cleanup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve;
+        })
+    );
+
+    const tool = createManagedTool({
+      name: 'managed-manual-health-cleanup-race',
+      description: 'Managed manual health cleanup race fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      cleanup,
+      autoCleanup: false,
+    });
+
+    await tool.initialize();
+
+    const healthCheckPromise = tool.healthCheck();
+    const cleanupPromise = tool.cleanup();
+
+    resolveHealthCheck?.();
+    await expect(healthCheckPromise).resolves.toEqual({
+      healthy: false,
+      error: 'Tool is not initialized',
+    });
+    expect(tool.getStats().lastHealthCheck).toBeUndefined();
+    expect(tool.getStats().lastHealthCheckTime).toBeUndefined();
+
+    resolveCleanup?.();
+    await cleanupPromise;
+  });
 });

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -91,19 +91,23 @@ describe('ManagedTool lifecycle', () => {
       autoCleanup: false,
     });
 
-    await tool.initialize();
-    await expect(tool.healthCheck()).resolves.toEqual({
-      healthy: true,
-      metadata: { run: 1 },
-    });
+    try {
+      await tool.initialize();
+      await expect(tool.healthCheck()).resolves.toEqual({
+        healthy: true,
+        metadata: { run: 1 },
+      });
 
-    await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(50);
 
-    expect(tool.getStats().lastHealthCheck).toEqual({
-      healthy: true,
-      metadata: { run: 2 },
-    });
-    expect(tool.getStats().lastHealthCheckTime).toBeTypeOf('number');
+      expect(tool.getStats().lastHealthCheck).toEqual({
+        healthy: true,
+        metadata: { run: 2 },
+      });
+      expect(tool.getStats().lastHealthCheckTime).toBeTypeOf('number');
+    } finally {
+      await tool.cleanup();
+    }
   });
 
   it('stops periodic health checks during cleanup and runs cleanup hooks', async () => {
@@ -135,7 +139,7 @@ describe('ManagedTool lifecycle', () => {
   });
 
   it('registers beforeExit cleanup when autoCleanup is enabled', async () => {
-    const processOn = vi.spyOn(process, 'on');
+    const processOn = vi.spyOn(process, 'on').mockImplementation(() => process);
     const cleanup = vi.fn(async () => {});
 
     const tool = createManagedTool({
@@ -152,6 +156,7 @@ describe('ManagedTool lifecycle', () => {
     await tool.initialize();
     beforeExitHandler?.();
     await vi.waitFor(() => expect(cleanup).toHaveBeenCalledTimes(1));
+    expect(processOn).toHaveBeenCalledWith('beforeExit', expect.any(Function));
   });
 
   it('exposes a LangChain-style invoke wrapper around execute', async () => {

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -110,6 +110,43 @@ describe('ManagedTool lifecycle', () => {
     }
   });
 
+  it('does not overlap periodic health checks when a prior run is still in flight', async () => {
+    vi.useFakeTimers();
+
+    let resolveHealthCheck: (() => void) | undefined;
+    const healthCheck = vi.fn(
+      () =>
+        new Promise<{ healthy: boolean; metadata: { run: number } }>((resolve) => {
+          resolveHealthCheck = () => resolve({ healthy: true, metadata: { run: 1 } });
+        })
+    );
+
+    const tool = createManagedTool({
+      name: 'managed-health-single-flight',
+      description: 'Managed health single-flight fixture',
+      execute: async () => 'ok',
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    try {
+      await tool.initialize();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(healthCheck).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(healthCheck).toHaveBeenCalledTimes(1);
+
+      resolveHealthCheck?.();
+      await vi.runAllTicks();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(healthCheck).toHaveBeenCalledTimes(2);
+    } finally {
+      await tool.cleanup();
+    }
+  });
+
   it('stops periodic health checks during cleanup and runs cleanup hooks', async () => {
     vi.useFakeTimers();
 
@@ -140,6 +177,7 @@ describe('ManagedTool lifecycle', () => {
 
   it('registers beforeExit cleanup when autoCleanup is enabled', async () => {
     const processOn = vi.spyOn(process, 'on').mockImplementation(() => process);
+    const processOff = vi.spyOn(process, 'off').mockImplementation(() => process);
     const cleanup = vi.fn(async () => {});
 
     const tool = createManagedTool({
@@ -157,6 +195,7 @@ describe('ManagedTool lifecycle', () => {
     beforeExitHandler?.();
     await vi.waitFor(() => expect(cleanup).toHaveBeenCalledTimes(1));
     expect(processOn).toHaveBeenCalledWith('beforeExit', expect.any(Function));
+    expect(processOff).toHaveBeenCalledWith('beforeExit', expect.any(Function));
   });
 
   it('exposes a LangChain-style invoke wrapper around execute', async () => {

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -31,6 +31,44 @@ describe('ManagedTool lifecycle', () => {
     expect(tool.getStats().initialized).toBe(true);
   });
 
+  it('treats initialize as single-flight under concurrent calls', async () => {
+    vi.useFakeTimers();
+
+    let resolveInitialize: (() => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInitialize = resolve;
+        })
+    );
+    const healthCheck = vi.fn(async () => ({ healthy: true }));
+
+    const tool = createManagedTool({
+      name: 'managed-init-single-flight',
+      description: 'Managed init single-flight fixture',
+      initialize,
+      execute: async () => 'ok',
+      healthCheck,
+      healthCheckInterval: 50,
+      autoCleanup: false,
+    });
+
+    const firstInitialize = tool.initialize();
+    const secondInitialize = tool.initialize();
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+
+    resolveInitialize?.();
+    await Promise.all([firstInitialize, secondInitialize]);
+
+    expect(tool.initialized).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(healthCheck).toHaveBeenCalledTimes(1);
+
+    await tool.cleanup();
+  });
+
   it('tracks successful and failed executions', async () => {
     const tool = createManagedTool({
       name: 'managed-stats',

--- a/packages/core/tests/tools/lifecycle.test.ts
+++ b/packages/core/tests/tools/lifecycle.test.ts
@@ -491,8 +491,9 @@ describe('ManagedTool lifecycle', () => {
     });
   });
 
-  it('treats cleanup as single-flight while teardown is still awaiting', async () => {
+  it('waits for in-flight cleanup before reinitializing', async () => {
     let resolveCleanup: (() => void) | undefined;
+    const initialize = vi.fn(async () => {});
     const cleanup = vi.fn(
       () =>
         new Promise<void>((resolve) => {
@@ -503,27 +504,30 @@ describe('ManagedTool lifecycle', () => {
     const tool = createManagedTool({
       name: 'managed-single-flight-cleanup',
       description: 'Managed single-flight cleanup fixture',
+      initialize,
       execute: async () => 'ok',
       cleanup,
       autoCleanup: false,
     });
 
     await tool.initialize();
+    expect(initialize).toHaveBeenCalledTimes(1);
 
     const firstCleanup = tool.cleanup();
     const secondCleanup = tool.cleanup();
+    const firstReinitialize = tool.initialize();
+    const secondReinitialize = tool.initialize();
 
     expect(tool.initialized).toBe(false);
 
-    await tool.initialize();
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(tool.initialized).toBe(false);
 
     resolveCleanup?.();
-    await Promise.all([firstCleanup, secondCleanup]);
+    await Promise.all([firstCleanup, secondCleanup, firstReinitialize, secondReinitialize]);
 
-    await tool.initialize();
     expect(tool.initialized).toBe(true);
+    expect(initialize).toHaveBeenCalledTimes(2);
   });
 
   it('ignores a late periodic health-check result from a prior lifecycle after reinitialize', async () => {

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, and teardown now blocks stale health-status writes once cleanup begins
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, and repeated `cleanup()` calls now share a single teardown pass
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `12 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `13 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1248,7 +1248,8 @@ Implementation notes:
   - `0b55206` fix(st-09032): preserve lifecycle public interface
   - `d619cba` fix(st-09032): harden lifecycle background hooks
   - `4a41ea6` fix(st-09032): handle lifecycle cleanup races
-  - pending review-fix commit: suppressed health-check cleanup race follow-up
+  - `ad63eee` fix(st-09032): block stale health updates during cleanup
+  - pending review-fix commit: cleanup single-flight follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1244,7 +1244,8 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `971defa` fix(st-09032): tighten managed tool lifecycle contracts
   - `429950b` docs(st-09032): record validation and move story to in-review
-  - review-fix commit pending for context soundness and lifecycle test isolation follow-ups
+  - `47407dc` fix(st-09032): tighten lifecycle review follow-ups
+  - review-fix commit pending for public interface compatibility and test contract alignment follow-ups
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,7 +1229,7 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, concurrent `initialize()` calls now share a single setup pass, cleanup waits for in-flight initialization before tearing down, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, concurrent `initialize()` calls now share a single setup pass, cleanup waits for in-flight initialization before tearing down, initialize waits for in-flight cleanup before reinitializing, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
   - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `18 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
@@ -1253,7 +1253,7 @@ Implementation notes:
   - `f9a5c93` fix(st-09032): restore cleanup reuse auto-cleanup
   - `8f6098a` fix(st-09032): guard health checks across reuse
   - `3dc1fc0` fix(st-09032): make initialize single-flight
-  - pending review-fix commit: initialize/cleanup ordering follow-up
+  - `e259ec2` fix(st-09032): coordinate cleanup with initialization
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, and reusable tools re-register auto-cleanup on re-initialize
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `14 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `16 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1250,7 +1250,8 @@ Implementation notes:
   - `4a41ea6` fix(st-09032): handle lifecycle cleanup races
   - `ad63eee` fix(st-09032): block stale health updates during cleanup
   - `c2ea15d` fix(st-09032): make cleanup single-flight
-  - pending review-fix commit: auto-cleanup re-registration follow-up
+  - `f9a5c93` fix(st-09032): restore cleanup reuse auto-cleanup
+  - pending review-fix commit: lifecycle generation guard follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1224,8 +1224,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09032-managed-tool-lifecycle-contracts` (`codex/fix/st-09032-managed-tool-lifecycle-contracts`)
-- [ ] Create draft PR with story ID in title
-  - Draft PR pending branch push
+- [x] Create draft PR with story ID in title
+  - Draft PR #95: https://github.com/TVScoundrel/agentforge/pull/95
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
@@ -1241,9 +1241,11 @@ Implementation notes:
   - `pnpm test --run` -> `163 passed | 16 skipped` files; `2233 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
   - `971defa` fix(st-09032): tighten managed tool lifecycle contracts
-- [ ] Mark PR Ready only after all story tasks are complete
+  - `429950b` docs(st-09032): record validation and move story to in-review
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, concurrent `initialize()` calls now share a single setup pass, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, concurrent `initialize()` calls now share a single setup pass, cleanup waits for in-flight initialization before tearing down, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `17 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `18 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1252,7 +1252,8 @@ Implementation notes:
   - `c2ea15d` fix(st-09032): make cleanup single-flight
   - `f9a5c93` fix(st-09032): restore cleanup reuse auto-cleanup
   - `8f6098a` fix(st-09032): guard health checks across reuse
-  - pending review-fix commit: initialize single-flight follow-up
+  - `3dc1fc0` fix(st-09032): make initialize single-flight
+  - pending review-fix commit: initialize/cleanup ordering follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1254,6 +1254,7 @@ Implementation notes:
   - `8f6098a` fix(st-09032): guard health checks across reuse
   - `3dc1fc0` fix(st-09032): make initialize single-flight
   - `e259ec2` fix(st-09032): coordinate cleanup with initialization
+  - `301c96e` fix(st-09032): wait for cleanup before initialize
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, and auto-cleanup listeners are removed during teardown even before initialization
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `8 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `10 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1246,7 +1246,8 @@ Implementation notes:
   - `429950b` docs(st-09032): record validation and move story to in-review
   - `47407dc` fix(st-09032): tighten lifecycle review follow-ups
   - `0b55206` fix(st-09032): preserve lifecycle public interface
-  - review-fix commit pending for auto-cleanup listener and periodic health-check follow-ups
+  - `d619cba` fix(st-09032): harden lifecycle background hooks
+  - review-fix commit pending for cleanup-before-initialize and late health-check teardown follow-ups
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, and auto-cleanup listeners are removed during teardown even before initialization
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, and teardown now blocks stale health-status writes once cleanup begins
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `10 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `12 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1248,6 +1248,7 @@ Implementation notes:
   - `0b55206` fix(st-09032): preserve lifecycle public interface
   - `d619cba` fix(st-09032): harden lifecycle background hooks
   - `4a41ea6` fix(st-09032): handle lifecycle cleanup races
+  - pending review-fix commit: suppressed health-check cleanup race follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, and repeated `cleanup()` calls now share a single teardown pass
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, and reusable tools re-register auto-cleanup on re-initialize
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `13 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `14 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1249,7 +1249,8 @@ Implementation notes:
   - `d619cba` fix(st-09032): harden lifecycle background hooks
   - `4a41ea6` fix(st-09032): handle lifecycle cleanup races
   - `ad63eee` fix(st-09032): block stale health updates during cleanup
-  - pending review-fix commit: cleanup single-flight follow-up
+  - `c2ea15d` fix(st-09032): make cleanup single-flight
+  - pending review-fix commit: auto-cleanup re-registration follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1247,7 +1247,7 @@ Implementation notes:
   - `47407dc` fix(st-09032): tighten lifecycle review follow-ups
   - `0b55206` fix(st-09032): preserve lifecycle public interface
   - `d619cba` fix(st-09032): harden lifecycle background hooks
-  - review-fix commit pending for cleanup-before-initialize and late health-check teardown follow-ups
+  - `4a41ea6` fix(st-09032): handle lifecycle cleanup races
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates, auto-cleanup listeners are removed during teardown even before initialization, teardown blocks stale health-status writes once cleanup begins, repeated `cleanup()` calls now share a single teardown pass, concurrent `initialize()` calls now share a single setup pass, reusable tools re-register auto-cleanup on re-initialize, and stale health-check results from prior lifecycles are ignored after cleanup/reinitialize boundaries
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `16 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `17 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1251,7 +1251,8 @@ Implementation notes:
   - `ad63eee` fix(st-09032): block stale health updates during cleanup
   - `c2ea15d` fix(st-09032): make cleanup single-flight
   - `f9a5c93` fix(st-09032): restore cleanup reuse auto-cleanup
-  - pending review-fix commit: lifecycle generation guard follow-up
+  - `8f6098a` fix(st-09032): guard health checks across reuse
+  - pending review-fix commit: initialize single-flight follow-up
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1223,17 +1223,26 @@ Implementation notes:
 **Branch:** `fix/st-09032-managed-tool-lifecycle-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09032-managed-tool-lifecycle-contracts`
+- [x] Create branch `fix/st-09032-managed-tool-lifecycle-contracts` (`codex/fix/st-09032-managed-tool-lifecycle-contracts`)
 - [ ] Create draft PR with story ID in title
-- [ ] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
-- [ ] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-- [ ] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - Draft PR pending branch push
+- [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
+  - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
+- [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
+  - Managed-tool hooks, default health responses, periodic health checks, process-exit registration, and `toLangChainTool()` runtime shape are preserved
+- [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `7 passed` tests
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
+- [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added a dedicated lifecycle suite plus source-included type regressions for typed context, execute inference, health metadata, and process-exit cleanup registration
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `163 passed | 16 skipped` files; `2233 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only
 - [ ] Commit completed checklist items as logical commits and push updates
+  - `971defa` fix(st-09032): tighten managed tool lifecycle contracts
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1244,6 +1244,7 @@ Implementation notes:
 - [x] Commit completed checklist items as logical commits and push updates
   - `971defa` fix(st-09032): tighten managed tool lifecycle contracts
   - `429950b` docs(st-09032): record validation and move story to in-review
+  - review-fix commit pending for context soundness and lifecycle test isolation follow-ups
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1229,9 +1229,9 @@ Implementation notes:
 - [x] Replace broad lifecycle generics and metadata boundaries in `packages/core/src/tools/lifecycle.ts` with safer contracts
   - Replaced broad `any` defaults with safer lifecycle defaults, aligned health metadata with shared JSON-safe payload types, and tightened LangChain interop typing without changing runtime behavior
 - [x] Preserve current managed-tool initialization, execution, cleanup, health-check, and LangChain interop behavior
-  - Managed-tool hooks, default health responses, periodic health checks, process-exit registration, and `toLangChainTool()` runtime shape are preserved
+  - Managed-tool hooks, default health responses, process-exit registration, and `toLangChainTool()` runtime shape are preserved; periodic health checks now run single-flight to avoid overlapping status updates
 - [x] Add/update focused tests for lifecycle hooks, health checks, stats, and process-exit cleanup behavior as needed
-  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `7 passed` tests
+  - `pnpm test --run packages/core/tests/tools/lifecycle.test.ts` -> `1 passed` file, `8 passed` tests
 - [x] Record explicit-`any` warning deltas for touched files in story docs
   - Recorded in `docs/st09032-managed-tool-lifecycle-contracts.md`; workspace baseline improved to `170/289`, `core` improved to `53/119`
 - [x] Add or update story documentation at `docs/st09032-managed-tool-lifecycle-contracts.md` (or document why not required)
@@ -1245,7 +1245,8 @@ Implementation notes:
   - `971defa` fix(st-09032): tighten managed tool lifecycle contracts
   - `429950b` docs(st-09032): record validation and move story to in-review
   - `47407dc` fix(st-09032): tighten lifecycle review follow-ups
-  - review-fix commit pending for public interface compatibility and test contract alignment follow-ups
+  - `0b55206` fix(st-09032): preserve lifecycle public interface
+  - review-fix commit pending for auto-cleanup listener and periodic health-check follow-ups
 - [x] Mark PR Ready only after all story tasks are complete
   - PR #95 marked ready: https://github.com/TVScoundrel/agentforge/pull/95
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1394,7 +1394,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09023
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/lifecycle.ts` replaces broad lifecycle `any` defaults with safer generic defaults or unknown-first contracts

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-04-23
-**Active Story:** ST-09032 (Ready)
+**Last Updated:** 2026-04-24
+**Active Story:** ST-09032 (In Review)
 
 ---
 
@@ -75,6 +75,7 @@ Recent improvement snapshot:
 - `ST-09029` merged after modularizing the plan-execute node layer into focused planner, executor, replanner, finisher, logger, and serialization helpers behind the stable public facade, with review-driven follow-up fixes for structured and array-based model-content normalization, finisher response compatibility, prompt formatting, undefined serialization semantics, and GraphInterrupt propagation.
 - `ST-09030` merged after extracting relational connection-manager query execution and dedicated-session adapter handling into focused helpers, preserving MySQL tuple normalization, SQLite non-query normalization, and dedicated PostgreSQL/MySQL session behavior while leaving the workspace explicit-`any` baseline unchanged at `180` and `tools` unchanged at `65`.
 - `ST-09031` merged after extracting the remaining tool-registry registration, update, removal, bulk-registration, and clear paths into a focused internal helper while preserving the stable public facade, mutation error semantics, and emitted events, and the next active Epic 9 target is `ST-09032`.
+- `ST-09032` tightened the managed-tool lifecycle surface around unknown-first generic defaults, JSON-safe health metadata, and typed LangChain interop while lowering the workspace explicit-`any` baseline from `180` to `170` and the `core` package from `63` to `53`.
 - `EP-09` remains open as the daily hardening stream, with the active queue now centered on tool-registry extraction, lifecycle hardening, and the remaining testing-contract follow-ons.
 - A fresh follow-on slice is now queued behind that work for connection-manager execution/session extraction, registry registration/mutation extraction, managed-tool lifecycle hardening, database-pool contract tightening, and testing runner type-boundary cleanup.
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-04-23
+**Last Updated:** 2026-04-24
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
+- **Ready:** 2 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 6 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09032` - Tighten Managed Tool Lifecycle Contracts
 - `ST-09034` - Tighten Snapshot Testing Runner Contracts
 - `ST-10001` - Audit Markdown Emoji Usage Across Project-Owned Docs
 
@@ -28,7 +27,7 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09032` - Tighten Managed Tool Lifecycle Contracts
 
 ---
 


### PR DESCRIPTION
## Summary
- tighten managed tool lifecycle contracts around unknown-first defaults and JSON-safe health metadata
- add direct lifecycle typecheck and runtime coverage for init, execute, cleanup, health checks, process-exit cleanup, and LangChain interop
- update Epic 9 planning and story documentation for ST-09032

## Testing
- pnpm exec tsc -p packages/core/tsconfig.json --noEmit
- pnpm exec eslint packages/core/src/tools/lifecycle.ts packages/core/src/tools/lifecycle.typecheck.ts packages/core/tests/tools/lifecycle.test.ts
- pnpm test --run packages/core/tests/tools/lifecycle.test.ts
- pnpm lint:explicit-any:baseline --silent
- pnpm test --run
- pnpm lint
