### PR TITLE
refactor(st-09039): tighten core mock tool testing helper contracts

### DIFF
--- a/.pr-body-st-09039.md
+++ b/.pr-body-st-09039.md
@@ -1,0 +1,39 @@
+## Story
+
+ST-09039 - Tighten Core Mock Tool Testing Helper Contracts
+
+## What Changed
+
+- replaced broad mock-tool and tool-simulator `any` seams in `packages/core/src/tools/testing.ts` with generic and unknown-first helper contracts
+- made `createMockTool(...)` preserve typed input/output payloads for exact-match responses, predicate responses, default responses, and invocation history
+- made `createToolSimulator(...)` infer input/output payloads from the selected named tool so `execute(name, input)` and `getInvocations(name)` stay type-safe
+- added focused runtime coverage in `packages/core/tests/tools/testing.test.ts`
+- added a standalone typecheck regression fixture in `packages/core/tests/tools/testing.typecheck.ts`
+- recorded the touched-file explicit-`any` improvement in `docs/st09039-core-mock-tool-testing-contracts.md`
+
+## Acceptance Criteria Coverage
+
+- `packages/core/src/tools/testing.ts` now replaces broad mock response, default response, invocation, and simulator input/output contracts with generic or unknown-first helper types
+- mock response matching, default responses, random errors, latency simulation, invocation recording, and simulator execution behavior remain unchanged
+- focused tests now cover typed mock responses, predicate matching, configured error recording, simulator missing-tool errors, and invocation clearing
+- touched files do not regress on explicit-`any` warnings; the main helper file improved from `8 -> 0` and the outcome is recorded in the story doc
+- story documentation was added at `docs/st09039-core-mock-tool-testing-contracts.md`
+
+## Test Strategy
+
+- first failing automated gate was the new standalone typecheck fixture `packages/core/tests/tools/testing.typecheck.ts`, which initially failed because the helper API did not yet expose generic input/output contracts
+- focused runtime tests verify preserved mock matching behavior, error bookkeeping, missing-tool failure behavior, and invocation clearing
+- full-suite validation was still run because the simulator helpers are shared test infrastructure used across packages
+
+## Validation Performed
+
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts`
+- `pnpm test --run packages/core/tests/tools/testing.test.ts`
+- `pnpm --filter @agentforge/core typecheck`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Ready for review

--- a/docs/st09039-core-mock-tool-testing-contracts.md
+++ b/docs/st09039-core-mock-tool-testing-contracts.md
@@ -1,0 +1,61 @@
+# ST-09039: Tighten Core Mock Tool Testing Helper Contracts
+
+## Summary
+
+Tightened the mock-tool and tool-simulator helper contracts in `packages/core/src/tools/testing.ts` so typed test helpers no longer rely on broad `any` payloads. The change preserves existing runtime matching and invocation behavior while making named-tool simulator execution and invocation inspection type-safe.
+
+## Scope
+
+Touched files:
+- `packages/core/src/tools/testing.ts`
+- `packages/core/tests/tools/testing.typecheck.ts`
+- `packages/core/tests/tools/testing.test.ts`
+
+## Test Strategy
+
+Test-first path used.
+
+The first failing automated gate was a standalone typecheck fixture for generic helper usage:
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts`
+- initial failure included:
+  - `Expected 0 type arguments, but got 2`
+  - `Unused '@ts-expect-error' directive`
+
+That failure proved `createMockTool(...)` and `createToolSimulator(...)` did not yet expose the intended generic input/output contracts.
+
+## Validation
+
+Focused validation after implementation:
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts`
+- `pnpm test --run packages/core/tests/tools/testing.test.ts`
+- `pnpm --filter @agentforge/core typecheck`
+- `pnpm lint:explicit-any:baseline`
+
+Coverage added in the focused regression files:
+- generic mock-tool input/output inference
+- predicate response matching
+- configured error recording
+- simulator missing-tool errors
+- simulator invocation clearing
+- named-tool simulator input/output inference and invocation typing
+
+## Explicit-any Delta
+
+Touched helper file:
+- `packages/core/src/tools/testing.ts`: `8 -> 0`
+
+Package and workspace baseline impact:
+- `core`: `44/119 -> 35/119`
+- workspace: `115/289 -> 106/289`
+
+## Behavior Notes
+
+Preserved behavior includes:
+- response matching by exact JSON payload or predicate
+- default response fallback
+- random error simulation
+- latency simulation
+- invocation recording timestamps and durations
+- simulator execution and missing-tool error behavior
+
+The main contract change is that mock tools and simulator tools now carry explicit generic input/output types, and named simulator execution can infer the correct payload shape from the selected tool name.

--- a/packages/core/src/tools/testing.ts
+++ b/packages/core/src/tools/testing.ts
@@ -3,40 +3,90 @@
  * @module tools/testing
  */
 
-export interface MockToolResponse {
-  input: any;
-  output?: any;
-  error?: Error;
+type MockToolMatcher<TInput> = TInput | ((input: TInput) => boolean);
+
+interface MockToolSuccessResponse<TInput, TOutput> {
+  input: MockToolMatcher<TInput>;
+  output: TOutput;
+  error?: never;
 }
 
-export interface MockToolConfig {
-  name: string;
+interface MockToolErrorResponse<TInput> {
+  input: MockToolMatcher<TInput>;
+  output?: never;
+  error: Error;
+}
+
+export type MockToolResponse<TInput = unknown, TOutput = unknown> =
+  | MockToolSuccessResponse<TInput, TOutput>
+  | MockToolErrorResponse<TInput>;
+
+export interface MockToolConfig<
+  TName extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+> {
+  name: TName;
   description?: string;
-  responses?: MockToolResponse[];
-  defaultResponse?: any;
+  responses?: MockToolResponse<TInput, TOutput>[];
+  defaultResponse?: TOutput;
   latency?: { min: number; max: number } | number;
   errorRate?: number;
 }
 
-export interface ToolInvocation {
-  input: any;
-  output?: any;
+export interface ToolInvocation<TInput = unknown, TOutput = unknown> {
+  input: TInput;
+  output?: TOutput;
   error?: Error;
   timestamp: number;
   duration: number;
 }
 
-export interface ToolSimulatorConfig {
-  tools: Array<{ name: string; invoke: (input: any) => Promise<any> }>;
+export interface SimulatedTool<TName extends string = string, TInput = unknown, TOutput = unknown> {
+  name: TName;
+  invoke(input: TInput): Promise<TOutput>;
+}
+
+type ToolName<TTools extends readonly SimulatedTool[]> = TTools[number]['name'] & string;
+type ToolByName<TTools extends readonly SimulatedTool[], TName extends ToolName<TTools>> = Extract<
+  TTools[number],
+  { name: TName }
+>;
+type ToolInputFor<TTools extends readonly SimulatedTool[], TName extends ToolName<TTools>> =
+  ToolByName<TTools, TName> extends SimulatedTool<string, infer TInput, unknown> ? TInput : never;
+type ToolOutputFor<TTools extends readonly SimulatedTool[], TName extends ToolName<TTools>> =
+  ToolByName<TTools, TName> extends SimulatedTool<string, unknown, infer TOutput> ? TOutput : never;
+
+export interface ToolSimulatorConfig<TTools extends readonly SimulatedTool[] = readonly SimulatedTool[]> {
+  tools: TTools;
   errorRate?: number;
   latency?: { mean: number; stddev: number };
   recordInvocations?: boolean;
 }
 
+export interface MockTool<TName extends string = string, TInput = unknown, TOutput = unknown>
+  extends SimulatedTool<TName, TInput, TOutput> {
+  description: string;
+  getInvocations: () => ToolInvocation<TInput, TOutput>[];
+  clearInvocations: () => void;
+}
+
+function matchesMockInput<TInput>(matcher: MockToolMatcher<TInput>, input: TInput): boolean {
+  if (typeof matcher === 'function') {
+    return (matcher as (input: TInput) => boolean)(input);
+  }
+
+  return JSON.stringify(matcher) === JSON.stringify(input);
+}
+
 /**
  * Create a mock tool for testing
  */
-export function createMockTool(config: MockToolConfig) {
+export function createMockTool<
+  TName extends string,
+  TInput = unknown,
+  TOutput = unknown,
+>(config: MockToolConfig<TName, TInput, TOutput>): MockTool<TName, TInput, TOutput> {
   const {
     name,
     description = `Mock tool: ${name}`,
@@ -46,12 +96,12 @@ export function createMockTool(config: MockToolConfig) {
     errorRate = 0,
   } = config;
 
-  const invocations: ToolInvocation[] = [];
+  const invocations: ToolInvocation<TInput, TOutput>[] = [];
 
   return {
     name,
     description,
-    invoke: async (input: any) => {
+    invoke: async (input: TInput) => {
       const startTime = Date.now();
 
       // Simulate latency
@@ -76,12 +126,7 @@ export function createMockTool(config: MockToolConfig) {
       }
 
       // Find matching response
-      const matchingResponse = responses.find((r) => {
-        if (typeof r.input === 'function') {
-          return r.input(input);
-        }
-        return JSON.stringify(r.input) === JSON.stringify(input);
-      });
+      const matchingResponse = responses.find((response) => matchesMockInput(response.input, input));
 
       if (matchingResponse) {
         if (matchingResponse.error) {
@@ -134,11 +179,13 @@ export function createMockTool(config: MockToolConfig) {
 /**
  * Create a tool simulator for testing
  */
-export function createToolSimulator(config: ToolSimulatorConfig) {
+export function createToolSimulator<const TTools extends readonly SimulatedTool[]>(
+  config: ToolSimulatorConfig<TTools>
+) {
   const { tools, errorRate = 0, latency, recordInvocations = true } = config;
 
   const toolMap = new Map(tools.map((t) => [t.name, t]));
-  const invocations = new Map<string, ToolInvocation[]>();
+  const invocations = new Map<string, ToolInvocation<unknown, unknown>[]>();
 
   // Initialize invocation tracking
   if (recordInvocations) {
@@ -160,7 +207,10 @@ export function createToolSimulator(config: ToolSimulatorConfig) {
   }
 
   return {
-    execute: async (toolName: string, input: any) => {
+    execute: async <TName extends ToolName<TTools>>(
+      toolName: TName,
+      input: ToolInputFor<TTools, TName>
+    ): Promise<ToolOutputFor<TTools, TName>> => {
       const tool = toolMap.get(toolName);
       if (!tool) {
         throw new Error(`Tool ${toolName} not found in simulator`);
@@ -198,7 +248,7 @@ export function createToolSimulator(config: ToolSimulatorConfig) {
             duration: Date.now() - startTime,
           });
         }
-        return result;
+        return result as ToolOutputFor<TTools, TName>;
       } catch (error) {
         if (recordInvocations) {
           invocations.get(toolName)!.push({
@@ -211,17 +261,24 @@ export function createToolSimulator(config: ToolSimulatorConfig) {
         throw error;
       }
     },
-    getInvocations: (toolName: string) => {
-      return invocations.get(toolName) ? [...invocations.get(toolName)!] : [];
+    getInvocations: <TName extends ToolName<TTools>>(toolName: TName): ToolInvocation<
+      ToolInputFor<TTools, TName>,
+      ToolOutputFor<TTools, TName>
+    >[] => {
+      const toolInvocations = invocations.get(toolName) ?? [];
+      return [...toolInvocations] as ToolInvocation<
+        ToolInputFor<TTools, TName>,
+        ToolOutputFor<TTools, TName>
+      >[];
     },
     getAllInvocations: () => {
-      const all: Record<string, ToolInvocation[]> = {};
+      const all: Partial<Record<ToolName<TTools>, ToolInvocation<unknown, unknown>[]>> = {};
       invocations.forEach((invs, name) => {
-        all[name] = [...invs];
+        all[name as ToolName<TTools>] = [...invs];
       });
       return all;
     },
-    clearInvocations: (toolName?: string) => {
+    clearInvocations: (toolName?: ToolName<TTools>) => {
       if (toolName) {
         invocations.get(toolName)?.splice(0);
       } else {
@@ -230,4 +287,3 @@ export function createToolSimulator(config: ToolSimulatorConfig) {
     },
   };
 }
-

--- a/packages/core/tests/tools/testing.test.ts
+++ b/packages/core/tests/tools/testing.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createMockTool, createToolSimulator } from '../../src/tools/testing.js';
+
+describe('tool testing helpers', () => {
+  it('matches predicate responses and falls back to the default response', async () => {
+    const tool = createMockTool<'search', { query: string }, { matches: string[] }>({
+      name: 'search',
+      responses: [
+        {
+          input: (input) => input.query.startsWith('prefix:'),
+          output: { matches: ['prefix'] },
+        },
+      ],
+      defaultResponse: { matches: [] },
+    });
+
+    await expect(tool.invoke({ query: 'prefix:alpha' })).resolves.toEqual({ matches: ['prefix'] });
+    await expect(tool.invoke({ query: 'other' })).resolves.toEqual({ matches: [] });
+  });
+
+  it('records configured errors in mock invocations', async () => {
+    const error = new Error('boom');
+    const tool = createMockTool<'failing', { id: number }, { ok: boolean }>({
+      name: 'failing',
+      responses: [{ input: { id: 1 }, error }],
+    });
+
+    await expect(tool.invoke({ id: 1 })).rejects.toThrow('boom');
+
+    expect(tool.getInvocations()).toHaveLength(1);
+    expect(tool.getInvocations()[0]?.error).toBe(error);
+    expect(tool.getInvocations()[0]?.timestamp).toBeTypeOf('number');
+    expect(tool.getInvocations()[0]?.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports missing simulator tools and clears recorded invocations', async () => {
+    const searchTool = createMockTool<'search', { query: string }, { matches: string[] }>({
+      name: 'search',
+      defaultResponse: { matches: [] },
+    });
+    const statusTool = createMockTool<'status', { id: number }, { ok: boolean }>({
+      name: 'status',
+      defaultResponse: { ok: true },
+    });
+
+    const simulator = createToolSimulator({
+      tools: [searchTool, statusTool] as const,
+    });
+
+    await simulator.execute('search', { query: 'alpha' });
+    await simulator.execute('status', { id: 1 });
+
+    expect(simulator.getInvocations('search')).toHaveLength(1);
+    expect(simulator.getInvocations('status')).toHaveLength(1);
+
+    simulator.clearInvocations('search');
+    expect(simulator.getInvocations('search')).toHaveLength(0);
+    expect(simulator.getInvocations('status')).toHaveLength(1);
+
+    simulator.clearInvocations();
+    expect(simulator.getInvocations('status')).toHaveLength(0);
+
+    await expect(
+      simulator.execute('missing' as 'search', { query: 'alpha' })
+    ).rejects.toThrow('Tool missing not found in simulator');
+  });
+});

--- a/packages/core/tests/tools/testing.typecheck.ts
+++ b/packages/core/tests/tools/testing.typecheck.ts
@@ -1,0 +1,66 @@
+import { createMockTool, createToolSimulator } from '../../src/tools/testing.js';
+
+type SearchInput = { query: string };
+type SearchOutput = { matches: string[] };
+type StatusInput = { id: number };
+type StatusOutput = { ok: boolean };
+
+async function assertMockToolTyping() {
+  const searchTool = createMockTool<'search', SearchInput, SearchOutput>({
+    name: 'search',
+    responses: [
+      {
+        input: { query: 'alpha' },
+        output: { matches: ['a'] },
+      },
+      {
+        input: (input) => input.query.startsWith('prefix:'),
+        output: { matches: ['prefix'] },
+      },
+    ],
+    defaultResponse: { matches: [] },
+  });
+
+  const output: SearchOutput = await searchTool.invoke({ query: 'alpha' });
+  const invocations = searchTool.getInvocations();
+  const invocationInput: SearchInput = invocations[0]!.input;
+  const invocationOutput: SearchOutput | undefined = invocations[0]!.output;
+
+  void output;
+  void invocationInput;
+  void invocationOutput;
+
+  // @ts-expect-error - query must stay string-typed
+  await searchTool.invoke({ query: 123 });
+}
+
+async function assertToolSimulatorTyping() {
+  const searchTool = createMockTool<'search', SearchInput, SearchOutput>({
+    name: 'search',
+    defaultResponse: { matches: [] },
+  });
+  const statusTool = createMockTool<'status', StatusInput, StatusOutput>({
+    name: 'status',
+    defaultResponse: { ok: true },
+  });
+  const tools = [searchTool, statusTool] as const;
+
+  const simulator = createToolSimulator({
+    tools,
+  });
+
+  const searchResult: SearchOutput = await simulator.execute('search', { query: 'alpha' });
+  const statusResult: StatusOutput = await simulator.execute('status', { id: 1 });
+  const searchInvocations = simulator.getInvocations('search');
+  const searchInvocationInput: SearchInput = searchInvocations[0]!.input;
+
+  void searchResult;
+  void statusResult;
+  void searchInvocationInput;
+
+  // @ts-expect-error - wrong input type for named tool
+  await simulator.execute('status', { id: 'bad' });
+}
+
+void assertMockToolTyping();
+void assertToolSimulatorTyping();

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1502,21 +1502,44 @@ Implementation notes:
 **Branch:** `fix/st-09039-core-mock-tool-testing-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09039-core-mock-tool-testing-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover typed mock responses, predicate matching, error recording, simulator missing-tool errors, and invocation clearing; first failing test should assert generic input/output inference for `createMockTool(...)`
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad mock response, default response, invocation, and simulator input/output contracts in `packages/core/src/tools/testing.ts` with generic or unknown-first helper types
-- [ ] Preserve mock response matching, default responses, random errors, latency simulation, invocation recording, and simulator execution behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09039-core-mock-tool-testing-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create branch `fix/st-09039-core-mock-tool-testing-contracts`
+- [x] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: cover typed mock responses, predicate matching, error recording, simulator missing-tool errors, and invocation clearing; first failing test should assert generic input/output inference for `createMockTool(...)`
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad mock response, default response, invocation, and simulator input/output contracts in `packages/core/src/tools/testing.ts` with generic or unknown-first helper types
+- [x] Preserve mock response matching, default responses, random errors, latency simulation, invocation recording, and simulator execution behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09039-core-mock-tool-testing-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Test-first evidence:
+  - Initial standalone typecheck gate failed as expected:
+    - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts`
+  - Failure modes before implementation included:
+    - `Expected 0 type arguments, but got 2`
+    - `Unused '@ts-expect-error' directive`
+- Focused validation after implementation:
+  - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts` passed
+  - `pnpm test --run packages/core/tests/tools/testing.test.ts` -> `1` file, `3` tests passed
+  - `pnpm --filter @agentforge/core typecheck` passed
+  - `pnpm test --run` -> `170` files passed, `16` skipped; `2286` tests passed, `286` skipped
+  - `pnpm lint` passed with warnings only and `0` errors
+- Residual impact assessment:
+  - Added a dedicated runtime test file plus a source-included typecheck fixture because the story changes both public helper typing and simulator runtime bookkeeping.
+- Explicit-`any` delta:
+  - `packages/core/src/tools/testing.ts` improved from `8 -> 0`
+  - `core` baseline improved from `44/119 -> 35/119`
+  - workspace baseline improved from `115/289 -> 106/289`
+ - PR workflow:
+   - Draft PR created with story ID in title; branch is ready to be marked `Ready for review`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1513,7 +1513,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09023
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/tools/testing.ts` replaces broad mock response, default response, invocation, and simulator input/output contracts with generic or unknown-first helper types

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-07
-**Active Story:** None
+**Last Updated:** 2026-05-08
+**Active Story:** ST-09039 (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-07
+**Last Updated:** 2026-05-08
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
+- **Ready:** 2 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09039` - Tighten Core Mock Tool Testing Helper Contracts
 - `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
 - `ST-09041` - Adopt Structured Logger in Conversation Simulator
 ---
@@ -27,7 +26,7 @@ _No stories currently in progress_
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09039` - Tighten Core Mock Tool Testing Helper Contracts
 
 ---
 


