### PR TITLE
ST-10006 Normalize emoji usage in example overview docs

### DIFF
--- a/.pr-body-st-10006.md
+++ b/.pr-body-st-10006.md
@@ -1,0 +1,33 @@
+## Story
+
+ST-10006 - Normalize Emoji Usage in Example Overview Docs
+
+## What Changed
+
+- removed decorative emoji from example overview headings in `examples/README.md` and `examples/vertical-agents/README.md`
+- removed decorative arrow glyphs from the vertical-agent overview `View Documentation` links
+- preserved functional test-status checkmarks and left literal sample output untouched
+- moved `ST-10006` into `In Review` in the EP-10 trackers
+
+## Acceptance Criteria Coverage
+
+- example overview and index markdown now avoids decorative emoji in headings and navigation copy within the scoped files
+- functional pass/fail markers and literal sample output remain intact where they carry real meaning
+- no linked destination, command, example behavior, or code snippet changed beyond markdown presentation cleanup
+- scope stayed limited to overview/index markdown rather than per-example deep-dive READMEs or runtime code
+- story documentation was added at `docs/st10006-example-overview-docs-emoji-normalization.md`
+
+## Test Strategy
+
+- no failing automated test was practical because this story changes markdown presentation only and does not modify runtime behavior or docs tooling behavior
+- validation relies on targeted markdown diff review, a scoped follow-up emoji scan, and standard repository quality gates
+
+## Validation Performed
+
+- `git diff --check`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Ready for review

--- a/docs/st10006-example-overview-docs-emoji-normalization.md
+++ b/docs/st10006-example-overview-docs-emoji-normalization.md
@@ -2,7 +2,7 @@
 
 **Story:** ST-10006 - Normalize Emoji Usage in Example Overview Docs
 **Epic:** EP-10 - Documentation Only Changes
-**Status:** In Progress
+**Status:** In Review
 
 ## Scope
 

--- a/docs/st10006-example-overview-docs-emoji-normalization.md
+++ b/docs/st10006-example-overview-docs-emoji-normalization.md
@@ -1,0 +1,37 @@
+# ST-10006: Example Overview Docs Emoji Normalization
+
+**Story:** ST-10006 - Normalize Emoji Usage in Example Overview Docs
+**Epic:** EP-10 - Documentation Only Changes
+**Status:** In Progress
+
+## Scope
+
+This story cleans the remaining decorative emoji in overview and catalog markdown for the examples area while preserving functional status markers and literal output examples that carry documented meaning.
+
+Targeted files:
+- `examples/README.md`
+- `examples/vertical-agents/README.md`
+
+Out of scope:
+- Per-example deep-dive READMEs
+- Runtime code, tests, or example behavior changes
+- Functional pass/fail markers such as `✅`
+- Literal sample output or code snippets where symbols are part of the documented behavior
+
+## Test Strategy
+
+No practical failing automated test exists for this story because it changes markdown presentation only and does not alter runtime behavior or docs tooling logic.
+
+Validation approach:
+- Review the targeted markdown diff directly
+- Re-scan the targeted files for remaining decorative emoji
+- Run the standard repository quality gates required by the checklist:
+  - `pnpm test --run`
+  - `pnpm lint`
+  - `git diff --check`
+
+## Implementation Notes
+
+- Removed decorative emoji from overview section headings in the example index pages.
+- Removed decorative arrow glyphs from `View Documentation` link text in the vertical-agents overview page.
+- Preserved test-status checkmarks because they act as meaningful pass indicators rather than decorative flair.

--- a/examples/README.md
+++ b/examples/README.md
@@ -202,7 +202,7 @@ pnpm tsx examples/applications/customer-support/src/index.ts
 
 ---
 
-## 🔌 Integrations
+## Integrations
 
 ### Express.js REST API
 **Framework**: Express.js  
