### PR TITLE
ST-09035: Tighten agent test runner state contracts

### DIFF
--- a/docs/st09035-agent-test-runner-state-contracts.md
+++ b/docs/st09035-agent-test-runner-state-contracts.md
@@ -40,7 +40,7 @@ Focused runtime coverage was added in `packages/testing/tests/runners/agent-test
 Focused validation:
 
 - `pnpm --filter @agentforge/testing typecheck` -> passed.
-- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `6` tests).
+- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `7` tests).
 - `pnpm lint:explicit-any:baseline` -> passed and improved from `144/289` to `135/289`; `testing` improved from `14/51` to `5/51`.
 
 Final validation:

--- a/docs/st09035-agent-test-runner-state-contracts.md
+++ b/docs/st09035-agent-test-runner-state-contracts.md
@@ -40,7 +40,7 @@ Focused runtime coverage was added in `packages/testing/tests/runners/agent-test
 Focused validation:
 
 - `pnpm --filter @agentforge/testing typecheck` -> passed.
-- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `4` tests).
+- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `6` tests).
 - `pnpm lint:explicit-any:baseline` -> passed and improved from `144/289` to `135/289`; `testing` improved from `14/51` to `5/51`.
 
 Final validation:

--- a/docs/st09035-agent-test-runner-state-contracts.md
+++ b/docs/st09035-agent-test-runner-state-contracts.md
@@ -1,0 +1,46 @@
+# ST-09035: Agent Test Runner State Contracts
+
+## Summary
+
+ST-09035 tightens the `@agentforge/testing` agent test runner surface by replacing broad agent, input, state, and step `any` contracts with unknown-first generics while preserving the existing runner behavior.
+
+## Contract Changes
+
+- Added `AgentTestAgent<TInput, TState>` for agent-like objects with an `invoke(...)` method.
+- Added `AgentTestRunnerStep<TState>` as the typed step-capture boundary for future step capture support.
+- Made `AgentTestConfig<TState>` generic so validation hooks receive the typed final state or `undefined` after failed execution.
+- Made `AgentTestResult<TState, TStep>` generic so final state and captured steps retain caller-provided types.
+- Made `AgentTestRunner<TInput, TState, TStep>` and `createAgentTestRunner(...)` generic over input, final state, and step contracts.
+- Exported the new runner contracts from `packages/testing/src/index.ts`.
+
+## Behavior Preservation
+
+The runtime runner flow is unchanged:
+
+- `run(...)` still invokes the supplied agent with the provided input.
+- Timeout failures are caught and returned as failed results instead of being thrown.
+- State validation still runs only when both `validateState` and `stateValidator` are configured.
+- Failed validation still returns a failed result with `State validation failed`.
+- `captureSteps` still returns the runner's current empty step list.
+- `runMany(...)` still runs all inputs concurrently with `Promise.all(...)`.
+
+## Test Strategy
+
+A source-included typecheck regression was added before production changes in `packages/testing/src/runners/agent-test-runner.typecheck.ts`. It initially failed because the safer exported contracts did not exist and `AgentTestConfig`/`AgentTestResult` were not generic.
+
+Focused runtime coverage was added in `packages/testing/tests/runners/agent-test-runner.test.ts` for:
+
+- Successful runner execution with final state, messages, execution metadata, and optional step capture.
+- Timeout failures returned as failed results.
+- Validation failures returned as failed results while preserving final state.
+- Multi-input `runMany(...)` execution.
+
+## Validation
+
+Focused validation:
+
+- `pnpm --filter @agentforge/testing typecheck` -> passed.
+- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `4` tests).
+- `pnpm lint:explicit-any:baseline` -> passed and improved from `144/289` to `135/289`; `testing` improved from `14/51` to `5/51`.
+
+Full-suite validation will be recorded before the PR is marked ready for review.

--- a/docs/st09035-agent-test-runner-state-contracts.md
+++ b/docs/st09035-agent-test-runner-state-contracts.md
@@ -8,7 +8,7 @@ ST-09035 tightens the `@agentforge/testing` agent test runner surface by replaci
 
 - Added `AgentTestAgent<TInput, TState>` for agent-like objects with an `invoke(...)` method.
 - Added `AgentTestRunnerStep<TState>` as the typed step-capture boundary for future step capture support.
