### PR TITLE
refactor(st-09040): tighten human-in-loop streaming resume contracts

### DIFF
--- a/.pr-body-st-09040.md
+++ b/.pr-body-st-09040.md
@@ -1,0 +1,39 @@
+## Story
+
+ST-09040 - Tighten Human-in-Loop Streaming Resume Contracts
+
+## What Changed
+
+- replaced the broad resume payload `any` boundary in `packages/core/src/streaming/human-in-loop.ts` with the shared JSON-safe `InterruptPayload` contract
+- kept `ResumeEventData` and `formatResumeEvent(...)` aligned with the existing interrupt resume command/options types already used in LangGraph interrupt flows
+- preserved runtime SSE event names, payload shape, and `resume-<interruptId>` event IDs
+- added focused runtime coverage in `packages/core/tests/streaming/human-in-loop.test.ts`
+- added a standalone typecheck regression fixture in `packages/core/tests/streaming/human-in-loop.typecheck.ts`
+- recorded the touched-file explicit-`any` improvement in `docs/st09040-human-in-loop-streaming-resume-contracts.md`
+
+## Acceptance Criteria Coverage
+
+- `packages/core/src/streaming/human-in-loop.ts` now replaces resume payload `any` contracts with a JSON-safe value type aligned with interrupt/resume boundaries
+- human request, response, interrupt, resume, waiting, and resumed SSE event formatting remains unchanged at runtime
+- focused tests now cover primitive resume payloads, object resume payloads, stable event IDs, and rejection of non-serializable resume values
+- touched files do not regress on explicit-`any` warnings; the main helper file improved from `2 -> 0` and the outcome is recorded in the story doc
+- story documentation was added at `docs/st09040-human-in-loop-streaming-resume-contracts.md`
+
+## Test Strategy
+
+- first failing automated gate was the new standalone typecheck fixture `packages/core/tests/streaming/human-in-loop.typecheck.ts`, which initially failed because the resume helper boundary still accepted non-serializable values through broad `any`
+- focused runtime coverage verifies preserved resume event serialization for primitive and object payloads plus stable `resume-<interruptId>` event IDs
+- broader validation relies on the full test suite and repo lint because the helper sits on a shared public SSE utility path in `@agentforge/core`
+
+## Validation Performed
+
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts`
+- `pnpm test --run packages/core/tests/streaming/human-in-loop.test.ts`
+- `pnpm --filter @agentforge/core typecheck`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Ready for review

--- a/docs/st09040-human-in-loop-streaming-resume-contracts.md
+++ b/docs/st09040-human-in-loop-streaming-resume-contracts.md
@@ -1,0 +1,56 @@
+# ST-09040: Tighten Human-in-Loop Streaming Resume Contracts
+
+## Summary
+
+Tightened the human-in-loop SSE resume event boundary in `packages/core/src/streaming/human-in-loop.ts` so resume payloads use the same JSON-safe contract as LangGraph interrupt resume flows. The change preserves existing event names, payload shape, and resume event ID formatting while removing broad `any` from the public resume event helpers.
+
+## Scope
+
+Touched files:
+- `packages/core/src/streaming/human-in-loop.ts`
+- `packages/core/tests/streaming/human-in-loop.test.ts`
+- `packages/core/tests/streaming/human-in-loop.typecheck.ts`
+
+## Test Strategy
+
+Test-first path used.
+
+The first failing automated gate was a standalone typecheck fixture for `formatResumeEvent(...)` and `ResumeEventData`:
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts`
+- initial failure included:
+  - `Unused '@ts-expect-error' directive.`
+
+That failure proved the resume boundary still accepted non-serializable values because the public helper contract was still typed with broad `any`.
+
+## Validation
+
+Focused validation after implementation:
+- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts`
+- `pnpm test --run packages/core/tests/streaming/human-in-loop.test.ts`
+- `pnpm --filter @agentforge/core typecheck`
+- `pnpm lint:explicit-any:baseline`
+
+Coverage added in the focused regression files:
+- primitive resume value serialization
+- object resume value serialization
+- stable `resume-<interruptId>` event IDs
+- rejection of non-serializable resume payloads in both helper calls and `ResumeEventData`
+
+## Explicit-any Delta
+
+Touched helper file:
+- `packages/core/src/streaming/human-in-loop.ts`: `2 -> 0`
+
+Package and workspace baseline impact:
+- `core`: `35/119 -> 33/119`
+- workspace: `106/289 -> 104/289`
+
+## Behavior Notes
+
+Preserved behavior includes:
+- `human_request`, `human_response`, `interrupt`, `resume`, `agent_waiting`, and `agent_resumed` SSE event names
+- `resume-<interruptId>` event ID formatting
+- serialized primitive and object resume payloads in `event.data`
+- unchanged waiting/resumed event formatting
+
+The contract change aligns resume SSE payloads with the existing `InterruptPayload` type already used by interrupt resume commands and options, without widening scope beyond the human-in-loop streaming helpers.

--- a/packages/core/src/streaming/human-in-loop.ts
+++ b/packages/core/src/streaming/human-in-loop.ts
@@ -4,7 +4,7 @@
  */
 
 import type { SSEEvent } from './types.js';
-import type { HumanRequest, AnyInterrupt } from '../langgraph/interrupts/types.js';
+import type { HumanRequest, AnyInterrupt, InterruptPayload } from '../langgraph/interrupts/types.js';
 
 /**
  * Human-in-the-loop SSE event types
@@ -51,7 +51,7 @@ export interface InterruptEventData {
 export interface ResumeEventData {
   type: 'resume';
   interruptId: string;
-  value: any;
+  value: InterruptPayload;
   threadId: string;
 }
 
@@ -169,7 +169,7 @@ export function formatInterruptEvent(interrupt: AnyInterrupt, threadId: string):
  */
 export function formatResumeEvent(
   interruptId: string,
-  value: any,
+  value: InterruptPayload,
   threadId: string
 ): SSEEvent {
   const data: ResumeEventData = {
@@ -223,4 +223,3 @@ export function formatAgentResumedEvent(threadId: string): SSEEvent {
     data: JSON.stringify(data),
   };
 }
-

--- a/packages/core/tests/streaming/human-in-loop.test.ts
+++ b/packages/core/tests/streaming/human-in-loop.test.ts
@@ -90,6 +90,25 @@ describe('Human-in-Loop SSE Utilities', () => {
       expect(data.value).toBe('resume value');
       expect(data.threadId).toBe('thread-456');
     });
+
+    it('should preserve object resume payloads and stable event ids', () => {
+      const resumeValue = {
+        approved: true,
+        actor: 'reviewer',
+        details: {
+          confidence: 0.9,
+          reasons: ['looks good'],
+        },
+      };
+
+      const event = formatResumeEvent('interrupt-456', resumeValue, 'thread-789');
+
+      expect(event.id).toBe('resume-interrupt-456');
+
+      const data = JSON.parse(event.data);
+      expect(data.value).toEqual(resumeValue);
+      expect(data.threadId).toBe('thread-789');
+    });
   });
 
   describe('formatAgentWaitingEvent', () => {
@@ -134,7 +153,7 @@ describe('Human-in-Loop SSE Utilities', () => {
         formatHumanRequestEvent(humanRequest, 'thread-1'),
         formatHumanResponseEvent('req-1', 'response', 'thread-1'),
         formatInterruptEvent(createHumanRequestInterrupt(humanRequest), 'thread-1'),
-        formatResumeEvent('int-1', 'value', 'thread-1'),
+        formatResumeEvent('int-1', { approved: true, reasons: ['ok'] }, 'thread-1'),
         formatAgentWaitingEvent('reason', 'thread-1'),
         formatAgentResumedEvent('thread-1'),
       ];
@@ -145,4 +164,3 @@ describe('Human-in-Loop SSE Utilities', () => {
     });
   });
 });
-

--- a/packages/core/tests/streaming/human-in-loop.typecheck.ts
+++ b/packages/core/tests/streaming/human-in-loop.typecheck.ts
@@ -1,0 +1,40 @@
+import { formatResumeEvent } from '../../src/streaming/human-in-loop.js';
+import type { ResumeEventData } from '../../src/streaming/human-in-loop.js';
+
+const primitiveEvent = formatResumeEvent('interrupt-1', 'approved', 'thread-1');
+void primitiveEvent;
+
+const objectEvent = formatResumeEvent(
+  'interrupt-2',
+  {
+    approved: true,
+    actor: 'reviewer',
+    reasons: ['safe'],
+    metadata: { confidence: 0.9, source: 'human' },
+  },
+  'thread-2'
+);
+void objectEvent;
+
+const data: ResumeEventData = {
+  type: 'resume',
+  interruptId: 'interrupt-3',
+  value: {
+    approved: false,
+    details: { retry: 1 },
+  },
+  threadId: 'thread-3',
+};
+void data;
+
+// @ts-expect-error resume values must remain JSON-safe
+formatResumeEvent('interrupt-4', { resolver: () => true }, 'thread-4');
+
+const invalidData: ResumeEventData = {
+  type: 'resume',
+  interruptId: 'interrupt-5',
+  // @ts-expect-error ResumeEventData.value must reject non-serializable payloads
+  value: { resolver: () => true },
+  threadId: 'thread-5',
+};
+void invalidData;

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1551,7 +1551,7 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09040-human-in-loop-streaming-resume-contracts`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Define test strategy before implementation: cover resume payload serialization, primitive/object resume values, and event ID stability; first failing test should assert resume value typing without public `any`
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
 - [x] Replace resume payload `any` contracts in `packages/core/src/streaming/human-in-loop.ts` with an unknown-first or JSON-safe value type aligned with interrupt/resume boundaries
