### PR TITLE
ST-10005 Add documentation style guardrails for emoji usage

### DIFF
--- a/.pr-body-st-10005.md
+++ b/.pr-body-st-10005.md
@@ -1,0 +1,32 @@
+## Story
+
+ST-10005 - Add Documentation Style Guardrails for Emoji Usage
+
+## What Changed
+
+- added a markdown style rule to `docs-site/contributing.md` that bans decorative emoji in project-owned markdown
+- documented the allowed exceptions for literal sample output, demonstrated runtime behavior, and meaningful non-emoji symbols
+- directed future markdown cleanup follow-ups into the evergreen EP-10 docs-only lane
+- moved `ST-10005` into `In Progress` in the Epic 10 trackers
+
+## Acceptance Criteria Coverage
+
+- contributor-facing guidance now defines the expected policy for decorative emoji usage in project-owned markdown
+- the rule distinguishes disallowed decoration from acceptable literal output and meaningful symbols
+- the guidance references EP-10 as the home for future markdown normalization follow-ups
+- the rule was added to an existing contributor/process file instead of a new redundant policy fragment
+- story documentation was added at `docs/st10005-docs-style-guardrails.md`
+
+## Test Strategy
+
+- no failing automated test was practical because this story changes contributor guidance only and does not modify runtime code or docs tooling behavior
+- validation relies on direct markdown review plus standard repo quality gates
+
+## Validation Performed
+
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Draft

--- a/.pr-body-st-10005.md
+++ b/.pr-body-st-10005.md
@@ -7,7 +7,7 @@ ST-10005 - Add Documentation Style Guardrails for Emoji Usage
 - added a markdown style rule to `docs-site/contributing.md` that bans decorative emoji in project-owned markdown
 - documented the allowed exceptions for literal sample output, demonstrated runtime behavior, and meaningful non-emoji symbols
 - directed future markdown cleanup follow-ups into the evergreen EP-10 docs-only lane
-- moved `ST-10005` into `In Review` in the Epic 10 trackers
+- moved `ST-10005` into `In Review` in the EP-10 trackers
 
 ## Acceptance Criteria Coverage
 

--- a/.pr-body-st-10005.md
+++ b/.pr-body-st-10005.md
@@ -7,7 +7,7 @@ ST-10005 - Add Documentation Style Guardrails for Emoji Usage
 - added a markdown style rule to `docs-site/contributing.md` that bans decorative emoji in project-owned markdown
 - documented the allowed exceptions for literal sample output, demonstrated runtime behavior, and meaningful non-emoji symbols
 - directed future markdown cleanup follow-ups into the evergreen EP-10 docs-only lane
-- moved `ST-10005` into `In Progress` in the Epic 10 trackers
+- moved `ST-10005` into `In Review` in the Epic 10 trackers
 
 ## Acceptance Criteria Coverage
 
@@ -29,4 +29,4 @@ ST-10005 - Add Documentation Style Guardrails for Emoji Usage
 
 ## Status
 
-Draft
+Ready for review

--- a/docs-site/contributing.md
+++ b/docs-site/contributing.md
@@ -167,6 +167,12 @@ pnpm preview
 - Write descriptive variable and function names
 - Add JSDoc comments for public APIs
 
+### Markdown Style
+- Do not add decorative emoji to project-owned markdown headings, bullets, status labels, or prose.
+- Keep emoji only when the character is part of literal sample output, demonstrated runtime behavior, or intentionally preserved user-facing content.
+- Meaningful non-emoji symbols such as arrows, comparison markers, or other plain Unicode text are acceptable when they add clarity instead of decoration.
+- If you find legacy markdown that still uses decorative emoji, capture the cleanup as a docs-only follow-up in Epic 10 instead of mixing it into unrelated runtime work.
+
 ### Testing
 - Write tests for all new features
 - Aim for high test coverage
@@ -195,4 +201,3 @@ By contributing, you agree that your contributions will be licensed under the MI
 ---
 
 **Thank you for contributing to AgentForge!**
-

--- a/docs-site/contributing.md
+++ b/docs-site/contributing.md
@@ -171,7 +171,7 @@ pnpm preview
 - Do not add decorative emoji to project-owned markdown headings, bullets, status labels, or prose.
 - Keep emoji only when the character is part of literal sample output, demonstrated runtime behavior, or intentionally preserved user-facing content.
 - Meaningful non-emoji symbols such as arrows, comparison markers, or other plain Unicode text are acceptable when they add clarity instead of decoration.
