### PR TITLE
ST-09047: Tighten JSON and HTTP Payload Schema Contracts

### DIFF
--- a/docs/st09047-json-http-payload-schema-contracts.md
+++ b/docs/st09047-json-http-payload-schema-contracts.md
@@ -1,0 +1,60 @@
+# ST-09047: Tighten JSON and HTTP Payload Schema Contracts
+
+## Summary
+
+Replaced broad JSON and HTTP payload `any` seams in `@agentforge/tools` with unknown-first schema contracts and an unknown-first `HttpResponse.data` boundary, while preserving JSON query/merge behavior and HTTP schema usage.
+
+## What Changed
+
+- changed JSON schemas in `packages/tools/src/data/json/types.ts`:
+  - `jsonStringifySchema.data` now uses `z.unknown()`
+  - `jsonQuerySchema.data` now uses `z.unknown()`
+  - `jsonMergeSchema.objects` now requires described `Record<string, unknown>` entries instead of blanket `z.any()`
+- changed HTTP types in `packages/tools/src/web/http/types.ts`:
+  - `httpRequestSchema.body` now uses `z.unknown()`
+  - `httpPostSchema.body` now uses `z.unknown()`
+  - `HttpResponse.data` is now `unknown`
+- hardened JSON tool implementations to match the stricter contracts:
+  - `packages/tools/src/data/json/tools/json-query.ts`
+  - `packages/tools/src/data/json/tools/json-merge.ts`
+- added focused regression coverage:
+  - `packages/tools/tests/data/json/json-types.test.ts`
+  - `packages/tools/tests/web/http-types.test.ts`
+
+## Test Strategy
+
+- first failing tests:
+  - `pnpm test --run packages/tools/tests/data/json/json-types.test.ts`
+  - failed because the JSON schema surfaces still exposed `ZodAny`
+  - `pnpm test --run packages/tools/tests/web/http-types.test.ts`
+  - the first run caught a test import-path mistake; after correcting the harness, the HTTP schema test validated the intended unknown-first body contract
+- focused follow-up validation:
+  - `pnpm test --run packages/tools/tests/data/json/json-types.test.ts packages/tools/tests/web/http-types.test.ts`
+  - `pnpm --filter @agentforge/tools typecheck`
+  - `pnpm --filter @agentforge/tools exec eslint src/data/json/types.ts src/data/json/tools/json-query.ts src/data/json/tools/json-merge.ts src/web/http/types.ts tests/data/json/json-types.test.ts tests/web/http-types.test.ts`
+  - `pnpm test --run`
+  - `pnpm lint`
+  - `pnpm lint:explicit-any:baseline`
+  - `git diff --check`
+
+## Behavior Notes
+
+- JSON query still supports dotted object traversal and array index access such as `roles[0].name`
+- JSON merge still preserves deep nested object merge behavior
+- HTTP request schemas still accept arbitrary request bodies; the contract is now explicit at the type boundary instead of flowing through `any`
+- `HttpResponse.data` is now caller-narrowed from `unknown`, matching the rest of the repo's unknown-first hardening direction
+
+## Explicit-`any` Impact
+
+- touched files:
+  - `packages/tools/src/data/json/types.ts`
+  - `packages/tools/src/web/http/types.ts`
+  - `packages/tools/src/data/json/tools/json-merge.ts`
+- explicit `any` delta for touched files:
+  - `packages/tools/src/data/json/types.ts`: removed `3` broad schema `any` seams
+  - `packages/tools/src/web/http/types.ts`: removed `3` payload/response `any` seams
+  - `packages/tools/src/data/json/tools/json-merge.ts`: removed `3` deep-merge helper `any` seams
+- current touched-file grep for `\\bany\\b` is clean
+- package typecheck and scoped eslint both pass after the contract shift
+- full-suite validation passed with `177` test files green (`16` skipped) and workspace lint passed with warnings only
+- explicit-`any` baseline improved from `90/289` to `84/289`, with `tools` improving from `59/67` to `53/67`