@@ -1562,8 +1562,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes
@@ -1587,6 +1587,9 @@ Implementation notes:
 - Final validation:
   - `pnpm test --run` -> `170` files passed, `16` skipped; `2287` tests passed, `286` skipped
   - `pnpm lint` passed with warnings only and `0` errors
+- PR workflow:
+  - Draft PR created with story ID in title: PR #109
+  - Branch is ready to be marked `Ready for review`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1550,21 +1550,43 @@ Implementation notes:
 **Branch:** `fix/st-09040-human-in-loop-streaming-resume-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09040-human-in-loop-streaming-resume-contracts`
+- [x] Create branch `fix/st-09040-human-in-loop-streaming-resume-contracts`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover resume payload serialization, primitive/object resume values, and event ID stability; first failing test should assert resume value typing without public `any`
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace resume payload `any` contracts in `packages/core/src/streaming/human-in-loop.ts` with an unknown-first or JSON-safe value type aligned with interrupt/resume boundaries
-- [ ] Preserve human request, response, interrupt, resume, waiting, and resumed SSE event formatting at runtime
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09040-human-in-loop-streaming-resume-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Define test strategy before implementation: cover resume payload serialization, primitive/object resume values, and event ID stability; first failing test should assert resume value typing without public `any`
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace resume payload `any` contracts in `packages/core/src/streaming/human-in-loop.ts` with an unknown-first or JSON-safe value type aligned with interrupt/resume boundaries
+- [x] Preserve human request, response, interrupt, resume, waiting, and resumed SSE event formatting at runtime
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09040-human-in-loop-streaming-resume-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+### Notes
+
+- Test-first evidence:
+  - Initial standalone typecheck gate failed as expected:
+    - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts`
+  - Failure mode before implementation included:
+    - `Unused '@ts-expect-error' directive.`
+- Focused validation after implementation:
+  - `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts` passed
+  - `pnpm test --run packages/core/tests/streaming/human-in-loop.test.ts` -> `1` file, `8` tests passed
+  - `pnpm --filter @agentforge/core typecheck` passed
+  - `pnpm lint:explicit-any:baseline` passed
+- Residual impact assessment:
+  - Added both a dedicated runtime test expansion and a standalone typecheck fixture because this story changes a public SSE payload contract and needs both serialization and type-boundary coverage.
+- Explicit-`any` delta:
+  - `packages/core/src/streaming/human-in-loop.ts` improved from `2 -> 0`
+  - `core` baseline improved from `35/119 -> 33/119`
+  - workspace baseline improved from `106/289 -> 104/289`
+- Final validation:
+  - `pnpm test --run` -> `170` files passed, `16` skipped; `2287` tests passed, `286` skipped
+  - `pnpm lint` passed with warnings only and `0` errors
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1530,7 +1530,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09024
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/streaming/human-in-loop.ts` replaces resume payload `any` contracts with an unknown-first or JSON-safe value type aligned with interrupt/resume boundaries

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1530,7 +1530,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09024
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/streaming/human-in-loop.ts` replaces resume payload `any` contracts with an unknown-first or JSON-safe value type aligned with interrupt/resume boundaries

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-09
-**Active Story:** ST-09040 (In Progress)
+**Active Story:** ST-09040 (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-08
-**Active Story:** None
+**Last Updated:** 2026-05-09
+**Active Story:** ST-09040 (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-09
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,13 +14,12 @@
 
 ## Ready
 
-- `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
 - `ST-09041` - Adopt Structured Logger in Conversation Simulator
 ---
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -19,13 +19,13 @@
 
 ## In Progress
 
