### PR TITLE
ST-09033: Tighten Database Pool Adapter Contracts

### DIFF
--- a/docs/st09033-database-pool-adapter-contracts.md
+++ b/docs/st09033-database-pool-adapter-contracts.md
@@ -1,0 +1,42 @@
+# ST-09033: Database Pool Adapter Contracts
+
+## Summary
+
+ST-09033 tightens the `@agentforge/core` database pool adapter surface by replacing broad query and parameter `any` contracts with exported unknown-first types while preserving the existing mock database pool behavior.
+
+## Contract Changes
+
+- Added `DatabaseQueryParams` as `readonly unknown[]` for SQL parameter arrays.
+- Added `DatabaseQueryResult` as the default unknown query result boundary.
+- Updated `DatabaseConnection.query(...)`, `DatabaseConnection.execute(...)`, `DatabasePool.query(...)`, and `DatabasePool.execute(...)` to use the safer parameter/result aliases.
+- Exported the new aliases from `packages/core/src/resources/index.ts` for downstream adapter implementations.
+
+## Behavior Preservation
+
+The runtime pool flow is unchanged:
+
+- `DatabasePool.acquire()` and `DatabasePool.release(...)` still delegate to the shared `ConnectionPool`.
+- `DatabasePool.query(...)` still acquires a connection, delegates to `connection.query(...)`, and releases in `finally`.
+- `DatabasePool.execute(...)` still acquires a connection, delegates to `connection.execute(...)`, and releases in `finally`, including failure paths.
+- The mock connection still returns an empty array for queries and throws when used after close.
+- Health-check validation still runs the configured query through `connection.query(...)`.
+
+## Test Strategy
+
+Focused behavior tests were added in `packages/core/tests/resources/database-pool.test.ts` for:
+
+- Typed readonly query parameter delegation through pooled connections.
+- Release-on-failure behavior for `execute(...)` delegation.
+- Health-check validation through the typed query contract.
+
+The behavior tests were written before production changes. They pass as characterization tests against the existing runtime behavior; the type-boundary hardening is then enforced by `@agentforge/core` typecheck and the explicit-`any` baseline check because Vitest does not type-check erased type-only imports.
+
+## Validation
+
+Focused validation:
+
+- `pnpm test --run packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts` -> passed (`2` files, `6` tests).
+- `pnpm --filter @agentforge/core typecheck` -> passed.
+- `pnpm lint:explicit-any:baseline` -> passed and improved from `153/289` to `144/289`; `core` improved from `53/119` to `44/119`.
+
+Full-suite and lint validation will be recorded before marking the PR ready.

--- a/docs/st09033-database-pool-adapter-contracts.md
+++ b/docs/st09033-database-pool-adapter-contracts.md
@@ -39,4 +39,7 @@ Focused validation:
 - `pnpm --filter @agentforge/core typecheck` -> passed.
 - `pnpm lint:explicit-any:baseline` -> passed and improved from `153/289` to `144/289`; `core` improved from `53/119` to `44/119`.
 
-Full-suite and lint validation will be recorded before marking the PR ready.
+Final validation:
+
+- `pnpm test --run` -> passed (`165` files, `2260` tests, `286` skipped).
+- `pnpm lint` -> passed with existing warnings only.

--- a/packages/core/src/resources/database-pool.ts
+++ b/packages/core/src/resources/database-pool.ts
@@ -14,9 +14,12 @@ export interface DatabaseConfig {
   connectionTimeout?: number;
 }
 