-- Made `AgentTestConfig<TState>` generic so validation hooks receive the typed final state or `undefined` after failed execution.
+- Made `AgentTestConfig<TState>` generic so validation hooks receive the typed final state when invocation completes; the parameter also permits `undefined` for agents that intentionally return no state.
 - Made `AgentTestResult<TState, TStep>` generic so final state and captured steps retain caller-provided types.
 - Made `AgentTestRunner<TInput, TState, TStep>` and `createAgentTestRunner(...)` generic over input, final state, and step contracts.
 - Exported the new runner contracts from `packages/testing/src/index.ts`.

--- a/docs/st09035-agent-test-runner-state-contracts.md
+++ b/docs/st09035-agent-test-runner-state-contracts.md
@@ -43,4 +43,7 @@ Focused validation:
 - `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `4` tests).
 - `pnpm lint:explicit-any:baseline` -> passed and improved from `144/289` to `135/289`; `testing` improved from `14/51` to `5/51`.
 
-Full-suite validation will be recorded before the PR is marked ready for review.
+Final validation:
+
+- `pnpm test --run` -> passed (`166` files, `2264` tests, `286` skipped).
+- `pnpm lint` -> exit `0`; warnings only.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -82,8 +82,10 @@ export {
 export {
   AgentTestRunner,
   createAgentTestRunner,
+  type AgentTestAgent,
   type AgentTestConfig,
   type AgentTestResult,
+  type AgentTestRunnerStep,
 } from './runners/agent-test-runner.js';
 
 export {

--- a/packages/testing/src/runners/agent-test-runner.ts
+++ b/packages/testing/src/runners/agent-test-runner.ts
@@ -1,4 +1,4 @@
-import { BaseMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
 
 /**
  * Agent-like contract used by the test runner.
@@ -115,12 +115,13 @@ export class AgentTestRunner<
     let messages: BaseMessage[] = [];
     let passed = true;
     let error: Error | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     
     try {
       // Set timeout if configured
       const timeout = this.config.timeout || 30000;
       const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Agent test timeout')), timeout);
+        timeoutId = setTimeout(() => reject(new Error('Agent test timeout')), timeout);
       });
       
       // Run agent
@@ -146,7 +147,13 @@ export class AgentTestRunner<
         }
       })();
       
-      await Promise.race([runPromise, timeoutPromise]);
+      try {
+        await Promise.race([runPromise, timeoutPromise]);
+      } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+      }
     } catch (err) {
       passed = false;
       error = err as Error;
@@ -187,6 +194,10 @@ export function createAgentTestRunner<
 }
 
 function extractMessages(state: unknown): BaseMessage[] {
-  const stateWithMessages = state as { messages?: BaseMessage[] };
-  return stateWithMessages.messages || [];
+  if (typeof state !== 'object' || state === null) {
+    return [];
+  }
+
+  const { messages } = state as { messages?: unknown };
+  return Array.isArray(messages) ? (messages as BaseMessage[]) : [];
 }

--- a/packages/testing/src/runners/agent-test-runner.ts
+++ b/packages/testing/src/runners/agent-test-runner.ts
@@ -119,7 +119,7 @@ export class AgentTestRunner<
     
     try {
       // Set timeout if configured
-      const timeout = this.config.timeout || 30000;
+      const timeout = this.config.timeout ?? 30000;
       const timeoutPromise = new Promise((_, reject) => {
         timeoutId = setTimeout(() => reject(new Error('Agent test timeout')), timeout);
       });

--- a/packages/testing/src/runners/agent-test-runner.ts
+++ b/packages/testing/src/runners/agent-test-runner.ts
@@ -1,9 +1,26 @@
 import { BaseMessage } from '@langchain/core/messages';
 
 /**
+ * Agent-like contract used by the test runner.
+ */
+export interface AgentTestAgent<TInput = unknown, TState = unknown> {
+  invoke(input: TInput): TState | Promise<TState>;
+}
+
+/**
+ * Captured runner step. The current runner preserves an empty step list, but
+ * this contract gives future step capture a typed state boundary.
+ */
+export interface AgentTestRunnerStep<TState = unknown> {
+  state: TState;
+  messages: BaseMessage[];
+  timestamp: number;
+}
+
+/**
  * Configuration for agent test runner
  */
-export interface AgentTestConfig {
+export interface AgentTestConfig<TState = unknown> {
   /**
    * Maximum time to wait for agent response (ms)
    */
@@ -22,17 +39,17 @@ export interface AgentTestConfig {
   /**
    * Custom state validator
    */
-  stateValidator?: (state: any) => boolean | Promise<boolean>;
+  stateValidator?: (state: TState | undefined) => boolean | Promise<boolean>;
 }
 
 /**
  * Result from agent test run
  */
-export interface AgentTestResult {
+export interface AgentTestResult<TState = unknown, TStep = AgentTestRunnerStep<TState>> {
   /**
    * Final state after execution
    */
-  finalState: any;
+  finalState: TState | undefined;
   
   /**
    * Messages exchanged
@@ -47,7 +64,7 @@ export interface AgentTestResult {
   /**
    * Intermediate steps (if captured)
    */
-  steps?: any[];
+  steps?: TStep[];
   
   /**
    * Whether the test passed
@@ -78,19 +95,23 @@ export interface AgentTestResult {
  * expect(result.messages.length).toBeGreaterThan(1);
  * ```
  */