-- If you find legacy markdown that still uses decorative emoji, capture the cleanup as a docs-only follow-up in Epic 10 instead of mixing it into unrelated runtime work.
+- If you find legacy markdown that still uses decorative emoji, capture the cleanup as a docs-only follow-up in EP-10 instead of mixing it into unrelated runtime work.
 
 ### Testing
 - Write tests for all new features

--- a/docs/st10005-docs-style-guardrails.md
+++ b/docs/st10005-docs-style-guardrails.md
@@ -1,0 +1,27 @@
+# ST-10005: Documentation Style Guardrails for Emoji Usage
+
+## Summary
+
+Add a contributor-facing markdown style rule so decorative emoji are not reintroduced into project-owned documentation after the EP-10 cleanup stories.
+
+## Placement Decision
+
+- The guidance lives in `docs-site/contributing.md` because that file is the existing contributor-facing documentation process guide.
+- A new standalone policy file was not created because this story only needs one clear markdown rule in an already authoritative location.
+
+## Rule Scope
+
+- Disallow decorative emoji in headings, bullets, status labels, and prose across project-owned markdown.
+- Allow emoji when they are part of literal sample output, demonstrated runtime behavior, or intentionally preserved user-facing content.
+- Allow meaningful non-emoji symbols where they improve clarity without acting as decoration.
+- Direct future repo-wide markdown cleanup follow-ups into EP-10, which remains the evergreen docs-only lane.
+
+## Test Strategy
+
+- No automated tests are required because this story changes contributor guidance only and does not modify runtime code or docs tooling.
+- Validation is direct markdown review plus standard repo quality gates.
+
+## Validation
+
+- `pnpm test --run` passed (`167` files passed, `16` skipped; `2272` tests passed, `286` skipped).
+- `pnpm lint` passed with warnings only (`0` errors).

--- a/planning/checklists/epic-10-story-tasks.md
+++ b/planning/checklists/epic-10-story-tasks.md
@@ -86,7 +86,7 @@
 
 ### Checklist
 - [x] Create branch `docs/st-10005-docs-style-guardrails`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Add contributor-facing or internal style guidance for decorative emoji usage in project-owned markdown
 - [x] Distinguish disallowed decorative emoji from acceptable literal sample output and meaningful symbols
 - [x] Reference EP-10 as the evergreen lane for future docs-only cleanup stories
@@ -94,15 +94,18 @@
 - [x] Assess test impact; add/update automated tests when needed, or document why tests are not required.
 - [x] Run full test suite before finalizing the PR and record results.
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results.
-- [ ] Commit completed checklist items as logical commits and push updates.
-- [ ] Mark PR Ready only after all story tasks are complete.
+- [x] Commit completed checklist items as logical commits and push updates.
+- [x] Mark PR Ready only after all story tasks are complete.
 - [ ] Wait for merge; do not merge directly from local branch.
 
 ### Notes
 
+- Draft PR #104: https://github.com/TVScoundrel/agentforge/pull/104
 - Documentation guidance was added to `docs-site/contributing.md` rather than a new standalone policy file so contributors have one authoritative markdown/process guide.
 - Test-first rationale:
   - No failing automated test was practical because this story changes contributor guidance only and does not modify runtime code or docs tooling behavior.
 - Validation:
   - `pnpm test --run` -> `167` files passed, `16` skipped; `2272` tests passed, `286` skipped
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
+- Ready for review:
+  - PR #104 ready for review: https://github.com/TVScoundrel/agentforge/pull/104

--- a/planning/checklists/epic-10-story-tasks.md
+++ b/planning/checklists/epic-10-story-tasks.md
@@ -85,15 +85,24 @@
 **Branch:** `docs/st-10005-docs-style-guardrails`
 
 ### Checklist
-- [ ] Create branch `docs/st-10005-docs-style-guardrails`
+- [x] Create branch `docs/st-10005-docs-style-guardrails`
 - [ ] Create draft PR with story ID in title
-- [ ] Add contributor-facing or internal style guidance for decorative emoji usage in project-owned markdown
-- [ ] Distinguish disallowed decorative emoji from acceptable literal sample output and meaningful symbols
-- [ ] Reference EP-10 as the evergreen lane for future docs-only cleanup stories
-- [ ] Add or update story documentation at `docs/st10005-docs-style-guardrails.md` (or document why not required).
-- [ ] Assess test impact; add/update automated tests when needed, or document why tests are not required.
-- [ ] Run full test suite before finalizing the PR and record results.
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results.
+- [x] Add contributor-facing or internal style guidance for decorative emoji usage in project-owned markdown
+- [x] Distinguish disallowed decorative emoji from acceptable literal sample output and meaningful symbols
+- [x] Reference EP-10 as the evergreen lane for future docs-only cleanup stories
+- [x] Add or update story documentation at `docs/st10005-docs-style-guardrails.md` (or document why not required).
+- [x] Assess test impact; add/update automated tests when needed, or document why tests are not required.
+- [x] Run full test suite before finalizing the PR and record results.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results.
 - [ ] Commit completed checklist items as logical commits and push updates.
 - [ ] Mark PR Ready only after all story tasks are complete.
 - [ ] Wait for merge; do not merge directly from local branch.