--- a/packages/tools/src/data/json/tools/json-merge.ts
+++ b/packages/tools/src/data/json/tools/json-merge.ts
@@ -11,22 +11,60 @@ function isMergeObject(value: unknown): value is MergeObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function setMergeProperty(target: MergeObject, key: string, value: unknown): void {
+  // Preserve user-visible keys like "__proto__" as own enumerable data properties
+  // without letting them mutate the target object's prototype.
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function cloneMergeObject(source: MergeObject): MergeObject {
+  const output: MergeObject = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (isMergeObject(value)) {
+      setMergeProperty(output, key, cloneMergeObject(value));
+      continue;
+    }
+
+    setMergeProperty(output, key, value);
+  }
+
+  return output;
+}
+
 function deepMerge(target: MergeObject, source: MergeObject): MergeObject {
-  const output: MergeObject = { ...target };
+  const output = cloneMergeObject(target);
 
   for (const [key, sourceValue] of Object.entries(source)) {
     const targetValue = output[key];
     if (isMergeObject(sourceValue) && isMergeObject(targetValue)) {
-      output[key] = deepMerge(targetValue, sourceValue);
+      setMergeProperty(output, key, deepMerge(targetValue, sourceValue));
       continue;
     }
 
     if (isMergeObject(sourceValue)) {
-      output[key] = deepMerge({}, sourceValue);
+      setMergeProperty(output, key, cloneMergeObject(sourceValue));
       continue;
     }
 
-    output[key] = sourceValue;
+    setMergeProperty(output, key, sourceValue);
+  }
+
+  return output;
+}
+
+function shallowMerge(objects: readonly MergeObject[]): MergeObject {
+  const output: MergeObject = {};
+
+  for (const object of objects) {
+    for (const [key, value] of Object.entries(object)) {
+      setMergeProperty(output, key, value);
+    }
   }
 
   return output;
@@ -46,7 +84,7 @@ export function createJsonMergeTool() {
       if (input.deep) {
         return input.objects.reduce<MergeObject>((acc, obj) => deepMerge(acc, obj), {});
       } else {
-        return Object.assign({}, ...input.objects);
+        return shallowMerge(input.objects);
       }
     })
     .build();

--- a/packages/tools/src/data/json/tools/json-merge.ts
+++ b/packages/tools/src/data/json/tools/json-merge.ts
@@ -5,6 +5,33 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { jsonMergeSchema } from '../types.js';
 
+type MergeObject = Record<string, unknown>;
+
+function isMergeObject(value: unknown): value is MergeObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(target: MergeObject, source: MergeObject): MergeObject {
+  const output: MergeObject = { ...target };
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    const targetValue = output[key];
+    if (isMergeObject(sourceValue) && isMergeObject(targetValue)) {
+      output[key] = deepMerge(targetValue, sourceValue);
+      continue;
+    }
+
+    if (isMergeObject(sourceValue)) {
+      output[key] = deepMerge({}, sourceValue);
+      continue;
+    }
+
+    output[key] = sourceValue;
+  }
+
+  return output;
+}
+
 /**
  * Create JSON merge tool
  */
@@ -17,25 +44,10 @@ export function createJsonMergeTool() {
     .schema(jsonMergeSchema)
     .implement(async (input) => {
       if (input.deep) {
-        // Deep merge
-        const deepMerge = (target: any, source: any): any => {
-          const output = { ...target };
-          for (const key in source) {
-            if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
-              output[key] = deepMerge(output[key] || {}, source[key]);
-            } else {
-              output[key] = source[key];
-            }
-          }
-          return output;
-        };
-        
-        return input.objects.reduce((acc, obj) => deepMerge(acc, obj), {});
+        return input.objects.reduce<MergeObject>((acc, obj) => deepMerge(acc, obj), {});
       } else {
-        // Shallow merge
         return Object.assign({}, ...input.objects);
       }
     })
     .build();
 }
-

--- a/packages/tools/src/data/json/tools/json-query.ts
+++ b/packages/tools/src/data/json/tools/json-query.ts
@@ -5,6 +5,33 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { jsonQuerySchema } from '../types.js';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getPathValue(current: unknown, part: string): unknown {
+  const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
+  if (arrayMatch) {
+    const [, key, index] = arrayMatch;
+    if (!isRecord(current)) {
+      return undefined;
+    }
+
+    const candidate = current[key];
+    if (!Array.isArray(candidate)) {
+      return undefined;
+    }
+
+    return candidate[parseInt(index, 10)];
+  }
+
+  if (!isRecord(current)) {
+    return undefined;
+  }
+
+  return current[part];
+}
+
 /**
  * Create JSON query tool
  */