+export type DatabaseQueryParams = readonly unknown[];
+export type DatabaseQueryResult = unknown;
+
 export interface DatabaseConnection {
-  query<T = any>(sql: string, params?: any[]): Promise<T>;
-  execute(sql: string, params?: any[]): Promise<void>;
+  query<TResult = DatabaseQueryResult>(sql: string, params?: DatabaseQueryParams): Promise<TResult>;
+  execute(sql: string, params?: DatabaseQueryParams): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -39,15 +42,18 @@ class MockDatabaseConnection implements DatabaseConnection {
 
   constructor(private config: DatabaseConfig) {}
 
-  async query<T = any>(sql: string, params?: any[]): Promise<T> {
+  async query<TResult = DatabaseQueryResult>(
+    _sql: string,
+    _params?: DatabaseQueryParams
+  ): Promise<TResult> {
     if (this.closed) {
       throw new Error('Connection is closed');
     }
     // Mock implementation
-    return [] as T;
+    return [] as TResult;
   }
 
-  async execute(sql: string, params?: any[]): Promise<void> {
+  async execute(_sql: string, _params?: DatabaseQueryParams): Promise<void> {
     if (this.closed) {
       throw new Error('Connection is closed');
     }
@@ -96,16 +102,19 @@ export class DatabasePool {
     return this.pool.release(connection);
   }
 
-  async query<T = any>(sql: string, params?: any[]): Promise<T> {
+  async query<TResult = DatabaseQueryResult>(
+    sql: string,
+    params?: DatabaseQueryParams
+  ): Promise<TResult> {
     const connection = await this.acquire();
     try {
-      return await connection.query<T>(sql, params);
+      return await connection.query<TResult>(sql, params);
     } finally {
       await this.release(connection);
     }
   }
 
-  async execute(sql: string, params?: any[]): Promise<void> {
+  async execute(sql: string, params?: DatabaseQueryParams): Promise<void> {
     const connection = await this.acquire();
     try {
       await connection.execute(sql, params);
@@ -130,4 +139,3 @@ export class DatabasePool {
 export function createDatabasePool(options: DatabasePoolOptions): DatabasePool {
   return new DatabasePool(options);
 }
-

--- a/packages/core/src/resources/index.ts
+++ b/packages/core/src/resources/index.ts
@@ -17,6 +17,8 @@ export {
   createDatabasePool,
   type DatabaseConfig,
   type DatabaseConnection,
+  type DatabaseQueryParams,
+  type DatabaseQueryResult,
   type DatabasePoolOptions,
 } from './database-pool.js';
 
@@ -55,4 +57,3 @@ export {
   type CircuitBreakerOptions,
   type CircuitBreakerStats,
 } from './circuit-breaker.js';
-

--- a/packages/core/tests/resources/database-pool.test.ts
+++ b/packages/core/tests/resources/database-pool.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDatabasePool,
+  type DatabaseConnection,
+  type DatabaseQueryParams,
+  type DatabasePool,
+} from '../../src/resources/database-pool.js';
+
+const databaseConfig = {
+  host: 'localhost',
+  database: 'agentforge',
+  user: 'agentforge',
+  password: 'secret',
+};
+
+describe('DatabasePool', () => {
+  const pools: DatabasePool[] = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+
+    for (const pool of pools) {
+      await pool.clear();
+    }
+    pools.length = 0;
+  });
+
+  it('delegates typed query parameters through pooled connections and releases the connection', async () => {
+    const pool = createDatabasePool({
+      config: databaseConfig,
+      pool: { max: 1 },
+    });
+    pools.push(pool);
+
+    const connection = await pool.acquire();
+    const queryCalls: Array<{ sql: string; params?: DatabaseQueryParams }> = [];
+    connection.query = async <TResult = unknown>(
+      sql: string,
+      params?: DatabaseQueryParams
+    ): Promise<TResult> => {
+      queryCalls.push({ sql, params });
+      return [{ id: 1, name: 'Ada' }] as TResult;
+    };
+    await pool.release(connection);
+
+    const params = ['active', 10] as const;
+    const result = await pool.query<Array<{ id: number; name: string }>>(
+      'SELECT * FROM users WHERE status = ? LIMIT ?',
+      params
+    );
+
+    expect(result).toEqual([{ id: 1, name: 'Ada' }]);
+    expect(queryCalls).toEqual([
+      {
+        sql: 'SELECT * FROM users WHERE status = ? LIMIT ?',
+        params,
+      },
+    ]);
+    expect(pool.getStats().acquired).toBe(0);
+  });
+
+  it('releases connections when execute delegation fails', async () => {
+    const pool = createDatabasePool({
+      config: databaseConfig,
+      pool: { max: 1 },
+    });
+    pools.push(pool);
+
+    const connection = await pool.acquire();
+    const executeCalls: Array<{ sql: string; params?: DatabaseQueryParams }> = [];
+    connection.execute = async (sql: string, params?: DatabaseQueryParams): Promise<void> => {
+      executeCalls.push({ sql, params });
+      throw new Error('execute failed');
+    };
+    await pool.release(connection);
+
+    const params = ['Ada'] as const;
+    await expect(pool.execute('DELETE FROM users WHERE name = ?', params)).rejects.toThrow('execute failed');
+
+    expect(executeCalls).toEqual([
+      {
+        sql: 'DELETE FROM users WHERE name = ?',
+        params,
+      },
+    ]);
+    expect(pool.getStats().acquired).toBe(0);
+  });
+
+  it('runs health-check validation through the typed query contract', async () => {
+    vi.useFakeTimers();
+
+    const pool = createDatabasePool({
+      config: databaseConfig,
+      pool: { max: 1 },
+      healthCheck: {
+        enabled: true,
+        interval: 10,
+        timeout: 5,
+        retries: 1,
+        query: 'SELECT healthy',
+      },
+    });
+    pools.push(pool);
+
+    const connection = await pool.acquire();
+    const query = vi.fn<DatabaseConnection['query']>(async <TResult = unknown>(
+      sql: string,
+      _params?: DatabaseQueryParams
+    ): Promise<TResult> => {
+      expect(sql).toBe('SELECT healthy');
+      return [{ healthy: true }] as TResult;
+    });
+    connection.query = query;
+    await pool.release(connection);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(pool.getStats().healthChecksPassed).toBe(1);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1281,10 +1281,15 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09033-database-pool-adapter-contracts.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Added focused database-pool coverage and ran `pnpm --filter @agentforge/core typecheck` to cover the type-only contract hardening.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `165 passed | 16 skipped` files; `2260 passed | 286 skipped` tests.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only.
+- [x] Commit completed checklist items as logical commits and push updates
+  - `decf940` chore(st-09033): start database pool adapter story
+  - `5a55680` fix(st-09033): tighten database pool adapter contracts
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #98 ready for review: https://github.com/TVScoundrel/agentforge/pull/98
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1267,7 +1267,7 @@ Implementation notes:
 **Branch:** `fix/st-09033-database-pool-adapter-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09033-database-pool-adapter-contracts`
+- [x] Create branch `fix/st-09033-database-pool-adapter-contracts`
 - [ ] Create draft PR with story ID in title
 - [ ] Replace broad query/parameter contracts in `packages/core/src/resources/database-pool.ts` with safer adapter types
 - [ ] Preserve current acquire/release, query/execute delegation, and pool lifecycle behavior

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1268,13 +1268,19 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09033-database-pool-adapter-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Replace broad query/parameter contracts in `packages/core/src/resources/database-pool.ts` with safer adapter types
-- [ ] Preserve current acquire/release, query/execute delegation, and pool lifecycle behavior
-- [ ] Add/update focused tests for pool acquisition, query/execute delegation, and health-check validation as needed
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09033-database-pool-adapter-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create draft PR with story ID in title
+  - Draft PR #98: https://github.com/TVScoundrel/agentforge/pull/98
+- [x] Replace broad query/parameter contracts in `packages/core/src/resources/database-pool.ts` with safer adapter types
+  - Added exported `DatabaseQueryParams` and `DatabaseQueryResult` aliases and moved query/execute params to readonly unknown-first boundaries.
+- [x] Preserve current acquire/release, query/execute delegation, and pool lifecycle behavior
+  - Focused tests cover query delegation, execute failure release, and health-check validation through the existing pool lifecycle.
+- [x] Add/update focused tests for pool acquisition, query/execute delegation, and health-check validation as needed
+  - Added `packages/core/tests/resources/database-pool.test.ts`; focused pool tests pass with `2` files and `6` tests including existing HTTP pool coverage.
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09033-database-pool-adapter-contracts.md`; workspace baseline improved from `153/289` to `144/289`, `core` from `53/119` to `44/119`.
+- [x] Add or update story documentation at `docs/st09033-database-pool-adapter-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added focused database-pool coverage and ran `pnpm --filter @agentforge/core typecheck` to cover the type-only contract hardening.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1411,7 +1411,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09032
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/resources/database-pool.ts` replaces broad connection/query parameter contracts with safer generic or unknown-first adapter types

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1411,7 +1411,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09032
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/resources/database-pool.ts` replaces broad connection/query parameter contracts with safer generic or unknown-first adapter types

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-03
-**Active Story:** ST-09033 (Ready)
+**Active Story:** ST-09033 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-03
-**Active Story:** ST-09033 (In Progress)
+**Active Story:** ST-09033 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 4 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 6 stories
 
@@ -23,13 +23,13 @@
 
 ## In Progress
 
-- `ST-09033` - Tighten Database Pool Adapter Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09033` - Tighten Database Pool Adapter Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **Ready:** 4 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 6 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09033` - Tighten Database Pool Adapter Contracts
 - `ST-09035` - Tighten Agent Test Runner State Contracts
 - `ST-10002` - Normalize Emoji Usage in Public-Facing Docs
 - `ST-10003` - Normalize Emoji Usage in Planning and Internal Docs
@@ -24,7 +23,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09033` - Tighten Database Pool Adapter Contracts
 
 ---
 


### PR DESCRIPTION
## Story
ST-09033: Tighten Database Pool Adapter Contracts

## What Changed
- Added exported `DatabaseQueryParams` and `DatabaseQueryResult` aliases in `@agentforge/core`.
- Replaced broad database pool query/execute parameter and result defaults with unknown-first readonly parameter boundaries.
- Exported the new aliases from the resources barrel for downstream adapter implementations.
- Added focused database pool tests and story documentation.

## Acceptance Criteria Coverage
- Database pool broad `any` contracts replaced with safer adapter types.
- Acquire/release, query/execute delegation, execute failure release, and health-check validation behavior preserved.
- Explicit-any baseline improved from `153/289` to `144/289`; `core` improved from `53/119` to `44/119`.
- Story documentation added at `docs/st09033-database-pool-adapter-contracts.md`.

## Test Strategy
- Added focused tests in `packages/core/tests/resources/database-pool.test.ts` for typed query parameters, execute failure release, and health-check validation.
- Preserved existing HTTP pool coverage as a neighboring resource-pool regression.
- Ran core typecheck because the key boundary change is type-only and Vitest does not type-check erased imports.

## Validation Performed
- `pnpm test --run packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts` -> passed (`2` files, `6` tests).
- `pnpm --filter @agentforge/core typecheck` -> passed.
- `pnpm lint:explicit-any:baseline` -> passed, improved to `144/289`.
- `pnpm test --run` -> passed (`165` files, `2260` tests, `286` skipped).
- `pnpm lint` -> passed with existing warnings only.

## Status
Ready for review.