### PR DESCRIPTION
## Story

ST-09039 - Tighten Core Mock Tool Testing Helper Contracts

## What Changed

- replaced broad mock-tool and tool-simulator `any` seams in `packages/core/src/tools/testing.ts` with generic and unknown-first helper contracts
- made `createMockTool(...)` preserve typed input/output payloads for exact-match responses, predicate responses, default responses, and invocation history
- made `createToolSimulator(...)` infer input/output payloads from the selected named tool so `execute(name, input)` and `getInvocations(name)` stay type-safe
- added focused runtime coverage in `packages/core/tests/tools/testing.test.ts`
- added a standalone typecheck regression fixture in `packages/core/tests/tools/testing.typecheck.ts`
- recorded the touched-file explicit-`any` improvement in `docs/st09039-core-mock-tool-testing-contracts.md`

## Acceptance Criteria Coverage

- `packages/core/src/tools/testing.ts` now replaces broad mock response, default response, invocation, and simulator input/output contracts with generic or unknown-first helper types
- mock response matching, default responses, random errors, latency simulation, invocation recording, and simulator execution behavior remain unchanged
- focused tests now cover typed mock responses, predicate matching, configured error recording, simulator missing-tool errors, and invocation clearing
- touched files do not regress on explicit-`any` warnings; the main helper file improved from `8 -> 0` and the outcome is recorded in the story doc
- story documentation was added at `docs/st09039-core-mock-tool-testing-contracts.md`

## Test Strategy

- first failing automated gate was the new standalone typecheck fixture `packages/core/tests/tools/testing.typecheck.ts`, which initially failed because the helper API did not yet expose generic input/output contracts
- focused runtime tests verify preserved mock matching behavior, error bookkeeping, missing-tool failure behavior, and invocation clearing
- full-suite validation was still run because the simulator helpers are shared test infrastructure used across packages

## Validation Performed

- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/tools/testing.typecheck.ts`
- `pnpm test --run packages/core/tests/tools/testing.test.ts`
- `pnpm --filter @agentforge/core typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
