### PR TITLE
ST-09037 Tighten ReAct builder and prompt boundary contracts

### DIFF
--- a/.pr-body-st-09037.md
+++ b/.pr-body-st-09037.md
@@ -1,0 +1,36 @@
+## Story
+
+ST-09037 - Tighten ReAct Builder and Prompt Boundary Contracts
+
+## What Changed
+
+- replaced broad `any` seams in `packages/patterns/src/react/{types,builder,agent,prompts}.ts` with explicit ReAct-local aliases for tool sources, checkpointers, prompt descriptors, and the compiled graph return type
+- preserved existing ReAct builder behavior, including deprecated `withLLM(...)`, `ToolRegistry` or array tool inputs, stop-condition routing, and `checkpointer: true` nested-graph behavior
+- added focused coverage for builder checkpointer handling, prompt helper formatting, and a standalone typecheck regression for the narrowed contracts
+- recorded the explicit-`any` warning reduction for the touched ReAct boundary files
+
+## Acceptance Criteria Coverage
+
+- `types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` now use exported aliases and unknown-first contracts instead of broad tool/schema/checkpointer/compiled-graph `any` surfaces
+- ReAct builder usage, `withLLM(...)`, stop-condition routing, checkpointer handling, and tool prompt formatting behavior remained unchanged
+- focused coverage now exercises builder validation, array tools, `ToolRegistry`, checkpointer handling, custom stop conditions, and prompt formatting
+- touched-file explicit-`any` deltas and the package/workspace baseline improvements are recorded in `docs/st09037-react-builder-prompt-boundary-contracts.md`
+
+## Test Strategy
+
+- first failing test path was a standalone typecheck fixture at `packages/patterns/tests/react/contracts.typecheck.ts` that asserted the narrowed builder/agent/prompt contracts
+- additional focused runtime tests cover builder checkpointer inputs plus prompt helper formatting
+- broader validation relies on the patterns package typecheck, the explicit-`any` baseline gate, the full test suite, and repo lint
+
+## Validation Performed
+
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/patterns/tests/react/contracts.typecheck.ts`
+- `pnpm test --run packages/patterns/tests/react/builder.test.ts packages/patterns/tests/react/agent.test.ts packages/patterns/tests/react/integration.test.ts packages/patterns/tests/react/prompts.test.ts`
+- `pnpm --filter @agentforge/patterns typecheck`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Draft

--- a/.pr-body-st-09037.md
+++ b/.pr-body-st-09037.md
@@ -33,4 +33,4 @@ ST-09037 - Tighten ReAct Builder and Prompt Boundary Contracts
 
 ## Status
 
-Draft
+Ready for review

--- a/docs/st09037-react-builder-prompt-boundary-contracts.md
+++ b/docs/st09037-react-builder-prompt-boundary-contracts.md
@@ -2,7 +2,7 @@
 
 **Story:** ST-09037 - Tighten ReAct Builder and Prompt Boundary Contracts
 **Epic:** EP-09 - SOLID Micro-Refactors and Type Boundary Hardening
-**Status:** In Progress
+**Status:** In Review
 
 ## Scope
 

--- a/docs/st09037-react-builder-prompt-boundary-contracts.md
+++ b/docs/st09037-react-builder-prompt-boundary-contracts.md
@@ -1,0 +1,59 @@
+# ST-09037: ReAct Builder and Prompt Boundary Contracts
+
+**Story:** ST-09037 - Tighten ReAct Builder and Prompt Boundary Contracts
+**Epic:** EP-09 - SOLID Micro-Refactors and Type Boundary Hardening
+**Status:** In Progress
+
+## Scope
+
+This story narrows the ReAct setup surface around tool collections, checkpointers, compiled graph return typing, and prompt helper descriptors without changing public runtime behavior.
+
+Touched production files:
+- `packages/patterns/src/react/types.ts`
+- `packages/patterns/src/react/builder.ts`
+- `packages/patterns/src/react/agent.ts`
+- `packages/patterns/src/react/prompts.ts`
+
+Touched focused tests:
+- `packages/patterns/tests/react/builder.test.ts`
+- `packages/patterns/tests/react/prompts.test.ts`
+- `packages/patterns/tests/react/contracts.typecheck.ts`
+
+## Test Strategy
+
+First failing test path:
+- A standalone typecheck fixture at `packages/patterns/tests/react/contracts.typecheck.ts` asserts the narrowed contracts for:
+  - compiled ReAct graph state/update typing
+  - builder `withCheckpointer(...)`
+  - builder tool-array input
+  - prompt tool descriptor schema typing
+- Before the refactor, the targeted typecheck failed because the ReAct builder/agent/prompt seams still exposed broad `any` contracts and unused `@ts-expect-error` assertions.
+
+Focused validation:
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/patterns/tests/react/contracts.typecheck.ts`
+- `pnpm test --run packages/patterns/tests/react/builder.test.ts packages/patterns/tests/react/agent.test.ts packages/patterns/tests/react/integration.test.ts packages/patterns/tests/react/prompts.test.ts`
+- `pnpm --filter @agentforge/patterns typecheck`
+
+Broader validation:
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Explicit `any` Delta
+
+Touched-file deltas:
+- `packages/patterns/src/react/types.ts`: `2 -> 0`
+- `packages/patterns/src/react/builder.ts`: `5 -> 0`
+- `packages/patterns/src/react/agent.ts`: `4 -> 0`
+- `packages/patterns/src/react/prompts.ts`: `1 -> 0`
+
+Aggregate impact:
+- touched ReAct files: `12 -> 0`
+- `patterns` baseline: `15/28 -> 3/28`
+- workspace baseline: `133/289 -> 121/289`
+
+## Implementation Notes
+
+- Introduced shared ReAct-local aliases for tool sources, checkpointer inputs, prompt tool descriptors, and the compiled graph return type.
+- Preserved deprecated `withLLM(...)`, tool-array and `ToolRegistry` inputs, custom stop-condition routing, and `checkpointer: true` parent-graph behavior.
+- Added prompt helper coverage for tool formatting, scratchpad rendering, and thought rendering order.

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -101,14 +101,6 @@ export function createReActAgent(
   config: ReActAgentConfig,
   options?: ReActBuilderOptions
 ): ReActAgentGraph {
-  const toRuntimeTool = (tool: ReActToolInput): ReActTool => ({
-    ...tool,
-    invoke: async (input) => tool.invoke(input as never),
-    execute: tool.execute
-      ? async (input) => tool.execute?.(input as never)
-      : undefined,
-  });
-
   // Extract configuration with defaults
   const {
     model,
@@ -129,7 +121,9 @@ export function createReActAgent(
   // Convert tools to array if it's a registry
   const toolArray: ReActTool[] = tools instanceof ToolRegistry
     ? tools.getAll()
-    : tools.map(toRuntimeTool);
+    // Array-provided tools are already runtime-compatible Tool instances.
+    // This intersection cast preserves object identity and prototype behavior.
+    : tools as ReActToolInput[] & ReActTool[];
 
   // Node names (for debugging/observability)
   const REASONING_NODE = nodeNames.reasoning || 'reasoning';

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -7,9 +7,14 @@
  */
 
 import { StateGraph, END } from '@langchain/langgraph';
-import type { CompiledStateGraph } from '@langchain/langgraph';
-import { ToolRegistry, type Tool } from '@agentforge/core';
-import type { ReActAgentConfig, ReActBuilderOptions } from './types.js';
+import { ToolRegistry } from '@agentforge/core';
+import type {
+  ReActAgentConfig,
+  ReActAgentGraph,
+  ReActBuilderOptions,
+  ReActCheckpointer,
+  ReActTool,
+} from './types.js';
 import { ReActState, type ReActStateType } from './state.js';
 import { DEFAULT_REACT_SYSTEM_PROMPT } from './prompts.js';
 import { createReasoningNode, createActionNode, createObservationNode } from './nodes.js';
@@ -94,7 +99,7 @@ import { createReasoningNode, createActionNode, createObservationNode } from './
 export function createReActAgent(
   config: ReActAgentConfig,
   options?: ReActBuilderOptions
-): CompiledStateGraph<any, any> {
+): ReActAgentGraph {
   // Extract configuration with defaults
   const {
     model,
@@ -113,7 +118,7 @@ export function createReActAgent(
   } = options || {};
 
   // Convert tools to array if it's a registry
-  const toolArray: Tool[] = tools instanceof ToolRegistry
+  const toolArray: ReActTool[] = tools instanceof ToolRegistry
     ? tools.getAll()
     : tools;
 
@@ -174,7 +179,7 @@ export function createReActAgent(
     .addNode(ACTION_NODE, actionNode)
     .addNode(OBSERVATION_NODE, observationNode)
     .addEdge('__start__', REASONING_NODE)
-    .addConditionalEdges(REASONING_NODE, shouldContinue as any)
+    .addConditionalEdges(REASONING_NODE, shouldContinue)
     .addEdge(ACTION_NODE, OBSERVATION_NODE)
     .addEdge(OBSERVATION_NODE, REASONING_NODE);
 
@@ -182,11 +187,11 @@ export function createReActAgent(
   // - If checkpointer is a BaseCheckpointSaver instance, use it directly
   // - If checkpointer is `true`, use parent's checkpointer with separate namespace (for nested graphs)
   // - If checkpointer is undefined, no checkpointing
-  const checkpointerConfig = checkpointer === true
+  const checkpointerConfig: { checkpointer: ReActCheckpointer } | undefined = checkpointer === true
     ? { checkpointer: true }  // Use parent's checkpointer with separate namespace
     : checkpointer
     ? { checkpointer }  // Use provided checkpointer instance
     : undefined;  // No checkpointing
 
-  return workflow.compile(checkpointerConfig) as any;
+  return workflow.compile(checkpointerConfig) as unknown as ReActAgentGraph;
 }

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -14,6 +14,7 @@ import type {
   ReActBuilderOptions,
   ReActCheckpointer,
   ReActTool,
+  ReActToolInput,
 } from './types.js';
 import { ReActState, type ReActStateType } from './state.js';
 import { DEFAULT_REACT_SYSTEM_PROMPT } from './prompts.js';
@@ -100,6 +101,14 @@ export function createReActAgent(
   config: ReActAgentConfig,
   options?: ReActBuilderOptions
 ): ReActAgentGraph {
+  const toRuntimeTool = (tool: ReActToolInput): ReActTool => ({
+    ...tool,
+    invoke: async (input) => tool.invoke(input as never),
+    execute: tool.execute
+      ? async (input) => tool.execute?.(input as never)
+      : undefined,
+  });
+
   // Extract configuration with defaults
   const {
     model,
@@ -120,7 +129,7 @@ export function createReActAgent(
   // Convert tools to array if it's a registry
   const toolArray: ReActTool[] = tools instanceof ToolRegistry
     ? tools.getAll()
-    : tools as unknown as ReActTool[];
+    : tools.map(toRuntimeTool);
 
   // Node names (for debugging/observability)
   const REASONING_NODE = nodeNames.reasoning || 'reasoning';

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -122,7 +122,7 @@ export function createReActAgent(
   const toolArray: ReActTool[] = tools instanceof ToolRegistry
     ? tools.getAll()
     // Array-provided tools are already runtime-compatible Tool instances.
-    // This intersection cast preserves object identity and prototype behavior.
+    // This intersection cast only erases the public input type at compile time.
     : tools as ReActToolInput[] & ReActTool[];
 
   // Node names (for debugging/observability)

--- a/packages/patterns/src/react/agent.ts
+++ b/packages/patterns/src/react/agent.ts
@@ -120,7 +120,7 @@ export function createReActAgent(
   // Convert tools to array if it's a registry
   const toolArray: ReActTool[] = tools instanceof ToolRegistry
     ? tools.getAll()
-    : tools;
+    : tools as unknown as ReActTool[];
 
   // Node names (for debugging/observability)
   const REASONING_NODE = nodeNames.reasoning || 'reasoning';

--- a/packages/patterns/src/react/builder.ts
+++ b/packages/patterns/src/react/builder.ts
@@ -16,9 +16,14 @@
  */
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import type { CompiledStateGraph } from '@langchain/langgraph';
-import { ToolRegistry, type Tool } from '@agentforge/core';
-import type { ReActAgentConfig, ReActBuilderOptions, StopConditionFn } from './types.js';
+import type {
+  ReActAgentConfig,
+  ReActAgentGraph,
+  ReActBuilderOptions,
+  ReActCheckpointer,
+  ReActToolSource,
+  StopConditionFn,
+} from './types.js';
 import { createReActAgent } from './agent.js';
 import { DEFAULT_REACT_SYSTEM_PROMPT } from './prompts.js';
 
@@ -54,7 +59,7 @@ export class ReActAgentBuilder {
    *
    * @param tools - Tool registry or array of tools
    */
-  withTools(tools: ToolRegistry | Tool<any, any>[]): this {
+  withTools(tools: ReActToolSource): this {
     this.config.tools = tools;
     return this;
   }
@@ -152,7 +157,7 @@ export class ReActAgentBuilder {
    *   .build();
    * ```
    */
-  withCheckpointer(checkpointer: any): this {
+  withCheckpointer(checkpointer: ReActCheckpointer): this {
     this.config.checkpointer = checkpointer;
     return this;
   }
@@ -163,7 +168,7 @@ export class ReActAgentBuilder {
    * @returns A compiled LangGraph StateGraph
    * @throws Error if required configuration is missing
    */
-  build(): CompiledStateGraph<any, any> {
+  build(): ReActAgentGraph {
     // Validate required fields
     if (!this.config.model) {
       throw new Error('ReActAgentBuilder: model is required. Use withModel() to set it.');
@@ -204,4 +209,3 @@ export class ReActAgentBuilder {
 export function createReActAgentBuilder(): ReActAgentBuilder {
   return new ReActAgentBuilder();
 }
-

--- a/packages/patterns/src/react/prompts.ts
+++ b/packages/patterns/src/react/prompts.ts
@@ -4,6 +4,8 @@
  * @module langgraph/patterns/react/prompts
  */
 
+import type { ReActPromptToolDescriptor } from './types.js';
+
 /**
  * Default system prompt for ReAct agents
  */
@@ -64,7 +66,7 @@ Or if you have enough information to answer, respond with:
 /**
  * Format tools for prompt injection
  */
-export function formatToolsForPrompt(tools: Array<{ name: string; description: string; schema: any }>): string {
+export function formatToolsForPrompt(tools: ReActPromptToolDescriptor[]): string {
   return tools
     .map((tool, index) => {
       return `${index + 1}. ${tool.name}: ${tool.description}`;
@@ -103,4 +105,3 @@ export function formatThoughts(thoughts: Array<{ content: string }>): string {
     .map((thought, index) => `${index + 1}. ${thought.content}`)
     .join('\n');
 }
-

--- a/packages/patterns/src/react/types.ts
+++ b/packages/patterns/src/react/types.ts
@@ -5,9 +5,20 @@
  */
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import type { BaseCheckpointSaver } from '@langchain/langgraph';
+import type { BaseCheckpointSaver, CompiledStateGraph } from '@langchain/langgraph';
 import type { ToolRegistry, Tool } from '@agentforge/core';
+import type { ZodSchema } from 'zod';
 import type { ReActStateType } from './state.js';
+
+export type ReActTool = Tool<unknown, unknown>;
+export type ReActToolSource = ToolRegistry | ReActTool[];
+export type ReActCheckpointer = BaseCheckpointSaver | true;
+export type ReActPromptToolDescriptor = {
+  name: string;
+  description: string;
+  schema: ZodSchema<unknown>;
+};
+export type ReActAgentGraph = CompiledStateGraph<ReActStateType, unknown>;
 
 /**
  * Configuration for creating a ReAct agent
@@ -22,7 +33,7 @@ export interface ReActAgentConfig {
    * Tools available to the agent
    * Can be a ToolRegistry or an array of Tools
    */
-  tools: ToolRegistry | Tool<any, any>[];
+  tools: ReActToolSource;
 
   /**
    * System prompt for the agent
@@ -79,7 +90,7 @@ export interface ReActAgentConfig {
    * });
    * ```
    */
-  checkpointer?: BaseCheckpointSaver | true;
+  checkpointer?: ReActCheckpointer;
 
   /**
    * Enable tool call deduplication to prevent calling the same tool with identical parameters multiple times

--- a/packages/patterns/src/react/types.ts
+++ b/packages/patterns/src/react/types.ts
@@ -6,19 +6,16 @@
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseCheckpointSaver, CompiledStateGraph } from '@langchain/langgraph';
-import type { ToolRegistry, Tool, ToolMetadata } from '@agentforge/core';
+import type { ToolRegistry, Tool } from '@agentforge/core';
 import type { ZodSchema } from 'zod';
 import type { ReActStateType } from './state.js';
 
 export type ReActTool = Tool<unknown, unknown>;
 // Preserve assignability for heterogeneous Tool<TInput, TOutput> values at the public
-// boundary by erasing the invoke parameter while keeping schema metadata readable.
-export interface ReActToolInput {
-  metadata: ToolMetadata;
-  schema: ZodSchema<unknown>;
-  invoke: (input: never) => Promise<unknown>;
-  execute?: (input: never) => Promise<unknown>;
-}
+// boundary by deriving from Tool while erasing only the callable input parameter.
+export type ReActToolInput =
+  Omit<ReActTool, 'invoke' | 'execute'> &
+  Pick<Tool<never, unknown>, 'invoke' | 'execute'>;
 export type ReActToolSource = ToolRegistry | ReActToolInput[];
 export type ReActCheckpointer = BaseCheckpointSaver | true;
 export type ReActPromptToolDescriptor = {

--- a/packages/patterns/src/react/types.ts
+++ b/packages/patterns/src/react/types.ts
@@ -6,12 +6,20 @@
 
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseCheckpointSaver, CompiledStateGraph } from '@langchain/langgraph';
-import type { ToolRegistry, Tool } from '@agentforge/core';
+import type { ToolRegistry, Tool, ToolMetadata } from '@agentforge/core';
 import type { ZodSchema } from 'zod';
 import type { ReActStateType } from './state.js';
 
 export type ReActTool = Tool<unknown, unknown>;
-export type ReActToolSource = ToolRegistry | ReActTool[];
+// Preserve assignability for heterogeneous Tool<TInput, TOutput> values at the public
+// boundary by erasing the invoke parameter while keeping schema metadata readable.
+export interface ReActToolInput {
+  metadata: ToolMetadata;
+  schema: ZodSchema<unknown>;
+  invoke: (input: never) => Promise<unknown>;
+  execute?: (input: never) => Promise<unknown>;
+}
+export type ReActToolSource = ToolRegistry | ReActToolInput[];
 export type ReActCheckpointer = BaseCheckpointSaver | true;
 export type ReActPromptToolDescriptor = {
   name: string;

--- a/packages/patterns/tests/react/builder.test.ts
+++ b/packages/patterns/tests/react/builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { ReActAgentBuilder, createReActAgentBuilder } from '../../src/react/builder.js';
 import { ToolRegistry, toolBuilder, ToolCategory } from '@agentforge/core';
 import { createMockLLM } from '@agentforge/testing';
+import { MemorySaver } from '@langchain/langgraph';
 import { z } from 'zod';
 
 const mockLLM = createMockLLM({ responses: ['Mock response'] }) as any;
@@ -90,6 +91,16 @@ describe('ReActAgentBuilder', () => {
       });
       expect(builder).toBeInstanceOf(ReActAgentBuilder);
     });
+
+    it('should accept parent checkpointer mode', () => {
+      const builder = new ReActAgentBuilder().withCheckpointer(true);
+      expect(builder).toBeInstanceOf(ReActAgentBuilder);
+    });
+
+    it('should accept explicit checkpointer instances', () => {
+      const builder = new ReActAgentBuilder().withCheckpointer(new MemorySaver());
+      expect(builder).toBeInstanceOf(ReActAgentBuilder);
+    });
   });
 
   describe('Validation', () => {
@@ -165,4 +176,3 @@ describe('ReActAgentBuilder', () => {
     });
   });
 });
-

--- a/packages/patterns/tests/react/contracts.typecheck.ts
+++ b/packages/patterns/tests/react/contracts.typecheck.ts
@@ -1,0 +1,45 @@
+import type { CompiledStateGraph, BaseCheckpointSaver } from '@langchain/langgraph';
+import type { Tool, ToolRegistry } from '@agentforge/core';
+import { ReActAgentBuilder } from '../../src/react/builder.js';
+import { createReActAgent } from '../../src/react/agent.js';
+import { formatToolsForPrompt } from '../../src/react/prompts.js';
+import type { ReActStateType } from '../../src/react/state.js';
+import { z, type ZodSchema } from 'zod';
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends
+  (<T>() => T extends Right ? 1 : 2) ? true : false;
+type AssertTrue<T extends true> = T;
+type GraphState<T> = T extends CompiledStateGraph<infer TState, infer _TUpdate> ? TState : never;
+type GraphUpdate<T> = T extends CompiledStateGraph<infer _TState, infer TUpdate> ? TUpdate : never;
+
+type BuilderCheckpointerArg = Parameters<ReActAgentBuilder['withCheckpointer']>[0];
+type BuilderToolsArg = Parameters<ReActAgentBuilder['withTools']>[0];
+type BuilderToolArrayArg = Exclude<BuilderToolsArg, ToolRegistry>;
+type PromptToolDescriptor = Parameters<typeof formatToolsForPrompt>[0][number];
+
+type _reactAgentStateMatchesReActState = AssertTrue<
+  Equal<GraphState<ReturnType<typeof createReActAgent>>, ReActStateType>
+>;
+type _reactAgentUpdateIsUnknown = AssertTrue<
+  Equal<GraphUpdate<ReturnType<typeof createReActAgent>>, unknown>
+>;
+type _builderCheckpointerMatchesContract = AssertTrue<
+  Equal<BuilderCheckpointerArg, BaseCheckpointSaver | true>
+>;
+type _builderToolsArrayMatchesContract = AssertTrue<
+  Equal<BuilderToolArrayArg, Tool<unknown, unknown>[]>
+>;
+type _promptToolDescriptorSchemaMatchesContract = AssertTrue<
+  Equal<PromptToolDescriptor['schema'], ZodSchema<unknown>>
+>;
+
+// @ts-expect-error invalid checkpointer values should be rejected by the builder contract
+new ReActAgentBuilder().withCheckpointer('invalid-checkpointer');
+
+// @ts-expect-error prompt tool descriptors should reject non-schema primitive values
+formatToolsForPrompt([{ name: 'bad-tool', description: 'desc', schema: 123 }]);
+
+formatToolsForPrompt([
+  { name: 'good-tool', description: 'desc', schema: z.object({ input: z.string() }) },
+]);

--- a/packages/patterns/tests/react/contracts.typecheck.ts
+++ b/packages/patterns/tests/react/contracts.typecheck.ts
@@ -4,6 +4,7 @@ import { ReActAgentBuilder } from '../../src/react/builder.js';
 import { createReActAgent } from '../../src/react/agent.js';
 import { formatToolsForPrompt } from '../../src/react/prompts.js';
 import type { ReActStateType } from '../../src/react/state.js';
+import type { ReActToolInput } from '../../src/react/types.js';
 import { z, type ZodSchema } from 'zod';
 
 type Equal<Left, Right> =
@@ -27,12 +28,16 @@ type _reactAgentUpdateIsUnknown = AssertTrue<
 type _builderCheckpointerMatchesContract = AssertTrue<
   Equal<BuilderCheckpointerArg, BaseCheckpointSaver | true>
 >;
-type _builderToolsArrayMatchesContract = AssertTrue<
-  Equal<BuilderToolArrayArg, Tool<unknown, unknown>[]>
+type _builderToolsArrayIsPublicToolInputArray = AssertTrue<
+  Equal<BuilderToolArrayArg, ReActToolInput[]>
 >;
 type _promptToolDescriptorSchemaMatchesContract = AssertTrue<
   Equal<PromptToolDescriptor['schema'], ZodSchema<unknown>>
 >;
+
+declare const typedTool: Tool<{ input: string }, { ok: boolean }>;
+const validToolArray: BuilderToolArrayArg = [typedTool];
+new ReActAgentBuilder().withTools(validToolArray);
 
 // @ts-expect-error invalid checkpointer values should be rejected by the builder contract
 new ReActAgentBuilder().withCheckpointer('invalid-checkpointer');

--- a/packages/patterns/tests/react/prompts.test.ts
+++ b/packages/patterns/tests/react/prompts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  formatScratchpad,
+  formatThoughts,
+  formatToolsForPrompt,
+} from '../../src/react/prompts.js';
+
+describe('ReAct prompt helpers', () => {
+  it('formats tool descriptors without changing order or labels', () => {
+    const formatted = formatToolsForPrompt([
+      {
+        name: 'search-web',
+        description: 'Search the web for information',
+        schema: z.object({ query: z.string() }),
+      },
+      {
+        name: 'read-file',
+        description: 'Read a file from disk',
+        schema: z.object({ path: z.string() }),
+      },
+    ]);
+
+    expect(formatted).toBe(
+      '1. search-web: Search the web for information\n2. read-file: Read a file from disk'
+    );
+  });
+
+  it('formats scratchpad entries with thought, action, and observation blocks', () => {
+    const formatted = formatScratchpad([
+      {
+        step: 1,
+        thought: 'Need external context',
+        action: 'search-web({"query":"agentforge"})',
+        observation: 'Found docs',
+      },
+    ]);
+
+    expect(formatted).toContain('Step 1:');
+    expect(formatted).toContain('Thought: Need external context');
+    expect(formatted).toContain('Action: search-web({"query":"agentforge"})');
+    expect(formatted).toContain('Observation: Found docs');
+  });
+
+  it('formats thoughts in order and preserves empty fallbacks', () => {
+    expect(formatThoughts([])).toBe('No previous thoughts.');
+    expect(formatThoughts([{ content: 'first' }, { content: 'second' }])).toBe('1. first\n2. second');
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1415,7 +1415,7 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09037-react-builder-prompt-boundary-contracts`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Define test strategy before implementation: cover builder validation, registry tools, array tools, checkpointer handling, custom stop conditions, and prompt formatting; first failing test should type-check the narrowed builder/prompt contracts
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
 - [x] Replace broad tool/schema/checkpointer/compiled-graph `any` surfaces in `packages/patterns/src/react/types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` with exported aliases or unknown-first contracts where practical
@@ -1426,8 +1426,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results. (`pnpm test --run` passed: 168 files, 2277 tests, 286 skipped)
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results. (passed with existing warning baseline and no errors)
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes
@@ -1445,6 +1445,8 @@ Implementation notes:
 - Explicit-`any` baseline:
   - `pnpm lint:explicit-any:baseline` -> `121/289` warnings overall, `patterns 3/28`
   - Touched ReAct files improved from `12 -> 0` explicit-`any` occurrences
+- PR:
+  - Draft PR #106 created: https://github.com/TVScoundrel/agentforge/pull/106
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1414,21 +1414,37 @@ Implementation notes:
 **Branch:** `fix/st-09037-react-builder-prompt-boundary-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09037-react-builder-prompt-boundary-contracts`
+- [x] Create branch `fix/st-09037-react-builder-prompt-boundary-contracts`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover builder validation, registry tools, array tools, checkpointer handling, custom stop conditions, and prompt formatting; first failing test should type-check the narrowed builder/prompt contracts
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad tool/schema/checkpointer/compiled-graph `any` surfaces in `packages/patterns/src/react/types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` with exported aliases or unknown-first contracts where practical
-- [ ] Preserve existing ReAct builder usage, deprecated `withLLM(...)`, stop-condition routing, checkpointer handling, and tool prompt formatting behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09037-react-builder-prompt-boundary-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Define test strategy before implementation: cover builder validation, registry tools, array tools, checkpointer handling, custom stop conditions, and prompt formatting; first failing test should type-check the narrowed builder/prompt contracts
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad tool/schema/checkpointer/compiled-graph `any` surfaces in `packages/patterns/src/react/types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` with exported aliases or unknown-first contracts where practical
+- [x] Preserve existing ReAct builder usage, deprecated `withLLM(...)`, stop-condition routing, checkpointer handling, and tool prompt formatting behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09037-react-builder-prompt-boundary-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results. (`pnpm test --run` passed: 168 files, 2277 tests, 286 skipped)
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results. (passed with existing warning baseline and no errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Test-first evidence:
+  - Initial contract gate failed as expected:
+    - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/patterns/tests/react/contracts.typecheck.ts`
+  - Failure mode before the refactor:
+    - broad ReAct builder/agent/prompt contracts failed exact type assertions
+    - `@ts-expect-error` checks for invalid builder checkpointer and invalid prompt schema were unused
+- Focused validation after the refactor:
+  - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/patterns/tests/react/contracts.typecheck.ts`
+  - `pnpm test --run packages/patterns/tests/react/builder.test.ts packages/patterns/tests/react/agent.test.ts packages/patterns/tests/react/integration.test.ts packages/patterns/tests/react/prompts.test.ts` -> `4` files, `44` tests passed
+  - `pnpm --filter @agentforge/patterns typecheck` passed
+- Explicit-`any` baseline:
+  - `pnpm lint:explicit-any:baseline` -> `121/289` warnings overall, `patterns 3/28`
+  - Touched ReAct files improved from `12 -> 0` explicit-`any` occurrences
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1479,7 +1479,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09023, ST-09029
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` replace broad tool/schema/checkpointer/compiled-graph `any` surfaces with exported aliases or unknown-first contracts where practical

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1479,7 +1479,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09023, ST-09029
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` replace broad tool/schema/checkpointer/compiled-graph `any` surfaces with exported aliases or unknown-first contracts where practical

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-05
-**Active Story:** ST-09037 (Ready)
+**Active Story:** ST-09037 (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,7 +2,7 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-05
+**Last Updated:** 2026-05-06
 **Active Story:** ST-09037 (In Review)
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-05
-**Active Story:** ST-09037 (In Progress)
+**Active Story:** ST-09037 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -6,8 +6,8 @@
 
 - **Ready:** 5 stories
 - **Ready:** 4 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -23,13 +23,13 @@
 
 ## In Progress
 
-- `ST-09037` - Tighten ReAct Builder and Prompt Boundary Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09037` - Tighten ReAct Builder and Prompt Boundary Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,7 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **Ready:** 4 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,7 +15,6 @@
 
 ## Ready
 
-- `ST-09037` - Tighten ReAct Builder and Prompt Boundary Contracts
 - `ST-09038` - Extract Data Transformer Object Path Helpers
 - `ST-09039` - Tighten Core Mock Tool Testing Helper Contracts
 - `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
@@ -23,7 +23,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09037` - Tighten ReAct Builder and Prompt Boundary Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,6 +1,6 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-05
+**Last Updated:** 2026-05-06
 
 ## Queue Status Summary
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,7 +4,6 @@
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
 - **Ready:** 4 stories
 - **In Progress:** 0 stories
 - **In Review:** 1 story


### PR DESCRIPTION
## Story

ST-09037 - Tighten ReAct Builder and Prompt Boundary Contracts

## What Changed

- replaced broad `any` seams in `packages/patterns/src/react/{types,builder,agent,prompts}.ts` with explicit ReAct-local aliases for tool sources, checkpointers, prompt descriptors, and the compiled graph return type
- preserved existing ReAct builder behavior, including deprecated `withLLM(...)`, `ToolRegistry` or array tool inputs, stop-condition routing, and `checkpointer: true` nested-graph behavior
- added focused coverage for builder checkpointer handling, prompt helper formatting, and a standalone typecheck regression for the narrowed contracts
- recorded the explicit-`any` warning reduction for the touched ReAct boundary files

## Acceptance Criteria Coverage

- `types.ts`, `builder.ts`, `agent.ts`, and `prompts.ts` now use exported aliases and unknown-first contracts instead of broad tool/schema/checkpointer/compiled-graph `any` surfaces
- ReAct builder usage, `withLLM(...)`, stop-condition routing, checkpointer handling, and tool prompt formatting behavior remained unchanged
- focused coverage now exercises builder validation, array tools, `ToolRegistry`, checkpointer handling, custom stop conditions, and prompt formatting
- touched-file explicit-`any` deltas and the package/workspace baseline improvements are recorded in `docs/st09037-react-builder-prompt-boundary-contracts.md`

## Test Strategy

- first failing test path was a standalone typecheck fixture at `packages/patterns/tests/react/contracts.typecheck.ts` that asserted the narrowed builder/agent/prompt contracts
- additional focused runtime tests cover builder checkpointer inputs plus prompt helper formatting
- broader validation relies on the patterns package typecheck, the explicit-`any` baseline gate, the full test suite, and repo lint

## Validation Performed

- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/patterns/tests/react/contracts.typecheck.ts`
- `pnpm test --run packages/patterns/tests/react/builder.test.ts packages/patterns/tests/react/agent.test.ts packages/patterns/tests/react/integration.test.ts packages/patterns/tests/react/prompts.test.ts`
- `pnpm --filter @agentforge/patterns typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