@@ -332,7 +332,7 @@ pnpm tsx examples/applications/customer-support/src/index.ts
 pnpm tsx examples/integrations/express-api/src/server.ts
 ```
 
-## 📖 Documentation
+## Documentation
 
 Each example includes:
 - Comprehensive README

--- a/examples/vertical-agents/README.md
+++ b/examples/vertical-agents/README.md
@@ -22,7 +22,7 @@ A configurable customer support agent with escalation capabilities.
 - Help desk automation
 - FAQ handling
 
-[View Documentation →](./customer-support/README.md)
+[View Documentation](./customer-support/README.md)
 
 ---
 
@@ -43,7 +43,7 @@ An automated code review agent with security and performance analysis.
 - Performance optimization
 - Code quality enforcement
 
-[View Documentation →](./code-review/README.md)
+[View Documentation](./code-review/README.md)
 
 ---
 
@@ -64,7 +64,7 @@ A flexible data analysis agent with statistical methods and visualization.
 - Data quality monitoring
 - Report generation
 
-[View Documentation →](./data-analyst/README.md)
+[View Documentation](./data-analyst/README.md)
 
 ---
 
@@ -293,7 +293,7 @@ it('should create security-focused review agent', () => {
 });
 ```
 
-## 📖 Documentation
+## Documentation
 
 Each agent includes:
 - **README.md** - Complete usage guide
@@ -302,7 +302,7 @@ Each agent includes:
 - **Examples** - Common use cases
 - **Tests** - Demonstrating all features
 
-## 🔗 Related Resources
+## Related Resources
 
 - [Vertical Agents Guide](../../docs-site/guide/advanced/vertical-agents.md) - Comprehensive guide
 - [Tool Builder API](../../packages/core/README.md) - Creating custom tools
@@ -329,7 +329,7 @@ Include clear README with examples, configuration reference, and usage patterns.
 ### 6. Version Carefully
 Follow semantic versioning when publishing vertical agents.
 
-## 🤝 Contributing
+## Contributing
 
 These examples are meant to inspire and guide. If you create interesting vertical agents:
 1. Follow the same patterns demonstrated here

--- a/planning/checklists/epic-10-story-tasks.md
+++ b/planning/checklists/epic-10-story-tasks.md
@@ -119,7 +119,7 @@
 
 ### Checklist
 - [x] Create branch `docs/st-10006-example-overview-docs-emoji-normalization`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Remove decorative emoji from targeted example overview and index markdown identified by the follow-up audit
 - [x] Preserve functional status markers and literal sample output where the symbols carry documented meaning
 - [x] Keep links, commands, and example descriptions unchanged aside from markdown presentation cleanup
@@ -130,8 +130,8 @@
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required.
 - [x] Run full test suite before finalizing the PR and record results. (`pnpm test --run` passed: 167 files, 2272 tests, 286 skipped)
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results. (passed with existing warning baseline and no errors)
-- [ ] Commit completed checklist items as logical commits and push updates.
-- [ ] Mark PR Ready only after all story tasks are complete.
+- [x] Commit completed checklist items as logical commits and push updates.
+- [x] Mark PR Ready only after all story tasks are complete.
 - [ ] Wait for merge; do not merge directly from local branch.
 
 ### Notes
@@ -141,3 +141,5 @@
 - Validation:
   - `git diff --check` passed.
   - Targeted scan after edits leaves only functional checkmarks and box-drawing tree structure in `examples/README.md` and `examples/vertical-agents/README.md`.
+- PR:
+  - Draft PR #105 created and then marked ready for review: https://github.com/TVScoundrel/agentforge/pull/105

--- a/planning/checklists/epic-10-story-tasks.md
+++ b/planning/checklists/epic-10-story-tasks.md
@@ -110,3 +110,34 @@
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - Ready for review:
   - PR #104 ready for review: https://github.com/TVScoundrel/agentforge/pull/104
