### PR TITLE
ST-09036 Tighten conversation simulator agent contracts

### DIFF
--- a/.pr-body-st-09036.md
+++ b/.pr-body-st-09036.md
@@ -7,7 +7,7 @@ ST-09036 - Tighten Conversation Simulator Agent Contracts
 - tightened `ConversationSimulator` to use the shared `AgentTestAgent` contract instead of `agent: any`
 - reused the agent test runner's unknown-first message extraction helper for invoke-result handling
 - added a source-included typecheck regression and focused simulator runtime tests
-- moved `ST-09036` into `In Progress` in the Epic 09 trackers
+- moved `ST-09036` into `In Review` in the Epic 09 trackers
 
 ## Acceptance Criteria Coverage
 
@@ -25,9 +25,10 @@ ST-09036 - Tighten Conversation Simulator Agent Contracts
 
 - `pnpm --filter @agentforge/testing typecheck`
 - `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
-- `pnpm test --run` pending
-- `pnpm lint` pending
+- `pnpm test --run`
+- `pnpm lint`
+- `pnpm lint:explicit-any:baseline` -> `133/289` warnings (`testing 3/51`), improving the workspace baseline from `135` to `133`
 
 ## Status
 
-Draft
+Ready for review

--- a/.pr-body-st-09036.md
+++ b/.pr-body-st-09036.md
@@ -1,0 +1,33 @@
+## Story
+
+ST-09036 - Tighten Conversation Simulator Agent Contracts
+
+## What Changed
+
+- tightened `ConversationSimulator` to use the shared `AgentTestAgent` contract instead of `agent: any`
+- reused the agent test runner's unknown-first message extraction helper for invoke-result handling
+- added a source-included typecheck regression and focused simulator runtime tests
+- moved `ST-09036` into `In Progress` in the Epic 09 trackers
+
+## Acceptance Criteria Coverage
+
+- `packages/testing/src/runners/conversation-simulator.ts` no longer relies on broad agent and invoke-result `any` seams
+- static simulation, dynamic simulation, max-turn behavior, stop-condition behavior, and malformed invoke-result handling are covered in focused tests
+- multi-turn flow, stop reasons, and captured error behavior are preserved
+- story documentation was added at `docs/st09036-conversation-simulator-agent-contracts.md`
+
+## Test Strategy
+
+- pre-implementation type regression in `packages/testing/src/runners/conversation-simulator.typecheck.ts`
+- focused runtime tests in `packages/testing/tests/runners/conversation-simulator.test.ts`
+
+## Validation Performed
+
+- `pnpm --filter @agentforge/testing typecheck`
+- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
+- `pnpm test --run` pending
+- `pnpm lint` pending
+
+## Status
+
+Draft

--- a/docs/st09036-conversation-simulator-agent-contracts.md
+++ b/docs/st09036-conversation-simulator-agent-contracts.md
@@ -14,6 +14,7 @@ Tighten `ConversationSimulator` around the same unknown-first agent and message 
 - `ConversationSimulator` now accepts `AgentTestAgent<ConversationSimulatorInput, TState>` instead of a broad `any`.
 - Message extraction reuses the agent test runner's unknown-first `extractMessages(...)` helper.
 - A missing or malformed invoke-result `messages` payload now surfaces as a captured simulator error through the existing `completed/error/stopReason` result path.
+- The generic factory signature now supports source-included typecheck coverage so downstream callers can supply state generics without casts.
 
 ## Validation
 
@@ -21,5 +22,12 @@ Tighten `ConversationSimulator` around the same unknown-first agent and message 
   - Before implementation: failed on `createConversationSimulator<ExampleState>(...)` because the factory accepted zero type arguments.
   - After implementation: passed.
 - `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts` passed (`1` file, `5` tests).
-- Full-suite and lint validation pending.
-- Explicit-`any` warning delta pending final lint/baseline verification.
+- `pnpm test --run` passed (`167` files passed, `16` skipped; `2272` tests passed, `286` skipped).
+- `pnpm lint` passed with warnings only (`0` errors).
+- `pnpm lint:explicit-any:baseline` passed at `133/289` warnings (`testing 3/51`).
+
+## Explicit-`any` Delta
+
+- `packages/testing/src/runners/conversation-simulator.ts`: `2` broad `agent: any` seams before, `0` after.
+- Workspace baseline: `135` -> `133`.
+- `packages/testing` baseline: `5` -> `3`.

--- a/docs/st09036-conversation-simulator-agent-contracts.md
+++ b/docs/st09036-conversation-simulator-agent-contracts.md
@@ -1,0 +1,25 @@
+# ST-09036: Conversation Simulator Agent Contracts
+
+## Summary
+
+Tighten `ConversationSimulator` around the same unknown-first agent and message extraction seam used by the agent test runner, so multi-turn testing no longer depends on a broad `agent: any` contract.
+
+## Test Strategy
+
+- Pre-implementation type regression: `pnpm --filter @agentforge/testing typecheck` failed because `createConversationSimulator<ExampleState>(...)` was not generic yet.
+- Focused runtime coverage targets static simulation, dynamic simulation, explicit max-turn stopping, configured stop conditions, and malformed invoke results.
+
+## Implementation Notes
+
+- `ConversationSimulator` now accepts `AgentTestAgent<ConversationSimulatorInput, TState>` instead of a broad `any`.
+- Message extraction reuses the agent test runner's unknown-first `extractMessages(...)` helper.
+- A missing or malformed invoke-result `messages` payload now surfaces as a captured simulator error through the existing `completed/error/stopReason` result path.
+
+## Validation
+
+- `pnpm --filter @agentforge/testing typecheck`:
+  - Before implementation: failed on `createConversationSimulator<ExampleState>(...)` because the factory accepted zero type arguments.
+  - After implementation: passed.
+- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts` passed (`1` file, `5` tests).
+- Full-suite and lint validation pending.
+- Explicit-`any` warning delta pending final lint/baseline verification.

