### PR TITLE
refactor(st-09041): adopt structured logger in conversation simulator

### DIFF
--- a/.pr-body-st-09041.md
+++ b/.pr-body-st-09041.md
@@ -1,0 +1,38 @@
+## Story
+
+ST-09041 - Adopt Structured Logger in Conversation Simulator
+
+## What Changed
+
+- replaced the verbose `console.log` path in `packages/testing/src/runners/conversation-simulator.ts` with the shared structured logger from `@agentforge/core`
+- added optional logger injection to `ConversationSimulatorConfig` so verbose logging can be verified without depending on global stdout
+- preserved the existing emitted turn strings by logging the same `User: ...` and `AI: ...` content through the structured logger path
+- added focused regression coverage in `packages/testing/tests/runners/conversation-simulator.test.ts`
+- recorded the logger verification approach and validation evidence in `docs/st09041-conversation-simulator-structured-logger.md`
+
+## Acceptance Criteria Coverage
+
+- `packages/testing/src/runners/conversation-simulator.ts` now replaces direct verbose `console.log` calls with a structured logger helper
+- verbose simulator output remains opt-in and continues to emit the same user and AI turn text while leaving non-verbose behavior unchanged
+- focused tests now cover verbose enabled routing, verbose disabled behavior, and emitted turn content
+- the story doc records the `CaptureStream` plus `console.log` spy approach used to verify the new logging route
+- story documentation was added at `docs/st09041-conversation-simulator-structured-logger.md`
+
+## Test Strategy
+
+- first failing automated test was added in `packages/testing/tests/runners/conversation-simulator.test.ts`
+- the initial failure showed the injected logger stream stayed empty, proving verbose output was still using the direct console path
+- focused regression tests now verify both enabled and disabled verbose behavior
+- broader safety comes from package typecheck, explicit-`any` baseline check, full-suite validation, and repo lint
+
+## Validation Performed
+
+- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
+- `pnpm --filter @agentforge/testing typecheck`
+- `pnpm lint:explicit-any:baseline`
+- `pnpm test --run`
+- `pnpm lint`
+
+## Status
+
+Ready for review

--- a/docs/st09041-conversation-simulator-structured-logger.md
+++ b/docs/st09041-conversation-simulator-structured-logger.md
@@ -1,0 +1,60 @@
+# ST-09041: Adopt Structured Logger in Conversation Simulator
+
+## Summary
+
+Replaced the verbose `console.log` path in `packages/testing/src/runners/conversation-simulator.ts` with the shared structured logger from `@agentforge/core`. The simulator now keeps verbose logging opt-in, preserves the same `User: ...` and `AI: ...` turn text, and supports optional logger injection so tests can verify the logging route without depending on global stdout.
+
+## Scope
+
+Touched files:
+- `packages/testing/src/runners/conversation-simulator.ts`
+- `packages/testing/tests/runners/conversation-simulator.test.ts`
+
+## Test Strategy
+
+Test-first path used.
+
+The first failing automated test was added in `packages/testing/tests/runners/conversation-simulator.test.ts`:
+- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
+- initial failure:
+  - `expected [] to have a length of 2 but got +0`
+
+That failure proved the new expectation was not yet satisfied: verbose output was still going to `console.log`, and the injected structured logger stream received nothing.
+
+## Logger Verification Approach
+
+The focused tests use two doubles:
+- a `CaptureStream` writable stream passed to `createLogger(...)` so emitted log lines can be asserted directly
+- a `vi.spyOn(console, 'log')` assertion to prove verbose output no longer routes through the console path
+
+This keeps verification local to the runner tests and avoids mutating process-wide stdout behavior.
+
+## Validation
+
+Focused validation after implementation:
+- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
+- `pnpm --filter @agentforge/testing typecheck`
+- `pnpm lint:explicit-any:baseline`
+
+Coverage added in the focused regression file:
+- verbose logging routes through the structured logger instead of `console.log`
+- verbose-disabled execution emits no logs
+- emitted verbose content still contains the same user and AI turn strings
+
+## Explicit-any Delta
+
+Touched files did not introduce new explicit-`any` warnings.
+
+Package and workspace baseline impact:
+- `testing`: `3/51 -> 3/51`
+- workspace: `104/289 -> 104/289`
+
+## Behavior Notes
+
+Preserved behavior includes:
+- verbose logging remains opt-in through `config.verbose`
+- non-verbose simulator behavior remains unchanged
+- static conversation simulation still appends only the latest agent message each turn
+- emitted turn text remains `User: <input>` and `AI: <content>`
+
+The only behavior change is the output sink for verbose mode: it now uses the shared structured logger path instead of direct console writes.