+
+---
+
+## ST-10006: Normalize Emoji Usage in Example Overview Docs
+
+**Branch:** `docs/st-10006-example-overview-docs-emoji-normalization`
+
+### Checklist
+- [x] Create branch `docs/st-10006-example-overview-docs-emoji-normalization`
+- [ ] Create draft PR with story ID in title
+- [x] Remove decorative emoji from targeted example overview and index markdown identified by the follow-up audit
+- [x] Preserve functional status markers and literal sample output where the symbols carry documented meaning
+- [x] Keep links, commands, and example descriptions unchanged aside from markdown presentation cleanup
+- [x] Add or update story documentation at `docs/st10006-example-overview-docs-emoji-normalization.md` (or document why not required).
+- [x] Define test strategy before implementation: this is a docs-only cleanup story with no practical failing automated test seam, so record the rationale and rely on targeted markdown diff review plus standard suite/lint verification.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation.
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required.
+- [x] Run full test suite before finalizing the PR and record results. (`pnpm test --run` passed: 167 files, 2272 tests, 286 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results. (passed with existing warning baseline and no errors)
+- [ ] Commit completed checklist items as logical commits and push updates.
+- [ ] Mark PR Ready only after all story tasks are complete.
+- [ ] Wait for merge; do not merge directly from local branch.
+
+### Notes
+
+- Test-first rationale:
+  - No practical failing automated test exists because the story changes markdown presentation only and does not modify runtime behavior or docs tooling logic.
+- Validation:
+  - `git diff --check` passed.
+  - Targeted scan after edits leaves only functional checkmarks and box-drawing tree structure in `examples/README.md` and `examples/vertical-agents/README.md`.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -134,7 +134,7 @@
 - Documentation-only cleanup work has a durable home instead of being forced into runtime epics
 - The epic remains open as an evergreen intake lane even when there are temporarily no active stories, so future docs-only work can be added without reopening or redefining the capability boundary
 
-**Stories:** ST-10001 through ST-10005
+**Stories:** ST-10001 through ST-10006
 
 #### Feature Context: Documentation Only Changes (from `planning/features/10-documentation-only-changes-feature-plan.md`)
 
@@ -1643,15 +1643,32 @@
 
 ---
 
+#### ST-10006: Normalize Emoji Usage in Example Overview Docs
+**User story:** As a developer browsing example catalogs, I want overview docs to avoid decorative emoji so navigation pages stay consistent and easy to scan.
+
+**Priority:** P2 (Medium)
+**Estimate:** 2 hours
+**Dependencies:** ST-10001 (merged), ST-10005 (merged)
+**Status:** In Review
+
+**Acceptance criteria:**
+- [ ] Example overview and index markdown targeted by the follow-up audit have decorative emoji removed from headings and similar navigation copy
+- [ ] Functional pass/fail markers and literal sample output remain intact where they convey real documented meaning
+- [ ] The cleanup does not change linked destinations, commands, example behavior, or code snippets beyond markdown presentation cleanup
+- [ ] Scope remains limited to overview/index markdown rather than per-example deep-dive READMEs or runtime code
+- [ ] Add or update story documentation at `docs/st10006-example-overview-docs-emoji-normalization.md`
+
+---
+
 ## Story Summary
 
-**Total Stories:** 81
+**Total Stories:** 82
 **By Priority:**
 - P0 (Critical): 17 stories
 - P1 (High): 27 stories
-- P2 (Medium): 37 stories
+- P2 (Medium): 38 stories
 
-**Total Estimated Effort:** ~291 hours (36.4 working days)
+**Total Estimated Effort:** ~293 hours (36.6 working days)
 
 **Dependency Chain:**
 1. Phase 1 (Foundation): ST-01001 → ST-01002 → ST-01003 → ST-01004
@@ -1663,4 +1680,4 @@
 7. Phase 7 (Skills Extraction): ST-07001 → ST-07002 → [ST-07003, ST-07004 parallel] → ST-07005; ST-07001 → ST-07006 (independent)
 8. Phase 8 (Type Safety Hardening): ST-08001 → [ST-08002, ST-08003, ST-08004 parallel]
 9. Phase 9 (SOLID Micro-Refactors): ST-09001 (Merged) → ST-09002 (Merged) → ST-09003 (Merged) → ST-09004 (Merged) → ST-09005 (Merged) → ST-09006 (Merged) → ST-09007 (Merged) → ST-09008 (Merged) → ST-09009 (Merged) → ST-09010 (Merged) → ST-09011 (Merged) → ST-09012 (Merged) → ST-09013 (Merged) → ST-09014 (Merged) → ST-09015 (Merged) → ST-09016 (Merged) → ST-09017 (Merged) → ST-09018 (Merged) → ST-09019 (Merged) → ST-09020 (Merged) → ST-09021 (Merged) → ST-09022 (Merged) → ST-09023 (Merged); ST-09025 (Merged) → ST-09026 (Merged) → ST-09031 (Merged); ST-09027 (Merged) → ST-09028 (Merged) → ST-09030 (Merged); ST-09032 → ST-09033; ST-09034 (Merged) → ST-09035 (Merged) → ST-09036 (Merged) → ST-09041; ST-09023 (Merged) and ST-09029 (Merged) → ST-09037; ST-09038 independent; ST-09023 (Merged) → ST-09039; ST-09024 (Merged) → ST-09040
-10. Phase 10 (Documentation Only Changes): ST-10001 → [ST-10002, ST-10003, ST-10004, ST-10005 parallel]; EP-10 remains evergreen and intentionally open for future docs-only stories even when no current stories are queued
+10. Phase 10 (Documentation Only Changes): ST-10001 → [ST-10002, ST-10003, ST-10004, ST-10005 parallel] → ST-10006; EP-10 remains evergreen and intentionally open for future docs-only stories even when no current stories are queued

--- a/planning/features/10-documentation-only-changes-feature-plan.md
+++ b/planning/features/10-documentation-only-changes-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-10 through EP-10
 **Status:** In Progress
 **Last Updated:** 2026-05-05
-**Active Story:** None
+**Active Story:** ST-10006 (In Review)
 
 ---
 
@@ -36,6 +36,7 @@
 - Cleaning public-facing docs such as the root README, package READMEs, and selected docs-site pages
 - Cleaning planning docs, internal docs, and example/template READMEs in separate, reviewable stories
 - Adding documentation style guidance that clarifies expected emoji usage going forward
+- Cleaning remaining example overview/index markdown slices after the initial repo-wide emoji cleanup
 
 ### Out of Scope
 - Runtime code changes or behavior changes
@@ -62,7 +63,7 @@
 
 ## Story Coverage by Epic
 
-- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (Merged), ST-10005 (Merged)
+- EP-10: ST-10001 (Merged), ST-10002 (Merged), ST-10003 (Merged), ST-10004 (Merged), ST-10005 (Merged), ST-10006 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -6,7 +6,7 @@
 
 - **Ready:** 5 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -29,7 +29,7 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-10006` - Normalize Emoji Usage in Example Overview Docs
 
 ---
 
@@ -131,4 +131,5 @@ _No stories currently in backlog_
 - Complete: ST-10005 - documentation emoji guardrails added to contributor guidance (PR #104, 2026-05-05)
 - Complete: ST-10004 - example/template docs emoji normalization merged (PR #102, 2026-05-05)
 - Complete: ST-10003 - planning and internal docs emoji normalization merged (PR #101, 2026-05-04)
+- EP-10 follow-up story `ST-10006` started on 2026-05-05 to clean remaining decorative emoji in example overview/index markdown while preserving functional status markers and literal sample output.
 - Current measured `no-explicit-any` baseline is `133` warnings (`cli 6`, `core 44`, `patterns 15`, `testing 3`, `tools 65`)


### PR DESCRIPTION
## Story

ST-10006 - Normalize Emoji Usage in Example Overview Docs

## What Changed

- removed decorative emoji from example overview headings in `examples/README.md` and `examples/vertical-agents/README.md`
- removed decorative arrow glyphs from the vertical-agent overview `View Documentation` links
- preserved functional test-status checkmarks and left literal sample output untouched
- moved `ST-10006` into `In Review` in the EP-10 trackers

## Acceptance Criteria Coverage

- example overview and index markdown now avoids decorative emoji in headings and navigation copy within the scoped files
- functional pass/fail markers and literal sample output remain intact where they carry real meaning
- no linked destination, command, example behavior, or code snippet changed beyond markdown presentation cleanup
- scope stayed limited to overview/index markdown rather than per-example deep-dive READMEs or runtime code
- story documentation was added at `docs/st10006-example-overview-docs-emoji-normalization.md`

## Test Strategy

- no failing automated test was practical because this story changes markdown presentation only and does not modify runtime behavior or docs tooling behavior
- validation relies on targeted markdown diff review, a scoped follow-up emoji scan, and standard repository quality gates

## Validation Performed

- `git diff --check`
- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