-- `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09040` - Tighten Human-in-Loop Streaming Resume Contracts
 
 ---
 


### PR DESCRIPTION
## Story

ST-09040 - Tighten Human-in-Loop Streaming Resume Contracts

## What Changed

- replaced the broad resume payload `any` boundary in `packages/core/src/streaming/human-in-loop.ts` with the shared JSON-safe `InterruptPayload` contract
- kept `ResumeEventData` and `formatResumeEvent(...)` aligned with the existing interrupt resume command/options types already used in LangGraph interrupt flows
- preserved runtime SSE event names, payload shape, and `resume-<interruptId>` event IDs
- added focused runtime coverage in `packages/core/tests/streaming/human-in-loop.test.ts`
- added a standalone typecheck regression fixture in `packages/core/tests/streaming/human-in-loop.typecheck.ts`
- recorded the touched-file explicit-`any` improvement in `docs/st09040-human-in-loop-streaming-resume-contracts.md`

## Acceptance Criteria Coverage

- `packages/core/src/streaming/human-in-loop.ts` now replaces resume payload `any` contracts with a JSON-safe value type aligned with interrupt/resume boundaries
- human request, response, interrupt, resume, waiting, and resumed SSE event formatting remains unchanged at runtime
- focused tests now cover primitive resume payloads, object resume payloads, stable event IDs, and rejection of non-serializable resume values
- touched files do not regress on explicit-`any` warnings; the main helper file improved from `2 -> 0` and the outcome is recorded in the story doc
- story documentation was added at `docs/st09040-human-in-loop-streaming-resume-contracts.md`

## Test Strategy

- first failing automated gate was the new standalone typecheck fixture `packages/core/tests/streaming/human-in-loop.typecheck.ts`, which initially failed because the resume helper boundary still accepted non-serializable values through broad `any`
- focused runtime coverage verifies preserved resume event serialization for primitive and object payloads plus stable `resume-<interruptId>` event IDs
- broader validation relies on the full test suite and repo lint because the helper sits on a shared public SSE utility path in `@agentforge/core`

## Validation Performed

- `./node_modules/.bin/tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node packages/core/tests/streaming/human-in-loop.typecheck.ts`
- `pnpm test --run packages/core/tests/streaming/human-in-loop.test.ts`
- `pnpm --filter @agentforge/core typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