@@ -20,15 +47,7 @@ export function createJsonQueryTool() {
       let current = input.data;
 
       for (const part of parts) {
-        // Handle array indexing: items[0]
-        const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
-        if (arrayMatch) {
-          const [, key, index] = arrayMatch;
-          current = current[key][parseInt(index, 10)];
-        } else {
-          current = current[part];
-        }
-
+        current = getPathValue(current, part);
         if (current === undefined) {
           throw new Error(`Path not found: ${input.path}`);
         }
@@ -41,4 +60,3 @@ export function createJsonQueryTool() {
     })
     .build();
 }
-

--- a/packages/tools/src/data/json/tools/json-query.ts
+++ b/packages/tools/src/data/json/tools/json-query.ts
@@ -6,7 +6,7 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { jsonQuerySchema } from '../types.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getPathValue(current: unknown, part: string): unknown {

--- a/packages/tools/src/data/json/types.ts
+++ b/packages/tools/src/data/json/types.ts
@@ -18,7 +18,7 @@ export const jsonParserSchema = z.object({
  * JSON stringify schema
  */
 export const jsonStringifySchema = z.object({
-  data: z.any().describe('Data to convert to JSON string'),
+  data: z.unknown().describe('Data to convert to JSON string'),
   pretty: z.boolean().default(false).describe('Format with indentation for readability'),
   indent: z.number().default(2).describe('Number of spaces for indentation (when pretty is true)'),
 });
@@ -27,7 +27,7 @@ export const jsonStringifySchema = z.object({
  * JSON query schema
  */
 export const jsonQuerySchema = z.object({
-  data: z.any().describe('JSON data to query'),
+  data: z.unknown().describe('JSON data to query'),
   path: z.string().describe('Dot notation path to query (e.g., "user.name" or "items[0].id")'),
 });
 
@@ -42,7 +42,9 @@ export const jsonValidatorSchema = z.object({
  * JSON merge schema
  */
 export const jsonMergeSchema = z.object({
-  objects: z.array(z.any().describe('Object to merge')).describe('Array of objects to merge'),
+  objects: z.array(
+    z.record(z.unknown().describe('Value associated with the object key')).describe('Object to merge')
+  ).describe('Array of objects to merge'),
   deep: z.boolean().default(false).describe('Perform deep merge (nested objects)'),
 });
 
@@ -53,4 +55,3 @@ export interface JsonToolsConfig {
   defaultIndent?: number;
   defaultPretty?: boolean;
 }
-

--- a/packages/tools/src/web/http/types.ts
+++ b/packages/tools/src/web/http/types.ts
@@ -18,7 +18,7 @@ export const httpRequestSchema = z.object({
   url: z.string().url().describe('The URL to make the request to'),
   method: HttpMethod.default('GET').describe('HTTP method to use'),
   headers: z.record(z.string()).optional().describe('Optional HTTP headers'),
-  body: z.any().optional().describe('Optional request body (for POST, PUT, PATCH)'),
+  body: z.unknown().optional().describe('Optional request body (for POST, PUT, PATCH)'),
   timeout: z.number().default(30000).describe('Request timeout in milliseconds'),
   params: z.record(z.string()).optional().describe('Optional URL query parameters'),
 });
@@ -30,7 +30,7 @@ export interface HttpResponse {
   status: number;
   statusText: string;
   headers: Record<string, string>;
-  data: any;
+  data: unknown;
   url: string;
   method: string;
 }
@@ -49,7 +49,7 @@ export const httpGetSchema = z.object({
  */
 export const httpPostSchema = z.object({
   url: z.string().url().describe('The URL to post to'),
-  body: z.any().describe('The request body (will be sent as JSON)'),
+  body: z.unknown().describe('The request body (will be sent as JSON)'),
   headers: z.record(z.string()).optional().describe('Optional HTTP headers'),
 });
 
@@ -60,4 +60,3 @@ export interface HttpToolsConfig {
   defaultTimeout?: number;
   defaultHeaders?: Record<string, string>;
 }
-

--- a/packages/tools/tests/data/json/json-types.test.ts
+++ b/packages/tools/tests/data/json/json-types.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { createJsonMergeTool } from '../../../src/data/json/tools/json-merge.js';
+import { createJsonQueryTool } from '../../../src/data/json/tools/json-query.js';
+import {
+  jsonMergeSchema,
+  jsonQuerySchema,
+  jsonStringifySchema,
+} from '../../../src/data/json/types.js';
+
+describe('json schemas', () => {
+  it('remove broad any payload seams while preserving valid inputs', () => {
+    expect(jsonStringifySchema.parse({
+      data: { id: 1, nested: { active: true }, tags: ['a'] },
+      pretty: true,
+      indent: 2,
+    })).toMatchObject({
+      data: { id: 1, nested: { active: true }, tags: ['a'] },
+      pretty: true,
+      indent: 2,
+    });
+
+    expect(jsonQuerySchema.parse({
+      data: { user: { name: 'Ada', roles: ['admin'] } },
+      path: 'user.name',
+    }).data).toEqual({ user: { name: 'Ada', roles: ['admin'] } });
+
+    expect(jsonMergeSchema.parse({
+      objects: [
+        { id: 1, nested: { enabled: true } },
+        { status: 'ok' },
+      ],
+      deep: true,
+    }).objects).toEqual([
+      { id: 1, nested: { enabled: true } },
+      { status: 'ok' },
+    ]);
+
+    expect(jsonStringifySchema.shape.data).toBeInstanceOf(z.ZodUnknown);
+    expect(jsonQuerySchema.shape.data).toBeInstanceOf(z.ZodUnknown);
+    expect(jsonMergeSchema.shape.objects.element).toBeInstanceOf(z.ZodRecord);
+
+    expect(() =>
+      jsonMergeSchema.parse({
+        objects: [{ id: 1 }, null],
+      })
+    ).toThrow();
+  });
+
+  it('preserve json query and deep merge behavior after unknown-first hardening', async () => {
+    const jsonQueryTool = createJsonQueryTool();
+    const jsonMergeTool = createJsonMergeTool();
+
+    await expect(jsonQueryTool.invoke({
+      data: {
+        user: {
+          profile: {
+            roles: [{ name: 'admin' }],
+          },
+        },
+      },
+      path: 'user.profile.roles[0].name',
+    })).resolves.toMatchObject({
+      success: true,
+      data: {
+        value: 'admin',
+        type: 'string',
+      },
+    });
+
+    await expect(jsonQueryTool.invoke({
+      data: { user: { name: 'Ada' } },
+      path: 'user.missing',
+    })).resolves.toMatchObject({
+      success: false,
+      error: 'Path not found: user.missing',
+    });
+
+    await expect(jsonMergeTool.invoke({
+      objects: [
+        { user: { name: 'Ada', flags: { active: true } } },
+        { user: { flags: { staff: true } }, status: 'ok' },
+      ],
+      deep: true,
+    })).resolves.toEqual({
+      user: {
+        name: 'Ada',
+        flags: {
+          active: true,
+          staff: true,
+        },
+      },
+      status: 'ok',
+    });
+  });
+});

--- a/packages/tools/tests/data/json/json-types.test.ts
+++ b/packages/tools/tests/data/json/json-types.test.ts
@@ -94,4 +94,49 @@ describe('json schemas', () => {
       status: 'ok',
     });
   });
+
+  it('reject array traversal as object records and harden merge special keys', async () => {
+    const jsonQueryTool = createJsonQueryTool();
+    const jsonMergeTool = createJsonMergeTool();
+
+    await expect(jsonQueryTool.invoke({
+      data: [['Ada']],
+      path: '0.name',
+    })).resolves.toMatchObject({
+      success: false,
+      error: 'Path not found: 0.name',
+    });
+
+    const polluted = await jsonMergeTool.invoke({
+      objects: [
+        {
+          safe: true,
+          ['__proto__']: { polluted: true },
+          constructor: 'ctor',
+          prototype: 'proto',
+        },
+      ],
+      deep: false,
+    });
+
+    expect(Object.getPrototypeOf(polluted)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyDescriptor(polluted, '__proto__')?.value).toEqual({ polluted: true });
+    expect(Object.getOwnPropertyDescriptor(polluted, 'constructor')?.value).toBe('ctor');
+    expect(Object.getOwnPropertyDescriptor(polluted, 'prototype')?.value).toBe('proto');
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+
+    const deepPolluted = await jsonMergeTool.invoke({
+      objects: [
+        { nested: { ['__proto__']: { polluted: true } } },
+        { nested: { safe: true } },
+      ],
+      deep: true,
+    });
+
+    expect(Object.getPrototypeOf(deepPolluted.nested as object)).toBe(Object.prototype);
+    expect(
+      Object.getOwnPropertyDescriptor(deepPolluted.nested as Record<string, unknown>, '__proto__')?.value
+    ).toEqual({ polluted: true });
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
 });

--- a/packages/tools/tests/web/http-types.test.ts
+++ b/packages/tools/tests/web/http-types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  httpPostSchema,
+  httpRequestSchema,
+} from '../../src/web/http/types.js';
+
+describe('http schemas', () => {
+  it('keep request payload boundaries unknown-first instead of any', () => {
+    expect(httpRequestSchema.parse({
+      url: 'https://example.com/api',
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: { ok: true, nested: ['x'] },
+      timeout: 5000,
+      params: { page: '1' },
+    })).toMatchObject({
+      url: 'https://example.com/api',
+      method: 'POST',
+      body: { ok: true, nested: ['x'] },
+      timeout: 5000,
+      params: { page: '1' },
+    });
+
+    expect(httpPostSchema.parse({
+      url: 'https://example.com/api',
+      body: { id: 1, active: true },
+      headers: { 'x-trace-id': 'trace-1' },
+    }).body).toEqual({ id: 1, active: true });
+
+    expect(httpRequestSchema.shape.body).toBeInstanceOf(z.ZodOptional);
+    expect(httpRequestSchema.shape.body.unwrap()).toBeInstanceOf(z.ZodUnknown);
+    expect(httpPostSchema.shape.body).toBeInstanceOf(z.ZodUnknown);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1877,25 +1877,40 @@ Focused validation notes:
 **Branch:** `refactor/st-09047-json-http-payload-schema-contracts`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09047-json-http-payload-schema-contracts`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover payload typing, request body serialization, and response data handling; first failing test should assert JSON/HTTP payload contracts no longer rely on broad `any`
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad schema or response payload `any` seams in `packages/tools/src/data/json/types.ts` and `packages/tools/src/web/http/types.ts` with unknown-first or JSON-safe contracts
-- [ ] Preserve JSON parse/stringify/query/merge behavior and HTTP request/response helper behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09047-json-http-payload-schema-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [x] Commit completed checklist items as logical commits and push updates
-  - `1509546` refactor(st-09048): modularize multi-agent routing
-  - `4b07c8a` docs(st-09048): capture review metadata
-  - `cf12350` fix(st-09048): harden routing strategy lookup
-  - `7820bc8` fix(st-09048): align routing fixtures and tracker state
+- [x] Create branch `refactor/st-09047-json-http-payload-schema-contracts`
+- [x] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: cover payload typing, request body serialization, and response data handling; first failing test should assert JSON/HTTP payload contracts no longer rely on broad `any`
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad schema or response payload `any` seams in `packages/tools/src/data/json/types.ts` and `packages/tools/src/web/http/types.ts` with unknown-first or JSON-safe contracts
+- [x] Preserve JSON parse/stringify/query/merge behavior and HTTP request/response helper behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09047-json-http-payload-schema-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Focused validation notes:
+
+- First failing schema gates:
+  - `pnpm test --run packages/tools/tests/data/json/json-types.test.ts`
+  - failed because JSON schemas still exposed `ZodAny` payload seams
+  - `pnpm test --run packages/tools/tests/web/http-types.test.ts`
+  - failed initially on the new test import path before the production assertion ran; corrected the harness, then the HTTP schema test exposed the `ZodAny` body seam as intended
+- Focused follow-up validation:
+  - `pnpm test --run packages/tools/tests/data/json/json-types.test.ts packages/tools/tests/web/http-types.test.ts`
+  - `2` files passed, `3` tests passed
+  - `pnpm --filter @agentforge/tools typecheck`
+  - `pnpm --filter @agentforge/tools exec eslint src/data/json/types.ts src/data/json/tools/json-query.ts src/data/json/tools/json-merge.ts src/web/http/types.ts tests/data/json/json-types.test.ts tests/web/http-types.test.ts`
+ - Full validation:
+   - `pnpm test --run` -> `177` files passed, `16` skipped; `2313` tests passed, `286` skipped
+   - `pnpm lint` -> passed with warnings only
+   - `pnpm lint:explicit-any:baseline` -> workspace `84/289`, tools `53/67`
+   - `git diff --check`
+   - Draft PR created as `#117`
 
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -1889,8 +1889,10 @@ Focused validation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `2249eb1` refactor(st-09047): tighten json and http payload contracts
+  - `c296911` docs(st-09047): capture validation and tracker state
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Focused validation notes:

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-20
-**Active Story:** None
+**Last Updated:** 2026-05-21
+**Active Story:** ST-09047 - Tighten JSON and HTTP Payload Schema Contracts
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-05-21
-**Active Story:** ST-09047 - Tighten JSON and HTTP Payload Schema Contracts
+**Active Story:** ST-09047 - Tighten JSON and HTTP Payload Schema Contracts (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 4 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -22,13 +22,13 @@
 
 ## In Progress
 
-- `ST-09047` - Tighten JSON and HTTP Payload Schema Contracts
+_No stories currently in progress_
 
 ---
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09047` - Tighten JSON and HTTP Payload Schema Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-20
+**Last Updated:** 2026-05-21
 
 ## Queue Status Summary
 
-- **Ready:** 5 stories
-- **In Progress:** 0 stories
+- **Ready:** 4 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09047` - Tighten JSON and HTTP Payload Schema Contracts
 - `ST-09049` - Modularize Core Tool Registry and Tests
 - `ST-09050` - Modularize Core Tool Builder and Tests
 - `ST-09051` - Modularize Multi-Agent Orchestration Agent and Tests
@@ -23,7 +22,7 @@
 
 ## In Progress
 
-_No stories currently in progress_
+- `ST-09047` - Tighten JSON and HTTP Payload Schema Contracts
 
 ---
 


### PR DESCRIPTION
## Story

- ST-09047 - Tighten JSON and HTTP Payload Schema Contracts

## What Changed

- replaced broad `any` payload seams in `packages/tools/src/data/json/types.ts` with unknown-first JSON schema contracts
- replaced broad `any` request/response seams in `packages/tools/src/web/http/types.ts` with unknown-first HTTP contracts
- hardened `json-query` and `json-merge` implementations to traverse and merge `unknown` values explicitly instead of relying on implicit `any`
- added focused regression coverage for schema boundaries and preserved JSON query/deep-merge behavior

## Acceptance Criteria Coverage

- payload typing, request-body serialization, and response data handling are covered by focused JSON and HTTP schema tests
- broad JSON and HTTP payload `any` seams in the targeted files are removed
- JSON query and merge behavior remains covered through focused runtime assertions
- package typecheck, scoped eslint, full test suite, workspace lint, explicit-`any` baseline, and `git diff --check` all pass

## Test Strategy

- first failing tests asserted that the new JSON and HTTP schema surfaces should no longer rely on `ZodAny`
- follow-up coverage added direct `json-query` and `json-merge` invocation checks to protect the runtime behavior touched by the contract hardening

## Validation Performed

- `pnpm test --run packages/tools/tests/data/json/json-types.test.ts packages/tools/tests/web/http-types.test.ts`
- `pnpm --filter @agentforge/tools typecheck`
- `pnpm --filter @agentforge/tools exec eslint src/data/json/types.ts src/data/json/tools/json-query.ts src/data/json/tools/json-merge.ts src/web/http/types.ts tests/data/json/json-types.test.ts tests/web/http-types.test.ts`
- `pnpm test --run`
- `pnpm lint`
- `pnpm lint:explicit-any:baseline`
- `git diff --check`

## Status

- Ready for review
- Full validation complete
- Story tracker moved to In Review