+
+### Notes
+
+- Documentation guidance was added to `docs-site/contributing.md` rather than a new standalone policy file so contributors have one authoritative markdown/process guide.
+- Test-first rationale:
+  - No failing automated test was practical because this story changes contributor guidance only and does not modify runtime code or docs tooling behavior.
+- Validation:
+  - `pnpm test --run` -> `167` files passed, `16` skipped; `2272` tests passed, `286` skipped
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1632,7 +1632,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-10001 (merged)
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] A contributor-facing or internal documentation style rule defines the expected policy for decorative emoji usage in project-owned markdown

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1632,7 +1632,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-10001 (merged)
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] A contributor-facing or internal documentation style rule defines the expected policy for decorative emoji usage in project-owned markdown

--- a/planning/features/10-documentation-only-changes-feature-plan.md
+++ b/planning/features/10-documentation-only-changes-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-10 through EP-10
 **Status:** In Progress
 **Last Updated:** 2026-05-05
-**Active Story:** ST-10004 (In Review)
+**Active Story:** ST-10005 (In Progress)
 
 ---
 
@@ -62,7 +62,7 @@
 
 ## Story Coverage by Epic
 
-- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (In Review), ST-10005 (Backlog)
+- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (In Review), ST-10005 (In Progress)
 
 ---
 

--- a/planning/features/10-documentation-only-changes-feature-plan.md
+++ b/planning/features/10-documentation-only-changes-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-10 through EP-10
 **Status:** In Progress
 **Last Updated:** 2026-05-05
-**Active Story:** ST-10005 (In Progress)
+**Active Story:** ST-10005 (In Review)
 
 ---
 
@@ -62,7 +62,7 @@
 
 ## Story Coverage by Epic
 
-- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (In Review), ST-10005 (In Progress)
+- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (In Review), ST-10005 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,7 +5,7 @@
 ## Queue Status Summary
 
 - **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-10005` - Add Documentation Style Guardrails for Emoji Usage
 - `ST-09037` - Tighten ReAct Builder and Prompt Boundary Contracts
 - `ST-09038` - Extract Data Transformer Object Path Helpers
 - `ST-09039` - Tighten Core Mock Tool Testing Helper Contracts
@@ -23,7 +22,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-10005` - Add Documentation Style Guardrails for Emoji Usage
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,9 +4,9 @@
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
-- **In Progress:** 1 story
-- **In Review:** 1 story
+- **Ready:** 4 stories
+- **In Progress:** 0 stories
+- **In Review:** 2 stories
 - **Blocked:** 0 stories
 - **Backlog:** 1 story
 
@@ -22,12 +22,13 @@
 
 ## In Progress
 
-- `ST-10005` - Add Documentation Style Guardrails for Emoji Usage
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
+- `ST-10005` - Add Documentation Style Guardrails for Emoji Usage
 - `ST-10004` - Normalize Emoji Usage in Examples and Template Docs
 
 ---


### PR DESCRIPTION
## Story

ST-10005 - Add Documentation Style Guardrails for Emoji Usage

## What Changed

- added a markdown style rule to `docs-site/contributing.md` that bans decorative emoji in project-owned markdown
- documented the allowed exceptions for literal sample output, demonstrated runtime behavior, and meaningful non-emoji symbols
- directed future markdown cleanup follow-ups into the evergreen EP-10 docs-only lane
- moved `ST-10005` into `In Review` in the EP-10 trackers

## Acceptance Criteria Coverage

- contributor-facing guidance now defines the expected policy for decorative emoji usage in project-owned markdown
- the rule distinguishes disallowed decoration from acceptable literal output and meaningful symbols
- the guidance references EP-10 as the home for future markdown normalization follow-ups
- the rule was added to an existing contributor/process file instead of a new redundant policy fragment
- story documentation was added at `docs/st10005-docs-style-guardrails.md`

## Test Strategy

- no failing automated test was practical because this story changes contributor guidance only and does not modify runtime code or docs tooling behavior
- validation relies on direct markdown review plus standard repo quality gates

## Validation Performed

- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