--- a/packages/testing/src/runners/conversation-simulator.ts
+++ b/packages/testing/src/runners/conversation-simulator.ts
@@ -1,6 +1,9 @@
+import { createLogger, type Logger } from '@agentforge/core';
 import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import type { AgentTestAgent } from './agent-test-runner.js';
 import { extractMessages } from './agent-test-runner.js';
+
+const conversationSimulatorLogger = createLogger('agentforge:testing:conversation-simulator');
 
 /**
  * Configuration for conversation simulator
@@ -20,6 +23,11 @@ export interface ConversationSimulatorConfig {
    * Whether to log conversation
    */
   verbose?: boolean;
+
+  /**
+   * Structured logger used for verbose conversation output
+   */
+  logger?: Logger;
   
   /**
    * Stop condition
@@ -116,18 +124,14 @@ export class ConversationSimulator<TState = unknown> {
         const userMessage = new HumanMessage(input);
         messages.push(userMessage);
         
-        if (this.config.verbose) {
-          console.log(`User: ${input}`);
-        }
+        this.logVerboseTurn('User', input);
         
         // Get agent response
         const result = await this.agent.invoke({ messages });
         const aiMessage = extractLatestMessage(result);
         messages.push(aiMessage);
         
-        if (this.config.verbose) {
-          console.log(`AI: ${aiMessage.content}`);
-        }
+        this.logVerboseTurn('AI', aiMessage.content);
         
         turns++;
         
@@ -208,6 +212,15 @@ export class ConversationSimulator<TState = unknown> {
       stopReason,
       error,
     };
+  }
+
+  private logVerboseTurn(role: 'User' | 'AI', content: unknown): void {
+    if (!this.config.verbose) {
+      return;
+    }
+
+    const logger = this.config.logger ?? conversationSimulatorLogger;
+    logger.info(`${role}: ${String(content)}`);
   }
 }
 

--- a/packages/testing/src/runners/conversation-simulator.ts
+++ b/packages/testing/src/runners/conversation-simulator.ts
@@ -3,7 +3,9 @@ import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import type { AgentTestAgent } from './agent-test-runner.js';
 import { extractMessages } from './agent-test-runner.js';
 
-const conversationSimulatorLogger = createLogger('agentforge:testing:conversation-simulator');
+const conversationSimulatorLogger = createLogger(
+  'agentforge:testing:runners:conversation-simulator'
+);
 
 /**
  * Configuration for conversation simulator

--- a/packages/testing/tests/runners/conversation-simulator.test.ts
+++ b/packages/testing/tests/runners/conversation-simulator.test.ts
@@ -1,9 +1,24 @@
+import { createLogger } from '@agentforge/core';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
-import { describe, expect, it } from 'vitest';
+import { Writable } from 'stream';
+import { describe, expect, it, vi } from 'vitest';
 import {
   ConversationSimulator,
   createConversationSimulator,
 } from '../../src/runners/conversation-simulator.js';
+
+class CaptureStream extends Writable {
+  public output: string[] = [];
+
+  _write(
+    chunk: string | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.output.push(chunk.toString());
+    callback();
+  }
+}
 
 describe('conversation simulator', () => {
   it('simulates a static conversation and appends only the latest agent message each turn', async () => {
@@ -100,5 +115,64 @@ describe('conversation simulator', () => {
     expect(result.turns).toBe(0);
     expect(result.messages).toEqual([new HumanMessage('hello')]);
     expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it('routes verbose turn output through the structured logger instead of console.log', async () => {
+    const stream = new CaptureStream();
+    const logger = createLogger('test-conversation-simulator', {
+      destination: stream,
+      includeTimestamp: false,
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const simulator = createConversationSimulator(
+        {
+          invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+            messages: [...input.messages, new AIMessage(`reply ${input.messages.length}`)],
+          }),
+        },
+        {
+          verbose: true,
+          logger,
+        }
+      );
+
+      await simulator.simulate(['hello']);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+
+    expect(stream.output).toHaveLength(2);
+    expect(stream.output[0]).toContain('User: hello');
+    expect(stream.output[1]).toContain('AI: reply 1');
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not emit verbose logs when verbose mode is disabled', async () => {
+    const stream = new CaptureStream();
+    const logger = createLogger('test-conversation-simulator', {
+      destination: stream,
+      includeTimestamp: false,
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const simulator = createConversationSimulator(
+        {
+          invoke: async (input: { messages: Array<HumanMessage | AIMessage> }) => ({
+            messages: [...input.messages, new AIMessage(`reply ${input.messages.length}`)],
+          }),
+        },
+        { logger }
+      );
+
+      await simulator.simulate(['hello']);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+
+    expect(stream.output).toEqual([]);
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1600,18 +1600,18 @@ Implementation notes:
 **Branch:** `refactor/st-09041-conversation-simulator-structured-logger`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09041-conversation-simulator-structured-logger`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover verbose logging enabled/disabled paths and emitted user/AI turn content; first failing test should assert verbose output routes through the structured logger instead of `console.log`
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace direct verbose `console.log` calls in `packages/testing/src/runners/conversation-simulator.ts` with a testing-package structured logger or shared logger helper
-- [ ] Preserve verbose opt-in behavior, emitted turn information, and all non-verbose simulator behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record any observability/test-double approach used to verify logger output in story docs
-- [ ] Add or update story documentation at `docs/st09041-conversation-simulator-structured-logger.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Create branch `refactor/st-09041-conversation-simulator-structured-logger`
+- [x] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: cover verbose logging enabled/disabled paths and emitted user/AI turn content; first failing test should assert verbose output routes through the structured logger instead of `console.log`
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace direct verbose `console.log` calls in `packages/testing/src/runners/conversation-simulator.ts` with a testing-package structured logger or shared logger helper
+- [x] Preserve verbose opt-in behavior, emitted turn information, and all non-verbose simulator behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record any observability/test-double approach used to verify logger output in story docs
+- [x] Add or update story documentation at `docs/st09041-conversation-simulator-structured-logger.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1612,8 +1612,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1547,7 +1547,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09036
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/testing/src/runners/conversation-simulator.ts` replaces direct verbose `console.log` calls with a testing-package structured logger or shared logger helper

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1547,7 +1547,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09036
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/testing/src/runners/conversation-simulator.ts` replaces direct verbose `console.log` calls with a testing-package structured logger or shared logger helper

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-09
-**Active Story:** None
+**Last Updated:** 2026-05-12
+**Active Story:** ST-09041
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 4 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -22,13 +22,13 @@
 
 ## In Progress
 
-- `ST-09041` - Adopt Structured Logger in Conversation Simulator
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09041` - Adopt Structured Logger in Conversation Simulator
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-09
+**Last Updated:** 2026-05-12
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **Ready:** 4 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09041` - Adopt Structured Logger in Conversation Simulator
 - `ST-09042` - Tighten SSE Formatter Generic Event Contracts
 - `ST-09043` - Tighten Error Reporter Context Contracts
 - `ST-09044` - Tighten Testing Mock Tool Factory Contracts
@@ -23,7 +22,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09041` - Adopt Structured Logger in Conversation Simulator
 
 ---
 


### PR DESCRIPTION
## Story

ST-09041 - Adopt Structured Logger in Conversation Simulator

## What Changed

- replaced the verbose `console.log` path in `packages/testing/src/runners/conversation-simulator.ts` with the shared structured logger from `@agentforge/core`
- added optional logger injection to `ConversationSimulatorConfig` so verbose logging can be verified without depending on global stdout
- preserved the existing emitted turn strings by logging the same `User: ...` and `AI: ...` content through the structured logger path
- added focused regression coverage in `packages/testing/tests/runners/conversation-simulator.test.ts`
- recorded the logger verification approach and validation evidence in `docs/st09041-conversation-simulator-structured-logger.md`

## Acceptance Criteria Coverage

- `packages/testing/src/runners/conversation-simulator.ts` now replaces direct verbose `console.log` calls with a structured logger helper
- verbose simulator output remains opt-in and continues to emit the same user and AI turn text while leaving non-verbose behavior unchanged
- focused tests now cover verbose enabled routing, verbose disabled behavior, and emitted turn content
- the story doc records the `CaptureStream` plus `console.log` spy approach used to verify the new logging route
- story documentation was added at `docs/st09041-conversation-simulator-structured-logger.md`

## Test Strategy

- first failing automated test was added in `packages/testing/tests/runners/conversation-simulator.test.ts`
- the initial failure showed the injected logger stream stayed empty, proving verbose output was still using the direct console path
- focused regression tests now verify both enabled and disabled verbose behavior
- broader safety comes from package typecheck, explicit-`any` baseline check, full-suite validation, and repo lint

## Validation Performed

- `pnpm test --run packages/testing/tests/runners/conversation-simulator.test.ts`
- `pnpm --filter @agentforge/testing typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status

Ready for review