-export class AgentTestRunner {
+export class AgentTestRunner<
+  TInput = unknown,
+  TState = unknown,
+  TStep = AgentTestRunnerStep<TState>,
+> {
   constructor(
-    private agent: any,
-    private config: AgentTestConfig = {}
+    private agent: AgentTestAgent<TInput, TState>,
+    private config: AgentTestConfig<TState> = {}
   ) {}
   
   /**
    * Run the agent with given input
    */
-  async run(input: any): Promise<AgentTestResult> {
+  async run(input: TInput): Promise<AgentTestResult<TState, TStep>> {
     const startTime = Date.now();
-    const steps: any[] = [];
-    let finalState: any;
+    const steps: TStep[] = [];
+    let finalState: TState | undefined;
     let messages: BaseMessage[] = [];
     let passed = true;
     let error: Error | undefined;
@@ -108,12 +129,12 @@ export class AgentTestRunner {
           // Capture intermediate steps
           const result = await this.agent.invoke(input);
           finalState = result;
-          messages = result.messages || [];
+          messages = extractMessages(result);
         } else {
           // Just run to completion
           const result = await this.agent.invoke(input);
           finalState = result;
-          messages = result.messages || [];
+          messages = extractMessages(result);
         }
         
         // Validate state if configured
@@ -146,7 +167,7 @@ export class AgentTestRunner {
   /**
    * Run multiple test cases
    */
-  async runMany(inputs: any[]): Promise<AgentTestResult[]> {
+  async runMany(inputs: TInput[]): Promise<AgentTestResult<TState, TStep>[]> {
     return Promise.all(inputs.map((input) => this.run(input)));
   }
 }
@@ -154,10 +175,18 @@ export class AgentTestRunner {
 /**
  * Create an agent test runner
  */
-export function createAgentTestRunner(
-  agent: any,
-  config?: AgentTestConfig
-): AgentTestRunner {
+export function createAgentTestRunner<
+  TInput = unknown,
+  TState = unknown,
+  TStep = AgentTestRunnerStep<TState>,
+>(
+  agent: AgentTestAgent<TInput, TState>,
+  config?: AgentTestConfig<TState>
+): AgentTestRunner<TInput, TState, TStep> {
   return new AgentTestRunner(agent, config);
 }
 
+function extractMessages(state: unknown): BaseMessage[] {
+  const stateWithMessages = state as { messages?: BaseMessage[] };
+  return stateWithMessages.messages || [];
+}

--- a/packages/testing/src/runners/agent-test-runner.typecheck.ts
+++ b/packages/testing/src/runners/agent-test-runner.typecheck.ts
@@ -1,0 +1,29 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AgentTestAgent,
+  AgentTestConfig,
+  AgentTestResult,
+  AgentTestRunnerStep,
+} from './agent-test-runner.js';
+
+type ExampleInput = { messages: BaseMessage[]; userId: string };
+type ExampleState = { messages: BaseMessage[]; score: number };
+type ExampleStep = { name: string; state: ExampleState };
+
+declare const agent: AgentTestAgent<ExampleInput, ExampleState>;
+declare const config: AgentTestConfig<ExampleState>;
+declare const result: AgentTestResult<ExampleState, ExampleStep>;
+declare const step: AgentTestRunnerStep<ExampleState>;
+
+async function acceptsTypedRunnerContracts(input: ExampleInput) {
+  const state = await agent.invoke(input);
+  const validationResult = await config.stateValidator?.(state);
+
+  result.finalState?.score.toFixed();
+  result.steps?.[0]?.state.score.toFixed();
+  step.state.score.toFixed();
+
+  return validationResult ?? true;
+}
+
+void acceptsTypedRunnerContracts;

--- a/packages/testing/tests/runners/agent-test-runner.test.ts
+++ b/packages/testing/tests/runners/agent-test-runner.test.ts
@@ -59,6 +59,20 @@ describe('agent test runner', () => {
     expect(result.error?.message).toBe('Agent test timeout');
   });
 
+  it('honors an explicit zero timeout', async () => {
+    const runner = new AgentTestRunner(
+      {
+        invoke: () => new Promise((resolve) => setTimeout(() => resolve({ messages: [] }), 10)),
+      },
+      { timeout: 0 }
+    );
+
+    const result = await runner.run({ messages: [] });
+
+    expect(result.passed).toBe(false);
+    expect(result.error?.message).toBe('Agent test timeout');
+  });
+
   it('falls back to empty messages when final state has a malformed messages field', async () => {
     const runner = createAgentTestRunner({
       invoke: async () => ({

--- a/packages/testing/tests/runners/agent-test-runner.test.ts
+++ b/packages/testing/tests/runners/agent-test-runner.test.ts
@@ -1,0 +1,75 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it } from 'vitest';
+import { AgentTestRunner, createAgentTestRunner } from '../../src/runners/agent-test-runner.js';
+
+describe('agent test runner', () => {
+  it('runs an agent and returns final state, messages, and execution metadata', async () => {
+    const messages = [new HumanMessage('hello'), new AIMessage('hi')];
+    const agent = {
+      invoke: async (input: { messages: HumanMessage[] }) => ({
+        messages: [...input.messages, messages[1]],
+        score: 1,
+      }),
+    };
+    const runner = createAgentTestRunner(agent, { captureSteps: true });
+
+    const result = await runner.run({ messages: [messages[0]] });
+
+    expect(result.passed).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.finalState).toEqual({ messages, score: 1 });
+    expect(result.messages).toEqual(messages);
+    expect(result.steps).toEqual([]);
+    expect(result.executionTime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports timeout failures without throwing', async () => {
+    const runner = new AgentTestRunner(
+      {
+        invoke: () => new Promise(() => undefined),
+      },
+      { timeout: 1 }
+    );
+
+    const result = await runner.run({ messages: [] });
+
+    expect(result.passed).toBe(false);
+    expect(result.finalState).toBeUndefined();
+    expect(result.messages).toEqual([]);
+    expect(result.error?.message).toBe('Agent test timeout');
+  });
+
+  it('runs configured validation against the final state', async () => {
+    const runner = createAgentTestRunner(
+      {
+        invoke: async () => ({ messages: [], valid: false }),
+      },
+      {
+        validateState: true,
+        stateValidator: (state) => state?.valid === true,
+      }
+    );
+
+    const result = await runner.run({ messages: [] });
+
+    expect(result.passed).toBe(false);
+    expect(result.finalState).toEqual({ messages: [], valid: false });
+    expect(result.error?.message).toBe('State validation failed');
+  });
+
+  it('runs multiple inputs independently', async () => {
+    const runner = createAgentTestRunner({
+      invoke: async (input: { value: number }) => ({
+        messages: [new AIMessage(String(input.value * 2))],
+        value: input.value * 2,
+      }),
+    });
+
+    const results = await runner.runMany([{ value: 1 }, { value: 2 }]);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => result.passed)).toEqual([true, true]);
+    expect(results.map((result) => result.finalState?.value)).toEqual([2, 4]);
+    expect(results.map((result) => result.messages[0]?.content)).toEqual(['2', '4']);
+  });
+});

--- a/packages/testing/tests/runners/agent-test-runner.test.ts
+++ b/packages/testing/tests/runners/agent-test-runner.test.ts
@@ -1,8 +1,12 @@
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AgentTestRunner, createAgentTestRunner } from '../../src/runners/agent-test-runner.js';
 
 describe('agent test runner', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('runs an agent and returns final state, messages, and execution metadata', async () => {
     const messages = [new HumanMessage('hello'), new AIMessage('hi')];
     const agent = {
@@ -23,6 +27,22 @@ describe('agent test runner', () => {
     expect(result.executionTime).toBeGreaterThanOrEqual(0);
   });
 
+  it('clears timeout handles when the agent finishes before the timeout', async () => {
+    vi.useFakeTimers();
+
+    const runner = createAgentTestRunner(
+      {
+        invoke: async () => ({ messages: [new AIMessage('done')] }),
+      },
+      { timeout: 30_000 }
+    );
+
+    const result = await runner.run({ messages: [] });
+
+    expect(result.passed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('reports timeout failures without throwing', async () => {
     const runner = new AgentTestRunner(
       {
@@ -37,6 +57,21 @@ describe('agent test runner', () => {
     expect(result.finalState).toBeUndefined();
     expect(result.messages).toEqual([]);
     expect(result.error?.message).toBe('Agent test timeout');
+  });
+
+  it('falls back to empty messages when final state has a malformed messages field', async () => {
+    const runner = createAgentTestRunner({
+      invoke: async () => ({
+        messages: 'not-an-array',
+        value: 1,
+      }),
+    });
+
+    const result = await runner.run({ messages: [] });
+
+    expect(result.passed).toBe(true);
+    expect(result.finalState).toEqual({ messages: 'not-an-array', value: 1 });
+    expect(result.messages).toEqual([]);
   });
 
   it('runs configured validation against the final state', async () => {

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1339,7 +1339,7 @@ Implementation notes:
 **Branch:** `fix/st-09035-agent-test-runner-state-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09035-agent-test-runner-state-contracts`
+- [x] Create branch `fix/st-09035-agent-test-runner-state-contracts`
 - [ ] Create draft PR with story ID in title
 - [ ] Replace broad agent, input, state, and step contracts in `packages/testing/src/runners/agent-test-runner.ts` with safer interfaces or generics
 - [ ] Preserve current timeout, validation, step-capture, and `runMany(...)` behavior

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1340,13 +1340,19 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09035-agent-test-runner-state-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Replace broad agent, input, state, and step contracts in `packages/testing/src/runners/agent-test-runner.ts` with safer interfaces or generics
-- [ ] Preserve current timeout, validation, step-capture, and `runMany(...)` behavior
-- [ ] Add/update focused tests for successful runs, timeout handling, validation failures, and multi-input execution
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09035-agent-test-runner-state-contracts.md` (or document why not required)
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required
+- [x] Create draft PR with story ID in title
+  - Draft PR #99: https://github.com/TVScoundrel/agentforge/pull/99
+- [x] Replace broad agent, input, state, and step contracts in `packages/testing/src/runners/agent-test-runner.ts` with safer interfaces or generics
+  - Added `AgentTestAgent`, `AgentTestRunnerStep`, and generic `AgentTestConfig`, `AgentTestResult`, `AgentTestRunner`, and `createAgentTestRunner(...)` contracts.
+- [x] Preserve current timeout, validation, step-capture, and `runMany(...)` behavior
+  - Focused runner coverage preserves successful runs, timeout failures, validation failures, empty step capture, and concurrent `runMany(...)` execution.
+- [x] Add/update focused tests for successful runs, timeout handling, validation failures, and multi-input execution
+  - Added `packages/testing/tests/runners/agent-test-runner.test.ts`.
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+  - Recorded in `docs/st09035-agent-test-runner-state-contracts.md`; workspace baseline improved from `144/289` to `135/289`, `testing` from `14/51` to `5/51`.
+- [x] Add or update story documentation at `docs/st09035-agent-test-runner-state-contracts.md` (or document why not required)
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
+  - Added source-included typecheck regression plus focused runtime runner coverage.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1353,10 +1353,15 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09035-agent-test-runner-state-contracts.md` (or document why not required)
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required
   - Added source-included typecheck regression plus focused runtime runner coverage.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `166 passed | 16 skipped` files; `2264 passed | 286 skipped` tests.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only.
+- [x] Commit completed checklist items as logical commits and push updates
+  - `8f87323` chore(st-09035): start agent runner contract story
+  - `3060f9d` fix(st-09035): tighten agent test runner contracts
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #99 ready for review: https://github.com/TVScoundrel/agentforge/pull/99
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1445,7 +1445,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09034
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/testing/src/runners/agent-test-runner.ts` replaces broad agent, input, state, and step `any` contracts with safer interfaces or unknown-first generics

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1445,7 +1445,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09034
-**Status:** In Progress
+**Status:** In Review (PR #99)
 
 **Acceptance criteria:**
 - [ ] `packages/testing/src/runners/agent-test-runner.ts` replaces broad agent, input, state, and step `any` contracts with safer interfaces or unknown-first generics

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-03
-**Active Story:** ST-09035 (Ready)
+**Last Updated:** 2026-05-04
+**Active Story:** ST-09035 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-04
-**Active Story:** ST-09035 (In Progress)
+**Active Story:** ST-09035 (In Review)
 
 ---
 
@@ -77,7 +77,7 @@ Recent improvement snapshot:
 - `ST-09032` merged after tightening the managed-tool lifecycle surface around unknown-first generic defaults, JSON-safe health metadata, typed LangChain interop, and lifecycle concurrency handling while lowering the workspace explicit-`any` baseline from `180` to `170` and the `core` package from `63` to `53`.
 - `ST-09034` merged after tightening snapshot runner contracts around unknown-first state normalization, typed snapshot diffs, normalized message snapshots, plain-object-only recursive normalization, and non-plain root diffs in `@agentforge/testing`.
 - `ST-09033` merged after tightening database pool adapter query parameter/result contracts around exported unknown-first aliases, lowering the workspace explicit-`any` baseline from `153` to `144` and the `core` package from `53` to `44`.
-- `ST-09035` is in progress after tightening the agent test runner around exported unknown-first agent, state, result, and step contracts, lowering the workspace explicit-`any` baseline from `144` to `135` and the `testing` package from `14` to `5`.
+- `ST-09035` is in review after tightening the agent test runner around exported unknown-first agent, state, result, and step contracts, lowering the workspace explicit-`any` baseline from `144` to `135` and the `testing` package from `14` to `5`.
 - `ST-09036` through `ST-09040` were added on 2026-05-03 as small SOLID/DRY follow-on slices covering conversation simulator contracts, ReAct builder/prompt boundaries, data transformer helper extraction, core mock-tool testing contracts, and human-in-loop streaming resume typing.
 - `EP-09` remains open as the daily hardening stream, with the active queue now centered on testing-contract follow-ons and small SOLID/DRY helper extractions.
 - A fresh follow-on slice is now queued behind current Ready work for testing runner type-boundary cleanup, ReAct boundary tightening, transformer DRY helper extraction, core testing-helper contracts, and streaming resume payload hardening.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -32,10 +32,10 @@
 
 ## Current Hotspot Snapshot
 
-Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-05-03):
+Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-05-04):
 
-- Total: `144` warnings (`src/**`)
-- By package: `cli 6`, `core 44`, `patterns 15`, `testing 14`, `tools 65`
+- Total: `135` warnings (`src/**`)
+- By package: `cli 6`, `core 44`, `patterns 15`, `testing 5`, `tools 65`
 
 Top runtime hotspots informing this feature slice:
 
@@ -77,7 +77,7 @@ Recent improvement snapshot:
 - `ST-09032` merged after tightening the managed-tool lifecycle surface around unknown-first generic defaults, JSON-safe health metadata, typed LangChain interop, and lifecycle concurrency handling while lowering the workspace explicit-`any` baseline from `180` to `170` and the `core` package from `63` to `53`.
 - `ST-09034` merged after tightening snapshot runner contracts around unknown-first state normalization, typed snapshot diffs, normalized message snapshots, plain-object-only recursive normalization, and non-plain root diffs in `@agentforge/testing`.
 - `ST-09033` merged after tightening database pool adapter query parameter/result contracts around exported unknown-first aliases, lowering the workspace explicit-`any` baseline from `153` to `144` and the `core` package from `53` to `44`.
-- `ST-09035` is ready as the next testing-package follow-on after the snapshot runner contract hardening dependency was merged.
+- `ST-09035` is in progress after tightening the agent test runner around exported unknown-first agent, state, result, and step contracts, lowering the workspace explicit-`any` baseline from `144` to `135` and the `testing` package from `14` to `5`.
 - `ST-09036` through `ST-09040` were added on 2026-05-03 as small SOLID/DRY follow-on slices covering conversation simulator contracts, ReAct builder/prompt boundaries, data transformer helper extraction, core mock-tool testing contracts, and human-in-loop streaming resume typing.
 - `EP-09` remains open as the daily hardening stream, with the active queue now centered on testing-contract follow-ons and small SOLID/DRY helper extractions.
 - A fresh follow-on slice is now queued behind current Ready work for testing runner type-boundary cleanup, ReAct boundary tightening, transformer DRY helper extraction, core testing-helper contracts, and streaming resume payload hardening.

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -128,4 +128,4 @@ _No stories currently blocked_
 - Epic 09 (SOLID Micro-Refactors and Type Boundary Hardening) was expanded a sixth time on 2026-05-03 with small SOLID/DRY follow-on stories ST-09036 through ST-09040
 - Epic 10 (Documentation Only Changes) was opened on 2026-04-18 as an evergreen docs-only lane for markdown cleanup, style normalization, and future documentation maintenance stories
 - ST-10001 complete - markdown emoji usage audit merged (PR #97, 2026-05-03); ST-10002 through ST-10005 promoted to Ready as capacity became available
-- Current measured `no-explicit-any` baseline is `144` warnings (`cli 6`, `core 44`, `patterns 15`, `testing 14`, `tools 65`)
+- Current measured `no-explicit-any` baseline is `135` warnings (`cli 6`, `core 44`, `patterns 15`, `testing 5`, `tools 65`)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 4 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 5 stories
 
@@ -23,13 +23,13 @@
 
 ## In Progress
 
-- `ST-09035` - Tighten Agent Test Runner State Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09035` - Tighten Agent Test Runner State Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-05-04
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **Ready:** 4 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 5 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09035` - Tighten Agent Test Runner State Contracts
 - `ST-10002` - Normalize Emoji Usage in Public-Facing Docs
 - `ST-10003` - Normalize Emoji Usage in Planning and Internal Docs
 - `ST-10004` - Normalize Emoji Usage in Examples and Template Docs
@@ -24,7 +23,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09035` - Tighten Agent Test Runner State Contracts
 
 ---
 


### PR DESCRIPTION
## Story

ST-09035: Tighten Agent Test Runner State Contracts

## What Changed

- Added exported unknown-first runner contracts: `AgentTestAgent<TInput, TState>` and `AgentTestRunnerStep<TState>`.
- Made `AgentTestConfig`, `AgentTestResult`, `AgentTestRunner`, and `createAgentTestRunner(...)` generic over agent input, final state, and step contracts.
- Preserved existing runner behavior for agent invocation, timeout failures, validation failures, optional empty step capture, and `runMany(...)`.
- Addressed review feedback by using a type-only message import, clearing timeout handles after the race settles, guarding malformed `messages` values, and honoring `timeout: 0`.
- Added a source-included typecheck regression and focused runtime tests for the runner.
- Added story documentation and planning/checklist updates.

## Acceptance Criteria Coverage

- [x] Replaced broad agent, input, state, and step contracts in `packages/testing/src/runners/agent-test-runner.ts` with safer interfaces/generics.
- [x] Preserved timeout handling, validation hooks, step-capture output, and `runMany(...)` behavior.
- [x] Added focused tests for successful runs, timeout handling, zero timeout, validation failures, malformed messages, timeout cleanup, and multi-input execution.
- [x] Recorded explicit-`any` warning deltas in `docs/st09035-agent-test-runner-state-contracts.md`.
- [x] Added story documentation at `docs/st09035-agent-test-runner-state-contracts.md`.

## Test Strategy

- Added `packages/testing/src/runners/agent-test-runner.typecheck.ts` before production changes; it initially failed because the safer exported contracts did not exist and result/config types were not generic.
- Added `packages/testing/tests/runners/agent-test-runner.test.ts` to preserve successful execution, timeout failure returns, zero-timeout behavior, validation failure returns, timeout cleanup, malformed message fallback, empty step capture, and `runMany(...)` behavior.

## Validation Performed

- `pnpm --filter @agentforge/testing typecheck` -> passed.
- `pnpm test --run packages/testing/tests/runners/agent-test-runner.test.ts` -> passed (`1` file, `7` tests).
- `pnpm lint:explicit-any:baseline` -> passed; workspace improved from `144/289` to `135/289`, `testing` improved from `14/51` to `5/51`.
- `pnpm test --run` -> passed (`166` files, `2264` tests, `286` skipped).
- `pnpm lint` -> exit `0`; warnings only.

## Status

Ready for review.