--- a/packages/testing/src/runners/agent-test-runner.ts
+++ b/packages/testing/src/runners/agent-test-runner.ts
@@ -193,7 +193,7 @@ export function createAgentTestRunner<
   return new AgentTestRunner(agent, config);
 }
 
-function extractMessages(state: unknown): BaseMessage[] {
+export function extractMessages(state: unknown): BaseMessage[] {
   if (typeof state !== 'object' || state === null) {
     return [];
   }

--- a/packages/testing/src/runners/conversation-simulator.ts
+++ b/packages/testing/src/runners/conversation-simulator.ts
@@ -1,4 +1,6 @@
-import { BaseMessage, HumanMessage, AIMessage } from '@langchain/core/messages';
+import { BaseMessage, HumanMessage } from '@langchain/core/messages';
+import type { AgentTestAgent } from './agent-test-runner.js';
+import { extractMessages } from './agent-test-runner.js';
 
 /**
  * Configuration for conversation simulator
@@ -60,6 +62,10 @@ export interface ConversationResult {
   error?: Error;
 }
 
+export interface ConversationSimulatorInput {
+  messages: BaseMessage[];
+}
+
 /**
  * Conversation simulator for testing multi-turn interactions
  * 
@@ -80,9 +86,9 @@ export interface ConversationResult {
  * expect(result.completed).toBe(true);
  * ```
  */
-export class ConversationSimulator {
+export class ConversationSimulator<TState = unknown> {
   constructor(
-    private agent: any,
+    private agent: AgentTestAgent<ConversationSimulatorInput, TState>,
     private config: ConversationSimulatorConfig = {}
   ) {}
   
@@ -116,7 +122,7 @@ export class ConversationSimulator {
         
         // Get agent response
         const result = await this.agent.invoke({ messages });
-        const aiMessage = result.messages[result.messages.length - 1];
+        const aiMessage = extractLatestMessage(result);
         messages.push(aiMessage);
         
         if (this.config.verbose) {
@@ -181,7 +187,7 @@ export class ConversationSimulator {
         messages.push(userMessage);
         
         const result = await this.agent.invoke({ messages });
-        const aiMessage = result.messages[result.messages.length - 1];
+        const aiMessage = extractLatestMessage(result);
         messages.push(aiMessage);
         
         turns++;
@@ -208,10 +214,20 @@ export class ConversationSimulator {
 /**
  * Create a conversation simulator
  */
-export function createConversationSimulator(
-  agent: any,
+export function createConversationSimulator<TState = unknown>(
+  agent: AgentTestAgent<ConversationSimulatorInput, TState>,
   config?: ConversationSimulatorConfig
-): ConversationSimulator {
+): ConversationSimulator<TState> {
   return new ConversationSimulator(agent, config);
 }
 
+function extractLatestMessage(state: unknown): BaseMessage {
+  const messages = extractMessages(state);
+  const latestMessage = messages[messages.length - 1];
+
+  if (!latestMessage) {
+    throw new Error('Agent response did not include any messages');
+  }
+
+  return latestMessage;
+}

--- a/packages/testing/src/runners/conversation-simulator.typecheck.ts
+++ b/packages/testing/src/runners/conversation-simulator.typecheck.ts
@@ -9,11 +9,9 @@ type ExampleState = {
 
 declare const agent: AgentTestAgent<{ messages: BaseMessage[] }, ExampleState>;
 
-async function acceptsTypedConversationSimulator() {
+export async function acceptsTypedConversationSimulator() {
   const simulator = createConversationSimulator<ExampleState>(agent);
   const result = await simulator.simulate(['hello']);
 
-  result.messages[0]?.content;
+  return result.messages[0]?.content;
 }
-
-void acceptsTypedConversationSimulator;

--- a/packages/testing/src/runners/conversation-simulator.typecheck.ts
+++ b/packages/testing/src/runners/conversation-simulator.typecheck.ts
@@ -1,0 +1,19 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { AgentTestAgent } from './agent-test-runner.js';
+import { createConversationSimulator } from './conversation-simulator.js';
+
+type ExampleState = {
+  messages: BaseMessage[];
+  score: number;
+};
+
+declare const agent: AgentTestAgent<{ messages: BaseMessage[] }, ExampleState>;
+
+async function acceptsTypedConversationSimulator() {
+  const simulator = createConversationSimulator<ExampleState>(agent);
+  const result = await simulator.simulate(['hello']);
+
+  result.messages[0]?.content;
+}
+
+void acceptsTypedConversationSimulator;

--- a/packages/testing/tests/runners/conversation-simulator.test.ts
+++ b/packages/testing/tests/runners/conversation-simulator.test.ts
@@ -1,0 +1,104 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it } from 'vitest';
+import {
+  ConversationSimulator,
+  createConversationSimulator,
+} from '../../src/runners/conversation-simulator.js';
+
+describe('conversation simulator', () => {
+  it('simulates a static conversation and appends only the latest agent message each turn', async () => {
+    const simulator = createConversationSimulator({
+      invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+        messages: [...input.messages, new AIMessage(`reply ${input.messages.length}`)],
+        score: input.messages.length,
+      }),
+    });
+
+    const result = await simulator.simulate(['hello', 'world']);
+
+    expect(result.completed).toBe(true);
+    expect(result.stopReason).toBe('max_turns');
+    expect(result.turns).toBe(2);
+    expect(result.messages).toHaveLength(4);
+    expect(result.messages[0]).toEqual(new HumanMessage('hello'));
+    expect(result.messages[1]).toEqual(new AIMessage('reply 1'));
+    expect(result.messages[2]).toEqual(new HumanMessage('world'));
+    expect(result.messages[3]).toEqual(new AIMessage('reply 3'));
+  });
+
+  it('supports dynamic input generation until the generator stops', async () => {
+    const simulator = new ConversationSimulator({
+      invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+        messages: [...input.messages, new AIMessage(`ack ${input.messages.length}`)],
+      }),
+    });
+
+    const result = await simulator.simulateDynamic((messages) => {
+      if (messages.length >= 4) {
+        return null;
+      }
+
+      return `turn ${messages.length}`;
+    });
+
+    expect(result.completed).toBe(true);
+    expect(result.stopReason).toBe('stop_condition');
+    expect(result.turns).toBe(2);
+    expect(result.messages).toHaveLength(4);
+  });
+
+  it('stops early when maxTurns is lower than the provided input count', async () => {
+    const simulator = createConversationSimulator(
+      {
+        invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+          messages: [...input.messages, new AIMessage(`reply ${input.messages.length}`)],
+        }),
+      },
+      { maxTurns: 1 }
+    );
+
+    const result = await simulator.simulate(['hello', 'world']);
+
+    expect(result.completed).toBe(true);
+    expect(result.stopReason).toBe('max_turns');
+    expect(result.turns).toBe(1);
+    expect(result.messages).toHaveLength(2);
+  });
+
+  it('honors the configured stop condition after appending the latest agent message', async () => {
+    const simulator = createConversationSimulator(
+      {
+        invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+          messages: [...input.messages, new AIMessage(`reply ${input.messages.length}`)],
+        }),
+      },
+      {
+        stopCondition: (messages) =>
+          messages[messages.length - 1] instanceof AIMessage,
+      }
+    );
+
+    const result = await simulator.simulate(['hello', 'world']);
+
+    expect(result.completed).toBe(true);
+    expect(result.stopReason).toBe('stop_condition');
+    expect(result.turns).toBe(1);
+    expect(result.messages).toHaveLength(2);
+  });
+
+  it('captures malformed invoke results as errors without throwing', async () => {
+    const simulator = createConversationSimulator({
+      invoke: async () => ({
+        messages: 'not-an-array',
+      }),
+    });
+
+    const result = await simulator.simulate(['hello']);
+
+    expect(result.completed).toBe(false);
+    expect(result.stopReason).toBe('error');
+    expect(result.turns).toBe(0);
+    expect(result.messages).toEqual([new HumanMessage('hello')]);
+    expect(result.error).toBeInstanceOf(Error);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1372,7 +1372,7 @@ Implementation notes:
 **Branch:** `fix/st-09036-conversation-simulator-agent-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09036-conversation-simulator-agent-contracts`
+- [x] Create branch `fix/st-09036-conversation-simulator-agent-contracts`
 - [ ] Create draft PR with story ID in title
 - [ ] Define test strategy before implementation: cover static simulation, dynamic simulation, stop conditions, max-turn behavior, and malformed invoke results; first failing test should assert typed handling of an invoke result without broad agent `any`
 - [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1373,20 +1373,38 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09036-conversation-simulator-agent-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover static simulation, dynamic simulation, stop conditions, max-turn behavior, and malformed invoke results; first failing test should assert typed handling of an invoke result without broad agent `any`
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad agent and invoke-result contracts in `packages/testing/src/runners/conversation-simulator.ts` with reusable unknown-first or generic runner interfaces
-- [ ] Preserve multi-turn simulation, dynamic input generation, stop-condition handling, verbose logging, and error capture behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09036-conversation-simulator-agent-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: cover static simulation, dynamic simulation, stop conditions, max-turn behavior, and malformed invoke results; first failing test should assert typed handling of an invoke result without broad agent `any`
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad agent and invoke-result contracts in `packages/testing/src/runners/conversation-simulator.ts` with reusable unknown-first or generic runner interfaces
+- [x] Preserve multi-turn simulation, dynamic input generation, stop-condition handling, verbose logging, and error capture behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09036-conversation-simulator-agent-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- PR #103: https://github.com/TVScoundrel/agentforge/pull/103
+- Pre-implementation failing type regression:
+  - `pnpm --filter @agentforge/testing typecheck` -> failed because `createConversationSimulator<ExampleState>(...)` accepted zero type arguments before the factory was made generic
+- Focused tests and type validation:
+  - `pnpm --filter @agentforge/testing typecheck` -> exit `0`
+  - `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts` -> `1` file passed, `5` tests passed
+- Full validation:
+  - `pnpm test --run` -> `167` files passed, `16` skipped; `2272` tests passed, `286` skipped
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+  - `pnpm lint:explicit-any:baseline` -> `133/289` warnings (`testing 3/51`), improving the workspace baseline from `135` to `133` and `testing` from `5` to `3`
+- Story impact:
+  - `packages/testing/src/runners/conversation-simulator.ts` removed two broad `agent: any` seams by sharing `AgentTestAgent` and unknown-first message extraction with the agent test runner
+  - Additional focused coverage now exercises static simulation, dynamic simulation, max-turn stopping, configured stop conditions, and malformed invoke results
+- Ready for review:
+  - PR #103 ready for review: https://github.com/TVScoundrel/agentforge/pull/103
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1462,7 +1462,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09035
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/testing/src/runners/conversation-simulator.ts` replaces broad agent and invoke-result `any` contracts with reusable unknown-first or generic runner interfaces

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-04
-**Active Story:** ST-09036 (Ready)
+**Last Updated:** 2026-05-06
+**Active Story:** ST-09036 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-06
-**Active Story:** ST-09036 (In Progress)
+**Active Story:** ST-09036 (In Review)
 
 ---
 
@@ -32,10 +32,10 @@
 
 ## Current Hotspot Snapshot
 
-Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-05-04):
+Current `@typescript-eslint/no-explicit-any` baseline check (`pnpm lint:explicit-any:baseline`, 2026-05-06):
 
-- Total: `135` warnings (`src/**`)
-- By package: `cli 6`, `core 44`, `patterns 15`, `testing 5`, `tools 65`
+- Total: `133` warnings (`src/**`)
+- By package: `cli 6`, `core 44`, `patterns 15`, `testing 3`, `tools 65`
 
 Top runtime hotspots informing this feature slice:
 
@@ -58,6 +58,7 @@ Recent improvement snapshot:
 - `ST-09011` tightened the committed explicit-`any` baseline caps from `496` to the current measured `289`, aligning the no-regression gate with the post-EP-09 warning floor.
 - `ST-09012` removed the remaining `exports.types` ordering warnings from `@agentforge/skills`, `@agentforge/tools`, and `@agentforge/testing`, quieting the routine build output without changing published entrypoint targets.
 - `ST-09013` merged with an intentional breaking tightening to the sequential workflow builder contract: explicit state generics were removed, and downstream callers must rely on schema-derived inference from `Annotation.Root(...)`.
+- `ST-09036` removed two broad `agent: any` seams from `packages/testing/src/runners/conversation-simulator.ts`, improving the workspace baseline from `135` to `133` and the `testing` baseline from `5` to `3`.
 - `ST-09014` merged after tightening the shared plan-execute tool and schema boundaries, lowering the workspace explicit-`any` baseline from `289` to `278` and the `patterns` package from `28` to `25`.
 - `ST-09015` merged after splitting the multi-agent node runtime into focused supervisor, worker, aggregator, and shared helper modules, lowering the workspace explicit-`any` baseline from `278` to `276` and the `patterns` package from `25` to `23`.
 - `ST-09016` merged after tightening the audit/health monitoring payload contracts, lowering the workspace explicit-`any` baseline from `276` to `271` and the `core` package from `111` to `106`, with follow-up fixes for falsy JSON payload retention, structured startup logging, and explicit zero timestamps.

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-05
+**Last Updated:** 2026-05-06
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
@@ -15,13 +15,11 @@
 ## Ready
 
 - `ST-10005` - Add Documentation Style Guardrails for Emoji Usage
-- `ST-09036` - Tighten Conversation Simulator Agent Contracts
-
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09036` - Tighten Conversation Simulator Agent Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 1 story
+- **In Progress:** 0 stories
+- **In Review:** 2 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -19,12 +19,13 @@
 
 ## In Progress
 
-- `ST-09036` - Tighten Conversation Simulator Agent Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
+- `ST-09036` - Tighten Conversation Simulator Agent Contracts
 - `ST-10004` - Normalize Emoji Usage in Examples and Template Docs
 
 ---
@@ -126,4 +127,4 @@ _No stories currently blocked_
 - ST-10001 complete - markdown emoji usage audit merged (PR #97, 2026-05-03); ST-10002 through ST-10005 promoted to Ready as capacity became available
 - ST-10002 complete - public-facing docs emoji normalization merged (PR #100, 2026-05-04); ST-10003 remained next in Ready at that point
 - Complete: ST-10003 - planning and internal docs emoji normalization merged (PR #101, 2026-05-04); ST-10004 moved into review on 2026-05-05
-- Current measured `no-explicit-any` baseline is `135` warnings (`cli 6`, `core 44`, `patterns 15`, `testing 5`, `tools 65`)
+- Current measured `no-explicit-any` baseline is `133` warnings (`cli 6`, `core 44`, `patterns 15`, `testing 3`, `tools 65`)


### PR DESCRIPTION
## Story

ST-09036 - Tighten Conversation Simulator Agent Contracts

## What Changed

- tightened `ConversationSimulator` to use the shared `AgentTestAgent` contract instead of `agent: any`
- reused the agent test runner's unknown-first message extraction helper for invoke-result handling
- added a source-included typecheck regression and focused simulator runtime tests
- moved `ST-09036` into `In Review` in the Epic 09 trackers

## Acceptance Criteria Coverage

- `packages/testing/src/runners/conversation-simulator.ts` no longer relies on broad agent and invoke-result `any` seams
- static simulation, dynamic simulation, max-turn behavior, stop-condition behavior, and malformed invoke-result handling are covered in focused tests
- multi-turn flow, stop reasons, and captured error behavior are preserved
- story documentation was added at `docs/st09036-conversation-simulator-agent-contracts.md`

## Test Strategy

- pre-implementation type regression in `packages/testing/src/runners/conversation-simulator.typecheck.ts`
- focused runtime tests in `packages/testing/tests/runners/conversation-simulator.test.ts`

## Validation Performed

- `pnpm --filter @agentforge/testing typecheck`
- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
- `pnpm test --run`
- `pnpm lint`
- `pnpm lint:explicit-any:baseline` -> `133/289` warnings (`testing 3/51`), improving the workspace baseline from `135` to `133`

## Status

Ready for review
