### PR TITLE
ST-09055: Modularize Relational Schema Inspector and Tests

### DIFF
--- a/docs/st09055-schema-inspector-modularization.md
+++ b/docs/st09055-schema-inspector-modularization.md
@@ -1,0 +1,60 @@
+# ST-09055: Schema Inspector Modularization
+
+## Summary
+
+`ST-09055` modularizes the relational schema inspector runtime and its coupled tests without changing public behavior. The public `SchemaInspector` facade remains stable while vendor-specific inspection, shared normalization helpers, and cache/filter orchestration are split into focused internal modules.
+
+## Test Strategy
+
+A structure-only failing test would mostly prove file layout rather than schema-inspection behavior. For this story, the real contract is preserving schema discovery output, metadata shape, cache semantics, table filtering, and public imports while splitting the oversized runtime and coupled test surface.
+
+The practical test-first substitute was:
+
+- split the existing schema-inspector test surface into focused PostgreSQL, cache, and filter suites first
+- use those focused suites as the regression net while extracting vendor-specific and shared runtime responsibilities behind the stable public facade
+
+No additional CI automation was required because the existing `@agentforge/tools` typecheck, focused test runs, workspace test suite, lint, and explicit-`any` baseline gate already cover the changed surfaces.
+
+## Runtime And Test Layout
+
+### Production
+
+- `packages/tools/src/data/relational/schema/schema-inspector.ts`: `725` -> `126` lines
+- Added `packages/tools/src/data/relational/schema/schema-inspector-shared.ts`: `249` lines
+- Added `packages/tools/src/data/relational/schema/schema-inspector-postgresql.ts`: `155` lines
+- Added `packages/tools/src/data/relational/schema/schema-inspector-mysql.ts`: `135` lines
+- Added `packages/tools/src/data/relational/schema/schema-inspector-sqlite.ts`: `95` lines
+
+### Tests
+
+- Replaced `packages/tools/tests/data/relational/schema-inspector.test.ts`: `152` lines
+- Added `packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts`: `86` lines
+- Added `packages/tools/tests/data/relational/schema-inspector-cache.test.ts`: `41` lines
+- Added `packages/tools/tests/data/relational/schema-inspector-filters.test.ts`: `38` lines
+- Added shared test helper `packages/tools/tests/data/relational/schema-inspector.test-utils.ts`
+
+## Behavior Preserved
+
+- PostgreSQL, MySQL, and SQLite schema-inspection entrypoints still return the same `DatabaseSchema` shape
+- cache-key, cache-TTL, and explicit invalidation semantics remain unchanged
+- table filter validation and filtered schema output remain unchanged
+- public `SchemaInspector` imports and invocation flow remain unchanged
+
+## Explicit-`any` Baseline
+
+- `pnpm lint:explicit-any:baseline` remained stable at `84/289` workspace warnings
+- `@agentforge/tools` remained stable at `53/67`
+
+## Validation
+
+- Focused schema-inspector suites:
+  - `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts`
+  - `3` files passed, `3` tests passed
+- Package checks:
+  - `pnpm --filter @agentforge/tools typecheck`
+  - `pnpm --filter @agentforge/tools exec eslint src/data/relational/schema/schema-inspector.ts src/data/relational/schema/schema-inspector-shared.ts src/data/relational/schema/schema-inspector-postgresql.ts src/data/relational/schema/schema-inspector-mysql.ts src/data/relational/schema/schema-inspector-sqlite.ts tests/data/relational/schema-inspector.test-utils.ts tests/data/relational/schema-inspector-postgresql.test.ts tests/data/relational/schema-inspector-cache.test.ts tests/data/relational/schema-inspector-filters.test.ts`
+- Workspace checks:
+  - `pnpm lint:explicit-any:baseline`
+  - `pnpm test --run` -> `202` files passed, `18` skipped; `2313` tests passed, `286` skipped
+  - `pnpm lint` -> passed with warnings only
+  - `git diff --check`

--- a/docs/st09055-schema-inspector-modularization.md
+++ b/docs/st09055-schema-inspector-modularization.md
@@ -49,7 +49,7 @@ No additional CI automation was required because the existing `@agentforge/tools
 
 - Focused schema-inspector suites:
   - `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts`
-  - `3` files passed, `3` tests passed
+  - `3` files passed, `4` tests passed
 - Package checks:
   - `pnpm --filter @agentforge/tools typecheck`
   - `pnpm --filter @agentforge/tools exec eslint src/data/relational/schema/schema-inspector.ts src/data/relational/schema/schema-inspector-shared.ts src/data/relational/schema/schema-inspector-postgresql.ts src/data/relational/schema/schema-inspector-mysql.ts src/data/relational/schema/schema-inspector-sqlite.ts tests/data/relational/schema-inspector.test-utils.ts tests/data/relational/schema-inspector-postgresql.test.ts tests/data/relational/schema-inspector-cache.test.ts tests/data/relational/schema-inspector-filters.test.ts`

--- a/packages/tools/src/data/relational/schema/schema-inspector-mysql.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector-mysql.ts
@@ -1,0 +1,135 @@
+import type { ForeignKeySchema, TableSchema } from './types.js';
+import {
+  applyIndexRows,
+  applyPrimaryKeyColumn,
+  createColumnSchema,
+  createTableMap,
+  getTableFromRow,
+  toBooleanValue,
+  toOptionalStringValue,
+  toStringValue,
+} from './schema-inspector-shared.js';
+
+const MYSQL_TABLES_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name AS table_name
+FROM information_schema.tables
+WHERE table_type = 'BASE TABLE'
+  AND table_schema = DATABASE()
+ORDER BY table_name
+`;
+
+const MYSQL_COLUMNS_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name AS table_name,
+  column_name AS column_name,
+  column_type AS data_type,
+  is_nullable AS is_nullable,
+  column_default AS column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+ORDER BY table_name, ordinal_position
+`;
+
+const MYSQL_PRIMARY_KEYS_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name AS table_name,
+  column_name AS column_name,
+  ordinal_position AS key_position
+FROM information_schema.key_column_usage
+WHERE table_schema = DATABASE()
+  AND constraint_name = 'PRIMARY'
+ORDER BY table_name, ordinal_position
+`;
+
+const MYSQL_FOREIGN_KEYS_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name AS table_name,
+  constraint_name AS constraint_name,
+  column_name AS column_name,
+  referenced_table_schema AS referenced_schema_name,
+  referenced_table_name AS referenced_table_name,
+  referenced_column_name AS referenced_column_name
+FROM information_schema.key_column_usage
+WHERE table_schema = DATABASE()
+  AND referenced_table_name IS NOT NULL
+ORDER BY table_name, constraint_name, ordinal_position
+`;
+
+const MYSQL_INDEXES_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name AS table_name,
+  index_name AS index_name,
+  non_unique AS non_unique,
+  column_name AS column_name,
+  seq_in_index AS seq_in_index
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND index_name <> 'PRIMARY'
+ORDER BY table_name, index_name, seq_in_index
+`;
+
+export async function inspectMySQL(
+  runQueryRows: (query: string) => Promise<Array<Record<string, unknown>>>,
+): Promise<TableSchema[]> {
+  const tableRows = await runQueryRows(MYSQL_TABLES_QUERY);
+  const tableMap = createTableMap(
+    tableRows.map((row) => ({
+      schemaName: toOptionalStringValue(row.schema_name),
+      tableName: toStringValue(row.table_name),
+    })),
+  );
+
+  const columnsRows = await runQueryRows(MYSQL_COLUMNS_QUERY);
+  for (const row of columnsRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    table.columns.push(createColumnSchema(row));
+  }
+
+  const primaryKeyRows = await runQueryRows(MYSQL_PRIMARY_KEYS_QUERY);
+  for (const row of primaryKeyRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    applyPrimaryKeyColumn(table, toStringValue(row.column_name));
+  }
+
+  const foreignKeyRows = await runQueryRows(MYSQL_FOREIGN_KEYS_QUERY);
+  for (const row of foreignKeyRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    const foreignKey: ForeignKeySchema = {
+      name: toOptionalStringValue(row.constraint_name),
+      column: toStringValue(row.column_name),
+      referencedSchema: toOptionalStringValue(row.referenced_schema_name),
+      referencedTable: toStringValue(row.referenced_table_name),
+      referencedColumn: toStringValue(row.referenced_column_name),
+    };
+
+    table.foreignKeys.push(foreignKey);
+  }
+
+  const indexRows = await runQueryRows(MYSQL_INDEXES_QUERY);
+  applyIndexRows(tableMap, indexRows, 'table_name', 'schema_name', {
+    indexNameField: 'index_name',
+    columnField: 'column_name',
+    positionField: 'seq_in_index',
+    uniqueResolver: (row) => !toBooleanValue(row.non_unique),
+  });
+
+  return Array.from(tableMap.values());
+}

--- a/packages/tools/src/data/relational/schema/schema-inspector-postgresql.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector-postgresql.ts
@@ -1,0 +1,155 @@
+import type { ForeignKeySchema, TableSchema } from './types.js';
+import {
+  applyIndexRows,
+  applyPrimaryKeyColumn,
+  createColumnSchema,
+  createTableMap,
+  getTableFromRow,
+  toOptionalStringValue,
+  toStringValue,
+  toBooleanValue,
+} from './schema-inspector-shared.js';
+
+const POSTGRES_TABLES_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name
+FROM information_schema.tables
+WHERE table_type = 'BASE TABLE'
+  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name
+`;
+
+const POSTGRES_COLUMNS_QUERY = `
+SELECT
+  table_schema AS schema_name,
+  table_name,
+  column_name,
+  data_type,
+  is_nullable,
+  column_default
+FROM information_schema.columns
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name, ordinal_position
+`;
+
+const POSTGRES_PRIMARY_KEYS_QUERY = `
+SELECT
+  kcu.table_schema AS schema_name,
+  kcu.table_name,
+  kcu.column_name,
+  kcu.ordinal_position AS key_position
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+ AND tc.table_name = kcu.table_name
+WHERE tc.constraint_type = 'PRIMARY KEY'
+ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position
+`;
+
+const POSTGRES_FOREIGN_KEYS_QUERY = `
+SELECT
+  tc.table_schema AS schema_name,
+  tc.table_name,
+  tc.constraint_name,
+  kcu.column_name,
+  ccu.table_schema AS referenced_schema_name,
+  ccu.table_name AS referenced_table_name,
+  ccu.column_name AS referenced_column_name
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_name = tc.constraint_name
+ AND ccu.table_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+ORDER BY tc.table_schema, tc.table_name, tc.constraint_name, kcu.ordinal_position
+`;
+
+const POSTGRES_INDEXES_QUERY = `
+SELECT
+  ns.nspname AS schema_name,
+  tbl.relname AS table_name,
+  idx.relname AS index_name,
+  ix.indisunique AS is_unique,
+  att.attname AS column_name,
+  ord.ordinality AS column_position
+FROM pg_class tbl
+JOIN pg_namespace ns
+  ON ns.oid = tbl.relnamespace
+JOIN pg_index ix
+  ON ix.indrelid = tbl.oid
+JOIN pg_class idx
+  ON idx.oid = ix.indexrelid
+JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS ord(attnum, ordinality)
+  ON true
+JOIN pg_attribute att
+  ON att.attrelid = tbl.oid
+ AND att.attnum = ord.attnum
+WHERE tbl.relkind = 'r'
+  AND ns.nspname NOT IN ('pg_catalog', 'information_schema')
+  AND ix.indisprimary = false
+ORDER BY ns.nspname, tbl.relname, idx.relname, ord.ordinality
+`;
+
+export async function inspectPostgreSQL(
+  runQueryRows: (query: string) => Promise<Array<Record<string, unknown>>>,
+): Promise<TableSchema[]> {
+  const tableRows = await runQueryRows(POSTGRES_TABLES_QUERY);
+  const tableMap = createTableMap(
+    tableRows.map((row) => ({
+      schemaName: toOptionalStringValue(row.schema_name),
+      tableName: toStringValue(row.table_name),
+    })),
+  );
+
+  const columnsRows = await runQueryRows(POSTGRES_COLUMNS_QUERY);
+  for (const row of columnsRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    table.columns.push(createColumnSchema(row));
+  }
+
+  const primaryKeyRows = await runQueryRows(POSTGRES_PRIMARY_KEYS_QUERY);
+  for (const row of primaryKeyRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    applyPrimaryKeyColumn(table, toStringValue(row.column_name));
+  }
+
+  const foreignKeyRows = await runQueryRows(POSTGRES_FOREIGN_KEYS_QUERY);
+  for (const row of foreignKeyRows) {
+    const table = getTableFromRow(tableMap, row, 'table_name', 'schema_name');
+    if (!table) {
+      continue;
+    }
+
+    const foreignKey: ForeignKeySchema = {
+      name: toOptionalStringValue(row.constraint_name),
+      column: toStringValue(row.column_name),
+      referencedSchema: toOptionalStringValue(row.referenced_schema_name),
+      referencedTable: toStringValue(row.referenced_table_name),
+      referencedColumn: toStringValue(row.referenced_column_name),
+    };
+
+    table.foreignKeys.push(foreignKey);
+  }
+
+  const indexRows = await runQueryRows(POSTGRES_INDEXES_QUERY);
+  applyIndexRows(tableMap, indexRows, 'table_name', 'schema_name', {
+    indexNameField: 'index_name',
+    columnField: 'column_name',
+    positionField: 'column_position',
+    uniqueResolver: (row) => toBooleanValue(row.is_unique),
+  });
+
+  return Array.from(tableMap.values());
+}

--- a/packages/tools/src/data/relational/schema/schema-inspector-shared.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector-shared.ts
@@ -1,0 +1,249 @@
+import { VALID_TABLE_FILTER_PATTERN } from './validation.js';
+import type {
+  ColumnSchema,
+  DatabaseSchema,
+  IndexSchema,
+  TableSchema,
+} from './types.js';
+
+export interface QueryRow {
+  [key: string]: unknown;
+}
+
+export interface TableRef {
+  schemaName?: string;
+  tableName: string;
+}
+
+interface IndexGroupEntry {
+  table: TableSchema;
+  indexName: string;
+  isUnique: boolean;
+  columnsByPosition: Array<{ position: number; column: string }>;
+}
+
+export function normalizeFilterName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function buildTableKey(tableName: string, schemaName?: string): string {
+  return schemaName ? `${schemaName}.${tableName}` : tableName;
+}
+
+export function toStringValue(value: unknown): string {
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+export function toOptionalStringValue(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const result = toStringValue(value);
+  return result.length > 0 ? result : undefined;
+}
+
+export function toBooleanValue(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'yes' || normalized === 'true' || normalized === 't' || normalized === '1';
+  }
+
+  return false;
+}
+
+export function toNumberValue(value: unknown): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  return 0;
+}
+
+export function validateTableFilters(tables?: string[]): Set<string> | null {
+  if (!tables) {
+    return null;
+  }
+
+  if (tables.length === 0) {
+    throw new Error('Tables filter must not be empty when provided');
+  }
+
+  const normalized = new Set<string>();
+  for (const table of tables) {
+    const trimmed = table.trim();
+    if (!VALID_TABLE_FILTER_PATTERN.test(trimmed)) {
+      throw new Error(
+        `Invalid table filter "${table}". Table filter contains invalid characters. Use alphanumeric, underscore, and optional schema qualification.`,
+      );
+    }
+    normalized.add(normalizeFilterName(trimmed));
+  }
+
+  return normalized;
+}
+
+export function cloneSchema(schema: DatabaseSchema): DatabaseSchema {
+  return {
+    vendor: schema.vendor,
+    generatedAt: schema.generatedAt,
+    tables: schema.tables.map((table) => ({
+      name: table.name,
+      schema: table.schema,
+      primaryKey: [...table.primaryKey],
+      columns: table.columns.map((column) => ({ ...column })),
+      foreignKeys: table.foreignKeys.map((foreignKey) => ({ ...foreignKey })),
+      indexes: table.indexes.map((index) => ({
+        name: index.name,
+        isUnique: index.isUnique,
+        columns: [...index.columns],
+      })),
+    })),
+  };
+}
+
+export function filterSchemaTables(schema: DatabaseSchema, tableFilters: Set<string> | null): DatabaseSchema {
+  if (!tableFilters) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    tables: schema.tables.filter((table) => {
+      const bare = normalizeFilterName(table.name);
+      const qualified = table.schema
+        ? normalizeFilterName(`${table.schema}.${table.name}`)
+        : bare;
+
+      return tableFilters.has(bare) || tableFilters.has(qualified);
+    }),
+  };
+}
+
+export function escapeSqliteStringLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export function sortColumnsByPosition(columnsByPosition: Array<{ position: number; column: string }>): string[] {
+  return columnsByPosition
+    .sort((a, b) => a.position - b.position)
+    .map((entry) => entry.column);
+}
+
+export function createTableMap(refs: TableRef[]): Map<string, TableSchema> {
+  const tableMap = new Map<string, TableSchema>();
+
+  for (const ref of refs) {
+    const key = buildTableKey(ref.tableName, ref.schemaName);
+    tableMap.set(key, {
+      name: ref.tableName,
+      schema: ref.schemaName,
+      columns: [],
+      primaryKey: [],
+      foreignKeys: [],
+      indexes: [],
+    });
+  }
+
+  return tableMap;
+}
+
+export function getTableFromRow(
+  tableMap: Map<string, TableSchema>,
+  row: QueryRow,
+  tableField: string,
+  schemaField?: string,
+): TableSchema | undefined {
+  const tableName = toStringValue(row[tableField]);
+  const schemaName = schemaField ? toOptionalStringValue(row[schemaField]) : undefined;
+  const key = buildTableKey(tableName, schemaName);
+  return tableMap.get(key);
+}
+
+export function createColumnSchema(row: QueryRow, fields?: {
+  name?: string;
+  type?: string;
+  nullable?: string;
+  defaultValue?: string;
+  primaryKey?: boolean;
+}): ColumnSchema {
+  return {
+    name: toStringValue(row[fields?.name ?? 'column_name']),
+    type: toStringValue(row[fields?.type ?? 'data_type']),
+    isNullable: toBooleanValue(row[fields?.nullable ?? 'is_nullable']),
+    defaultValue: row[fields?.defaultValue ?? 'column_default'] ?? null,
+    isPrimaryKey: fields?.primaryKey ?? false,
+  };
+}
+
+export function applyPrimaryKeyColumn(table: TableSchema, columnName: string): void {
+  table.primaryKey.push(columnName);
+
+  const column = table.columns.find((entry) => entry.name === columnName);
+  if (column) {
+    column.isPrimaryKey = true;
+  }
+}
+
+export function applyIndexRows(
+  tableMap: Map<string, TableSchema>,
+  rows: QueryRow[],
+  tableField: string,
+  schemaField: string | undefined,
+  config: {
+    indexNameField: string;
+    columnField: string;
+    positionField: string;
+    uniqueResolver: (row: QueryRow) => boolean;
+  },
+): void {
+  const grouped = new Map<string, IndexGroupEntry>();
+
+  for (const row of rows) {
+    const table = getTableFromRow(tableMap, row, tableField, schemaField);
+    if (!table) {
+      continue;
+    }
+
+    const indexName = toStringValue(row[config.indexNameField]);
+    if (!indexName) {
+      continue;
+    }
+
+    const groupKey = `${table.schema ?? ''}.${table.name}.${indexName}`;
+    const entry = grouped.get(groupKey) ?? {
+      table,
+      indexName,
+      isUnique: config.uniqueResolver(row),
+      columnsByPosition: [],
+    };
+
+    entry.columnsByPosition.push({
+      position: toNumberValue(row[config.positionField]),
+      column: toStringValue(row[config.columnField]),
+    });
+    grouped.set(groupKey, entry);
+  }
+
+  for (const entry of grouped.values()) {
+    const index: IndexSchema = {
+      name: entry.indexName,
+      isUnique: entry.isUnique,
+      columns: sortColumnsByPosition(entry.columnsByPosition),
+    };
+    entry.table.indexes.push(index);
+  }
+}

--- a/packages/tools/src/data/relational/schema/schema-inspector-sqlite.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector-sqlite.ts
@@ -1,0 +1,95 @@
+import type { ForeignKeySchema, IndexSchema, TableSchema } from './types.js';
+import {
+  createColumnSchema,
+  createTableMap,
+  escapeSqliteStringLiteral,
+  sortColumnsByPosition,
+  toBooleanValue,
+  toNumberValue,
+  toStringValue,
+} from './schema-inspector-shared.js';
+
+const SQLITE_TABLES_QUERY = `
+SELECT
+  name AS table_name
+FROM sqlite_master
+WHERE type = 'table'
+  AND name NOT LIKE 'sqlite_%'
+ORDER BY name
+`;
+
+export async function inspectSQLite(
+  runQueryRows: (query: string) => Promise<Array<Record<string, unknown>>>,
+): Promise<TableSchema[]> {
+  const tableRows = await runQueryRows(SQLITE_TABLES_QUERY);
+  const tableMap = createTableMap(
+    tableRows.map((row) => ({
+      tableName: toStringValue(row.table_name),
+    })),
+  );
+
+  for (const table of tableMap.values()) {
+    const tableLiteral = escapeSqliteStringLiteral(table.name);
+
+    const columnRows = await runQueryRows(`PRAGMA table_info('${tableLiteral}')`);
+    const primaryKeyColumns: Array<{ position: number; column: string }> = [];
+
+    for (const row of columnRows) {
+      const pkPosition = toNumberValue(row.pk);
+      const columnName = toStringValue(row.name);
+
+      if (pkPosition > 0) {
+        primaryKeyColumns.push({ position: pkPosition, column: columnName });
+      }
+
+      table.columns.push(
+        createColumnSchema(row, {
+          name: 'name',
+          type: 'type',
+          nullable: 'notnull',
+          defaultValue: 'dflt_value',
+          primaryKey: pkPosition > 0,
+        }),
+      );
+      table.columns[table.columns.length - 1].isNullable = !toBooleanValue(row.notnull);
+    }
+
+    table.primaryKey = sortColumnsByPosition(primaryKeyColumns);
+
+    const foreignKeyRows = await runQueryRows(`PRAGMA foreign_key_list('${tableLiteral}')`);
+    for (const row of foreignKeyRows) {
+      const foreignKey: ForeignKeySchema = {
+        column: toStringValue(row.from),
+        referencedTable: toStringValue(row.table),
+        referencedColumn: toStringValue(row.to),
+      };
+      table.foreignKeys.push(foreignKey);
+    }
+
+    const indexListRows = await runQueryRows(`PRAGMA index_list('${tableLiteral}')`);
+    for (const indexRow of indexListRows) {
+      const indexName = toStringValue(indexRow.name);
+      if (!indexName || toStringValue(indexRow.origin) === 'pk') {
+        continue;
+      }
+
+      const indexNameLiteral = escapeSqliteStringLiteral(indexName);
+      const indexInfoRows = await runQueryRows(`PRAGMA index_info('${indexNameLiteral}')`);
+      const indexColumns = sortColumnsByPosition(
+        indexInfoRows.map((row) => ({
+          position: toNumberValue(row.seqno),
+          column: toStringValue(row.name),
+        })),
+      );
+
+      const index: IndexSchema = {
+        name: indexName,
+        isUnique: toBooleanValue(indexRow.unique),
+        columns: indexColumns,
+      };
+      table.indexes.push(index);
+    }
+  }
+
+  return Array.from(tableMap.values());
+}

--- a/packages/tools/src/data/relational/schema/schema-inspector-sqlite.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector-sqlite.ts
@@ -42,16 +42,15 @@ export async function inspectSQLite(
         primaryKeyColumns.push({ position: pkPosition, column: columnName });
       }
 
-      table.columns.push(
-        createColumnSchema(row, {
-          name: 'name',
-          type: 'type',
-          nullable: 'notnull',
-          defaultValue: 'dflt_value',
-          primaryKey: pkPosition > 0,
-        }),
-      );
-      table.columns[table.columns.length - 1].isNullable = !toBooleanValue(row.notnull);
+      const column = createColumnSchema(row, {
+        name: 'name',
+        type: 'type',
+        nullable: 'notnull',
+        defaultValue: 'dflt_value',
+        primaryKey: pkPosition > 0,
+      });
+      column.isNullable = !toBooleanValue(row.notnull);
+      table.columns.push(column);
     }
 
     table.primaryKey = sortColumnsByPosition(primaryKeyColumns);

--- a/packages/tools/src/data/relational/schema/schema-inspector.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector.ts
@@ -112,6 +112,8 @@ export class SchemaInspector {
         return inspectMySQL((query) => this.runQueryRows(query));
       case 'sqlite':
         return inspectSQLite((query) => this.runQueryRows(query));
+      default:
+        throw new Error(`Unsupported database vendor: ${String(this.vendor)}`);
     }
   }
 

--- a/packages/tools/src/data/relational/schema/schema-inspector.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector.ts
@@ -7,29 +7,24 @@ import { createLogger } from '@agentforge/core';
 import type { ConnectionManager } from '../connection/connection-manager.js';
 import { executeQuery } from '../query/query-executor.js';
 import type { DatabaseVendor } from '../types.js';
-import { VALID_TABLE_FILTER_PATTERN } from './validation.js';
+import { inspectMySQL } from './schema-inspector-mysql.js';
+import { inspectPostgreSQL } from './schema-inspector-postgresql.js';
+import {
+  cloneSchema,
+  filterSchemaTables,
+  validateTableFilters,
+  type QueryRow,
+} from './schema-inspector-shared.js';
+import { inspectSQLite } from './schema-inspector-sqlite.js';
 import type {
-  ColumnSchema,
   DatabaseSchema,
-  ForeignKeySchema,
-  IndexSchema,
   SchemaInspectOptions,
   SchemaInspectorConfig,
   TableSchema,
 } from './types.js';
 
 const logger = createLogger('agentforge:tools:data:relational:schema-inspector');
-
 const DEFAULT_CACHE_TTL_MS = 60_000;
-
-interface QueryRow {
-  [key: string]: unknown;
-}
-
-interface TableRef {
-  schemaName?: string;
-  tableName: string;
-}
 
 interface CacheEntry {
   expiresAt: number;
@@ -37,284 +32,6 @@ interface CacheEntry {
 }
 
 const schemaCache = new Map<string, CacheEntry>();
-
-const POSTGRES_TABLES_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name
-FROM information_schema.tables
-WHERE table_type = 'BASE TABLE'
-  AND table_schema NOT IN ('pg_catalog', 'information_schema')
-ORDER BY table_schema, table_name
-`;
-
-const POSTGRES_COLUMNS_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name,
-  column_name,
-  data_type,
-  is_nullable,
-  column_default
-FROM information_schema.columns
-WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-ORDER BY table_schema, table_name, ordinal_position
-`;
-
-const POSTGRES_PRIMARY_KEYS_QUERY = `
-SELECT
-  kcu.table_schema AS schema_name,
-  kcu.table_name,
-  kcu.column_name,
-  kcu.ordinal_position AS key_position
-FROM information_schema.table_constraints tc
-JOIN information_schema.key_column_usage kcu
-  ON tc.constraint_name = kcu.constraint_name
- AND tc.table_schema = kcu.table_schema
- AND tc.table_name = kcu.table_name
-WHERE tc.constraint_type = 'PRIMARY KEY'
-ORDER BY kcu.table_schema, kcu.table_name, kcu.ordinal_position
-`;
-
-const POSTGRES_FOREIGN_KEYS_QUERY = `
-SELECT
-  tc.table_schema AS schema_name,
-  tc.table_name,
-  tc.constraint_name,
-  kcu.column_name,
-  ccu.table_schema AS referenced_schema_name,
-  ccu.table_name AS referenced_table_name,
-  ccu.column_name AS referenced_column_name
-FROM information_schema.table_constraints tc
-JOIN information_schema.key_column_usage kcu
-  ON tc.constraint_name = kcu.constraint_name
- AND tc.table_schema = kcu.table_schema
-JOIN information_schema.constraint_column_usage ccu
-  ON ccu.constraint_name = tc.constraint_name
- AND ccu.table_schema = tc.table_schema
-WHERE tc.constraint_type = 'FOREIGN KEY'
-ORDER BY tc.table_schema, tc.table_name, tc.constraint_name, kcu.ordinal_position
-`;
-
-const POSTGRES_INDEXES_QUERY = `
-SELECT
-  ns.nspname AS schema_name,
-  tbl.relname AS table_name,
-  idx.relname AS index_name,
-  ix.indisunique AS is_unique,
-  att.attname AS column_name,
-  ord.ordinality AS column_position
-FROM pg_class tbl
-JOIN pg_namespace ns
-  ON ns.oid = tbl.relnamespace
-JOIN pg_index ix
-  ON ix.indrelid = tbl.oid
-JOIN pg_class idx
-  ON idx.oid = ix.indexrelid
-JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS ord(attnum, ordinality)
-  ON true
-JOIN pg_attribute att
-  ON att.attrelid = tbl.oid
- AND att.attnum = ord.attnum
-WHERE tbl.relkind = 'r'
-  AND ns.nspname NOT IN ('pg_catalog', 'information_schema')
-  AND ix.indisprimary = false
-ORDER BY ns.nspname, tbl.relname, idx.relname, ord.ordinality
-`;
-
-const MYSQL_TABLES_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name AS table_name
-FROM information_schema.tables
-WHERE table_type = 'BASE TABLE'
-  AND table_schema = DATABASE()
-ORDER BY table_name
-`;
-
-const MYSQL_COLUMNS_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name AS table_name,
-  column_name AS column_name,
-  column_type AS data_type,
-  is_nullable AS is_nullable,
-  column_default AS column_default
-FROM information_schema.columns
-WHERE table_schema = DATABASE()
-ORDER BY table_name, ordinal_position
-`;
-
-const MYSQL_PRIMARY_KEYS_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name AS table_name,
-  column_name AS column_name,
-  ordinal_position AS key_position
-FROM information_schema.key_column_usage
-WHERE table_schema = DATABASE()
-  AND constraint_name = 'PRIMARY'
-ORDER BY table_name, ordinal_position
-`;
-
-const MYSQL_FOREIGN_KEYS_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name AS table_name,
-  constraint_name AS constraint_name,
-  column_name AS column_name,
-  referenced_table_schema AS referenced_schema_name,
-  referenced_table_name AS referenced_table_name,
-  referenced_column_name AS referenced_column_name
-FROM information_schema.key_column_usage
-WHERE table_schema = DATABASE()
-  AND referenced_table_name IS NOT NULL
-ORDER BY table_name, constraint_name, ordinal_position
-`;
-
-const MYSQL_INDEXES_QUERY = `
-SELECT
-  table_schema AS schema_name,
-  table_name AS table_name,
-  index_name AS index_name,
-  non_unique AS non_unique,
-  column_name AS column_name,
-  seq_in_index AS seq_in_index
-FROM information_schema.statistics
-WHERE table_schema = DATABASE()
-  AND index_name <> 'PRIMARY'
-ORDER BY table_name, index_name, seq_in_index
-`;
-
-const SQLITE_TABLES_QUERY = `
-SELECT
-  name AS table_name
-FROM sqlite_master
-WHERE type = 'table'
-  AND name NOT LIKE 'sqlite_%'
-ORDER BY name
-`;
-
-function normalizeFilterName(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function buildTableKey(tableName: string, schemaName?: string): string {
-  return schemaName ? `${schemaName}.${tableName}` : tableName;
-}
-
-function toStringValue(value: unknown): string {
-  return typeof value === 'string' ? value : String(value ?? '');
-}
-
-function toOptionalStringValue(value: unknown): string | undefined {
-  if (value === null || value === undefined) {
-    return undefined;
-  }
-
-  const result = toStringValue(value);
-  return result.length > 0 ? result : undefined;
-}
-
-function toBooleanValue(value: unknown): boolean {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-
-  if (typeof value === 'number') {
-    return value !== 0;
-  }
-
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    return normalized === 'yes' || normalized === 'true' || normalized === 't' || normalized === '1';
-  }
-
-  return false;
-}
-
-function toNumberValue(value: unknown): number {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  }
-
-  return 0;
-}
-
-function validateTableFilters(tables?: string[]): Set<string> | null {
-  if (!tables) {
-    return null;
-  }
-
-  if (tables.length === 0) {
-    throw new Error('Tables filter must not be empty when provided');
-  }
-
-  const normalized = new Set<string>();
-  for (const table of tables) {
-    const trimmed = table.trim();
-    if (!VALID_TABLE_FILTER_PATTERN.test(trimmed)) {
-      throw new Error(
-        `Invalid table filter "${table}". Table filter contains invalid characters. Use alphanumeric, underscore, and optional schema qualification.`,
-      );
-    }
-    normalized.add(normalizeFilterName(trimmed));
-  }
-
-  return normalized;
-}
-
-function cloneSchema(schema: DatabaseSchema): DatabaseSchema {
-  return {
-    vendor: schema.vendor,
-    generatedAt: schema.generatedAt,
-    tables: schema.tables.map((table) => ({
-      name: table.name,
-      schema: table.schema,
-      primaryKey: [...table.primaryKey],
-      columns: table.columns.map((column) => ({ ...column })),
-      foreignKeys: table.foreignKeys.map((foreignKey) => ({ ...foreignKey })),
-      indexes: table.indexes.map((index) => ({
-        name: index.name,
-        isUnique: index.isUnique,
-        columns: [...index.columns],
-      })),
-    })),
-  };
-}
-
-function filterSchemaTables(schema: DatabaseSchema, tableFilters: Set<string> | null): DatabaseSchema {
-  if (!tableFilters) {
-    return schema;
-  }
-
-  return {
-    ...schema,
-    tables: schema.tables.filter((table) => {
-      const bare = normalizeFilterName(table.name);
-      const qualified = table.schema
-        ? normalizeFilterName(`${table.schema}.${table.name}`)
-        : bare;
-
-      return tableFilters.has(bare) || tableFilters.has(qualified);
-    }),
-  };
-}
-
-function escapeSqliteStringLiteral(value: string): string {
-  return value.replace(/'/g, "''");
-}
-
-function sortColumnsByPosition(columnsByPosition: Array<{ position: number; column: string }>): string[] {
-  return columnsByPosition
-    .sort((a, b) => a.position - b.position)
-    .map((entry) => entry.column);
-}
 
 /**
  * Inspects database schemas across PostgreSQL, MySQL, and SQLite.
@@ -327,13 +44,6 @@ export class SchemaInspector {
   private readonly cacheTtlMs: number;
   private readonly cacheKey?: string;
 
-  /**
-   * Create a new SchemaInspector.
-   *
-   * @param manager - ConnectionManager instance for database access
-   * @param vendor - Database vendor ('postgresql' | 'mysql' | 'sqlite')
-   * @param config - Optional configuration for cache TTL and cache key
-   */
   constructor(
     private readonly manager: ConnectionManager,
     private readonly vendor: DatabaseVendor,
@@ -343,11 +53,6 @@ export class SchemaInspector {
     this.cacheKey = config?.cacheKey;
   }
 
-  /**
-   * Clear cached schema data.
-   *
-   * @param cacheKey - Specific cache key to clear. If omitted, clears all cached schemas.
-   */
   static clearCache(cacheKey?: string): void {
     if (cacheKey) {
       schemaCache.delete(cacheKey);
@@ -357,19 +62,10 @@ export class SchemaInspector {
     schemaCache.clear();
   }
 
-  /** Invalidate this inspector's cached schema, if any. */
   invalidateCache(): void {
     SchemaInspector.clearCache(this.cacheKey);
   }
 
-  /**
-   * Inspect the database schema and return structured metadata.
-   *
-   * Results are cached when a `cacheKey` was provided at construction time.
-   *
-   * @param options - Optional table filters and cache bypass flag
-   * @returns Structured schema with tables, columns, indexes, and foreign keys
-   */
   async inspect(options?: SchemaInspectOptions): Promise<DatabaseSchema> {
     const tableFilters = validateTableFilters(options?.tables);
     const bypassCache = options?.bypassCache ?? false;
@@ -395,11 +91,7 @@ export class SchemaInspector {
   }
 
   private async inspectFromDatabase(): Promise<DatabaseSchema> {
-    const tables = this.vendor === 'postgresql'
-      ? await this.inspectPostgreSQL()
-      : this.vendor === 'mysql'
-      ? await this.inspectMySQL()
-      : await this.inspectSQLite();
+    const tables = await this.inspectTables();
 
     return {
       vendor: this.vendor,
@@ -412,6 +104,17 @@ export class SchemaInspector {
     };
   }
 
+  private async inspectTables(): Promise<TableSchema[]> {
+    switch (this.vendor) {
+      case 'postgresql':
+        return inspectPostgreSQL((query) => this.runQueryRows(query));
+      case 'mysql':
+        return inspectMySQL((query) => this.runQueryRows(query));
+      case 'sqlite':
+        return inspectSQLite((query) => this.runQueryRows(query));
+    }
+  }
+
   private async runQueryRows(query: string): Promise<QueryRow[]> {
     const result = await executeQuery(this.manager, {
       sql: query,
@@ -419,307 +122,5 @@ export class SchemaInspector {
     });
 
     return result.rows as QueryRow[];
-  }
-
-  private createTableMap(refs: TableRef[]): Map<string, TableSchema> {
-    const tableMap = new Map<string, TableSchema>();
-
-    for (const ref of refs) {
-      const key = buildTableKey(ref.tableName, ref.schemaName);
-      tableMap.set(key, {
-        name: ref.tableName,
-        schema: ref.schemaName,
-        columns: [],
-        primaryKey: [],
-        foreignKeys: [],
-        indexes: [],
-      });
-    }
-
-    return tableMap;
-  }
-
-  private getTableFromRow(
-    tableMap: Map<string, TableSchema>,
-    row: QueryRow,
-    tableField: string,
-    schemaField?: string,
-  ): TableSchema | undefined {
-    const tableName = toStringValue(row[tableField]);
-    const schemaName = schemaField ? toOptionalStringValue(row[schemaField]) : undefined;
-    const key = buildTableKey(tableName, schemaName);
-    return tableMap.get(key);
-  }
-
-  private async inspectPostgreSQL(): Promise<TableSchema[]> {
-    const tableRows = await this.runQueryRows(POSTGRES_TABLES_QUERY);
-    const tableMap = this.createTableMap(
-      tableRows.map((row) => ({
-        schemaName: toOptionalStringValue(row.schema_name),
-        tableName: toStringValue(row.table_name),
-      })),
-    );
-
-    const columnsRows = await this.runQueryRows(POSTGRES_COLUMNS_QUERY);
-    for (const row of columnsRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const column: ColumnSchema = {
-        name: toStringValue(row.column_name),
-        type: toStringValue(row.data_type),
-        isNullable: toBooleanValue(row.is_nullable),
-        defaultValue: row.column_default ?? null,
-        isPrimaryKey: false,
-      };
-      table.columns.push(column);
-    }
-
-    const primaryKeyRows = await this.runQueryRows(POSTGRES_PRIMARY_KEYS_QUERY);
-    for (const row of primaryKeyRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const columnName = toStringValue(row.column_name);
-      table.primaryKey.push(columnName);
-
-      const column = table.columns.find((entry) => entry.name === columnName);
-      if (column) {
-        column.isPrimaryKey = true;
-      }
-    }
-
-    const foreignKeyRows = await this.runQueryRows(POSTGRES_FOREIGN_KEYS_QUERY);
-    for (const row of foreignKeyRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const foreignKey: ForeignKeySchema = {
-        name: toOptionalStringValue(row.constraint_name),
-        column: toStringValue(row.column_name),
-        referencedSchema: toOptionalStringValue(row.referenced_schema_name),
-        referencedTable: toStringValue(row.referenced_table_name),
-        referencedColumn: toStringValue(row.referenced_column_name),
-      };
-
-      table.foreignKeys.push(foreignKey);
-    }
-
-    const indexRows = await this.runQueryRows(POSTGRES_INDEXES_QUERY);
-    this.applyIndexRows(tableMap, indexRows, 'table_name', 'schema_name', {
-      indexNameField: 'index_name',
-      columnField: 'column_name',
-      positionField: 'column_position',
-      uniqueResolver: (row) => toBooleanValue(row.is_unique),
-    });
-
-    return Array.from(tableMap.values());
-  }
-
-  private async inspectMySQL(): Promise<TableSchema[]> {
-    const tableRows = await this.runQueryRows(MYSQL_TABLES_QUERY);
-    const tableMap = this.createTableMap(
-      tableRows.map((row) => ({
-        schemaName: toOptionalStringValue(row.schema_name),
-        tableName: toStringValue(row.table_name),
-      })),
-    );
-
-    const columnsRows = await this.runQueryRows(MYSQL_COLUMNS_QUERY);
-    for (const row of columnsRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const column: ColumnSchema = {
-        name: toStringValue(row.column_name),
-        type: toStringValue(row.data_type),
-        isNullable: toBooleanValue(row.is_nullable),
-        defaultValue: row.column_default ?? null,
-        isPrimaryKey: false,
-      };
-      table.columns.push(column);
-    }
-
-    const primaryKeyRows = await this.runQueryRows(MYSQL_PRIMARY_KEYS_QUERY);
-    for (const row of primaryKeyRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const columnName = toStringValue(row.column_name);
-      table.primaryKey.push(columnName);
-
-      const column = table.columns.find((entry) => entry.name === columnName);
-      if (column) {
-        column.isPrimaryKey = true;
-      }
-    }
-
-    const foreignKeyRows = await this.runQueryRows(MYSQL_FOREIGN_KEYS_QUERY);
-    for (const row of foreignKeyRows) {
-      const table = this.getTableFromRow(tableMap, row, 'table_name', 'schema_name');
-      if (!table) {
-        continue;
-      }
-
-      const foreignKey: ForeignKeySchema = {
-        name: toOptionalStringValue(row.constraint_name),
-        column: toStringValue(row.column_name),
-        referencedSchema: toOptionalStringValue(row.referenced_schema_name),
-        referencedTable: toStringValue(row.referenced_table_name),
-        referencedColumn: toStringValue(row.referenced_column_name),
-      };
-
-      table.foreignKeys.push(foreignKey);
-    }
-
-    const indexRows = await this.runQueryRows(MYSQL_INDEXES_QUERY);
-    this.applyIndexRows(tableMap, indexRows, 'table_name', 'schema_name', {
-      indexNameField: 'index_name',
-      columnField: 'column_name',
-      positionField: 'seq_in_index',
-      uniqueResolver: (row) => !toBooleanValue(row.non_unique),
-    });
-
-    return Array.from(tableMap.values());
-  }
-
-  private async inspectSQLite(): Promise<TableSchema[]> {
-    const tableRows = await this.runQueryRows(SQLITE_TABLES_QUERY);
-    const tableMap = this.createTableMap(
-      tableRows.map((row) => ({
-        tableName: toStringValue(row.table_name),
-      })),
-    );
-
-    for (const table of tableMap.values()) {
-      const tableLiteral = escapeSqliteStringLiteral(table.name);
-
-      const columnRows = await this.runQueryRows(`PRAGMA table_info('${tableLiteral}')`);
-      const primaryKeyColumns: Array<{ position: number; column: string }> = [];
-
-      for (const row of columnRows) {
-        const pkPosition = toNumberValue(row.pk);
-        const columnName = toStringValue(row.name);
-
-        if (pkPosition > 0) {
-          primaryKeyColumns.push({ position: pkPosition, column: columnName });
-        }
-
-        const column: ColumnSchema = {
-          name: columnName,
-          type: toStringValue(row.type),
-          isNullable: !toBooleanValue(row.notnull),
-          defaultValue: row.dflt_value ?? null,
-          isPrimaryKey: pkPosition > 0,
-        };
-        table.columns.push(column);
-      }
-
-      table.primaryKey = sortColumnsByPosition(primaryKeyColumns);
-
-      const foreignKeyRows = await this.runQueryRows(`PRAGMA foreign_key_list('${tableLiteral}')`);
-      for (const row of foreignKeyRows) {
-        const foreignKey: ForeignKeySchema = {
-          column: toStringValue(row.from),
-          referencedTable: toStringValue(row.table),
-          referencedColumn: toStringValue(row.to),
-        };
-        table.foreignKeys.push(foreignKey);
-      }
-
-      const indexListRows = await this.runQueryRows(`PRAGMA index_list('${tableLiteral}')`);
-      for (const indexRow of indexListRows) {
-        const indexName = toStringValue(indexRow.name);
-        if (!indexName || toStringValue(indexRow.origin) === 'pk') {
-          continue;
-        }
-
-        const indexNameLiteral = escapeSqliteStringLiteral(indexName);
-        const indexInfoRows = await this.runQueryRows(`PRAGMA index_info('${indexNameLiteral}')`);
-        const indexColumns = sortColumnsByPosition(
-          indexInfoRows.map((row) => ({
-            position: toNumberValue(row.seqno),
-            column: toStringValue(row.name),
-          })),
-        );
-
-        const index: IndexSchema = {
-          name: indexName,
-          isUnique: toBooleanValue(indexRow.unique),
-          columns: indexColumns,
-        };
-        table.indexes.push(index);
-      }
-    }
-
-    return Array.from(tableMap.values());
-  }
-
-  private applyIndexRows(
-    tableMap: Map<string, TableSchema>,
-    rows: QueryRow[],
-    tableField: string,
-    schemaField: string | undefined,
-    config: {
-      indexNameField: string;
-      columnField: string;
-      positionField: string;
-      uniqueResolver: (row: QueryRow) => boolean;
-    },
-  ): void {
-    const grouped = new Map<
-      string,
-      {
-        table: TableSchema;
-        indexName: string;
-        isUnique: boolean;
-        columnsByPosition: Array<{ position: number; column: string }>;
-      }
-    >();
-
-    for (const row of rows) {
-      const table = this.getTableFromRow(tableMap, row, tableField, schemaField);
-      if (!table) {
-        continue;
-      }
-
-      const indexName = toStringValue(row[config.indexNameField]);
-      if (!indexName) {
-        continue;
-      }
-
-      const groupKey = `${table.schema ?? ''}.${table.name}.${indexName}`;
-      const entry = grouped.get(groupKey) ?? {
-        table,
-        indexName,
-        isUnique: config.uniqueResolver(row),
-        columnsByPosition: [],
-      };
-
-      entry.columnsByPosition.push({
-        position: toNumberValue(row[config.positionField]),
-        column: toStringValue(row[config.columnField]),
-      });
-      grouped.set(groupKey, entry);
-    }
-
-    for (const entry of grouped.values()) {
-      const index: IndexSchema = {
-        name: entry.indexName,
-        isUnique: entry.isUnique,
-        columns: sortColumnsByPosition(entry.columnsByPosition),
-      };
-      entry.table.indexes.push(index);
-    }
   }
 }

--- a/packages/tools/tests/data/relational/schema-inspector-cache.test.ts
+++ b/packages/tools/tests/data/relational/schema-inspector-cache.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Cache-focused SchemaInspector coverage.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SchemaInspector } from '../../../src/data/relational/schema/schema-inspector.js';
+import { createMockManager } from './schema-inspector.test-utils.js';
+
+describe('SchemaInspector cache behavior', () => {
+  beforeEach(() => {
+    SchemaInspector.clearCache();
+  });
+
+  it('should use cache and support explicit cache invalidation', async () => {
+    const queue = [
+      { rows: [{ schema_name: 'public', table_name: 'users' }] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [{ schema_name: 'public', table_name: 'users' }] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+    ];
+    const { manager, executeMock } = createMockManager(queue);
+    const inspector = new SchemaInspector(manager, 'postgresql', {
+      cacheKey: 'pg:cache-test',
+      cacheTtlMs: 60_000,
+    });
+
+    await inspector.inspect();
+    await inspector.inspect();
+    expect(executeMock).toHaveBeenCalledTimes(5);
+
+    inspector.invalidateCache();
+    await inspector.inspect();
+    expect(executeMock).toHaveBeenCalledTimes(10);
+  });
+});

--- a/packages/tools/tests/data/relational/schema-inspector-filters.test.ts
+++ b/packages/tools/tests/data/relational/schema-inspector-filters.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Filter-validation SchemaInspector coverage.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SchemaInspector } from '../../../src/data/relational/schema/schema-inspector.js';
+import { createMockManager } from './schema-inspector.test-utils.js';
+
+describe('SchemaInspector table filtering', () => {
+  beforeEach(() => {
+    SchemaInspector.clearCache();
+  });
+
+  it('should filter tables and validate table filter syntax', async () => {
+    const { manager, executeMock } = createMockManager([
+      {
+        rows: [
+          { schema_name: 'public', table_name: 'users' },
+          { schema_name: 'public', table_name: 'orders' },
+        ],
+      },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+    ]);
+    const inspector = new SchemaInspector(manager, 'postgresql');
+
+    await expect(
+      inspector.inspect({ tables: ['invalid-table-name!'] }),
+    ).rejects.toThrow(/contains invalid characters/);
+    expect(executeMock).toHaveBeenCalledTimes(0);
+
+    const filtered = await inspector.inspect({ tables: ['public.orders'] });
+    expect(filtered.tables).toHaveLength(1);
+    expect(filtered.tables[0].name).toBe('orders');
+  });
+});

--- a/packages/tools/tests/data/relational/schema-inspector-filters.test.ts
+++ b/packages/tools/tests/data/relational/schema-inspector-filters.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
+import type { DatabaseVendor } from '../../../src/data/relational/types.js';
 import { SchemaInspector } from '../../../src/data/relational/schema/schema-inspector.js';
 import { createMockManager } from './schema-inspector.test-utils.js';
 
@@ -34,5 +35,13 @@ describe('SchemaInspector table filtering', () => {
     const filtered = await inspector.inspect({ tables: ['public.orders'] });
     expect(filtered.tables).toHaveLength(1);
     expect(filtered.tables[0].name).toBe('orders');
+  });
+
+  it('should fail fast for unsupported runtime vendors', async () => {
+    const { manager, executeMock } = createMockManager([]);
+    const inspector = new SchemaInspector(manager, 'oracle' as DatabaseVendor);
+
+    await expect(inspector.inspect()).rejects.toThrow('Unsupported database vendor: oracle');
+    expect(executeMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts
+++ b/packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts
@@ -1,25 +1,12 @@
 /**
- * Unit tests for SchemaInspector.
+ * PostgreSQL-focused SchemaInspector coverage.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ConnectionManager } from '../../../src/data/relational/connection/connection-manager.js';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { SchemaInspector } from '../../../src/data/relational/schema/schema-inspector.js';
+import { createMockManager } from './schema-inspector.test-utils.js';
 
-function createMockManager(queue: Array<{ rows: unknown[] }>): {
-  manager: ConnectionManager;
-  executeMock: ReturnType<typeof vi.fn>;
-} {
-  const executeMock = vi.fn();
-  for (const result of queue) {
-    executeMock.mockResolvedValueOnce(result);
-  }
-
-  const manager = { execute: executeMock } as unknown as ConnectionManager;
-  return { manager, executeMock };
-}
-
-describe('SchemaInspector', () => {
+describe('SchemaInspector PostgreSQL introspection', () => {
   beforeEach(() => {
     SchemaInspector.clearCache();
   });
@@ -95,58 +82,5 @@ describe('SchemaInspector', () => {
     ]);
     expect(schema.tables[0].columns.find((column) => column.name === 'id')?.isPrimaryKey).toBe(true);
     expect(executeMock).toHaveBeenCalledTimes(5);
-  });
-
-  it('should use cache and support explicit cache invalidation', async () => {
-    const queue = [
-      { rows: [{ schema_name: 'public', table_name: 'users' }] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [{ schema_name: 'public', table_name: 'users' }] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-    ];
-    const { manager, executeMock } = createMockManager(queue);
-    const inspector = new SchemaInspector(manager, 'postgresql', {
-      cacheKey: 'pg:cache-test',
-      cacheTtlMs: 60_000,
-    });
-
-    await inspector.inspect();
-    await inspector.inspect();
-    expect(executeMock).toHaveBeenCalledTimes(5);
-
-    inspector.invalidateCache();
-    await inspector.inspect();
-    expect(executeMock).toHaveBeenCalledTimes(10);
-  });
-
-  it('should filter tables and validate table filter syntax', async () => {
-    const { manager, executeMock } = createMockManager([
-      {
-        rows: [
-          { schema_name: 'public', table_name: 'users' },
-          { schema_name: 'public', table_name: 'orders' },
-        ],
-      },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-      { rows: [] },
-    ]);
-    const inspector = new SchemaInspector(manager, 'postgresql');
-
-    await expect(
-      inspector.inspect({ tables: ['invalid-table-name!'] }),
-    ).rejects.toThrow(/contains invalid characters/);
-    expect(executeMock).toHaveBeenCalledTimes(0);
-
-    const filtered = await inspector.inspect({ tables: ['public.orders'] });
-    expect(filtered.tables).toHaveLength(1);
-    expect(filtered.tables[0].name).toBe('orders');
   });
 });

--- a/packages/tools/tests/data/relational/schema-inspector.test-utils.ts
+++ b/packages/tools/tests/data/relational/schema-inspector.test-utils.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+import type { ConnectionManager } from '../../../src/data/relational/connection/connection-manager.js';
+
+export function createMockManager(queue: Array<{ rows: unknown[] }>): {
+  manager: ConnectionManager;
+  executeMock: ReturnType<typeof vi.fn>;
+} {
+  const executeMock = vi.fn();
+  for (const result of queue) {
+    executeMock.mockResolvedValueOnce(result);
+  }
+
+  const manager = { execute: executeMock } as unknown as ConnectionManager;
+  return { manager, executeMock };
+}

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2195,23 +2195,46 @@ Implementation notes:
 **Branch:** `refactor/st-09055-schema-inspector-modularization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09055-schema-inspector-modularization`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove schema inspection behavior remains stable while the oversized runtime and test files are split
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Reduce `packages/tools/src/data/relational/schema/schema-inspector.ts` below the 300 line planning cutoff by extracting focused internal modules for vendor inspection, schema normalization, cache/refresh orchestration, and shared metadata helpers behind a stable facade
-- [ ] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
-- [ ] Split the schema-inspector coverage into focused test modules so vendor-specific, normalization, and caching-path behavior no longer depend on a single oversized test surface
-- [ ] Preserve existing schema-inspector behavior, metadata shape, caching semantics, and public imports
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched schema-inspector modules in story docs
-- [ ] Add or update story documentation at `docs/st09055-schema-inspector-modularization.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Create branch `refactor/st-09055-schema-inspector-modularization`
+- [x] Create draft PR with story ID in title
+  - Draft PR #124: https://github.com/TVScoundrel/agentforge/pull/124
+- [x] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove schema inspection behavior remains stable while the oversized runtime and test files are split
+  - A structure-only failing test would mostly prove repository layout instead of schema behavior. The practical test-first substitute was splitting focused PostgreSQL, cache, and filter suites first, then using those suites as the regression net while extracting vendor-specific and shared runtime responsibilities.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - A failing structure-only test was not practical for proving schema behavior. Focused suite decomposition was used as the closest behavior-preserving automated safety net before runtime extraction.
+- [x] Reduce `packages/tools/src/data/relational/schema/schema-inspector.ts` below the 300 line planning cutoff by extracting focused internal modules for vendor inspection, schema normalization, cache/refresh orchestration, and shared metadata helpers behind a stable facade
+  - `schema-inspector.ts` reduced from `725` lines to `126` lines with new focused runtime modules in `schema-inspector-shared.ts`, `schema-inspector-postgresql.ts`, `schema-inspector-mysql.ts`, and `schema-inspector-sqlite.ts`
+- [x] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
+  - Extracted runtime modules are `249`, `155`, `135`, and `95` lines respectively; no exception required
+- [x] Split the schema-inspector coverage into focused test modules so vendor-specific, normalization, and caching-path behavior no longer depend on a single oversized test surface
+  - Replaced `packages/tools/tests/data/relational/schema-inspector.test.ts` with focused PostgreSQL, cache, and filter suites plus `schema-inspector.test-utils.ts`
+- [x] Preserve existing schema-inspector behavior, metadata shape, caching semantics, and public imports
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+  - `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts` -> `3` files passed, `3` tests passed
+- [x] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched schema-inspector modules in story docs
+  - Recorded in `docs/st09055-schema-inspector-modularization.md`; explicit-`any` baseline remained stable at `workspace 84/289`, `tools 53/67`
+- [x] Add or update story documentation at `docs/st09055-schema-inspector-modularization.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - The focused suite split now covers the modularized facade's PostgreSQL metadata shape, cache invalidation flow, and filter validation boundary. No further story-local automated coverage was required for this behavior-preserving split.
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `202` files passed, `18` skipped; `2313` tests passed, `286` skipped
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with warnings only (`0` errors)
+- [x] Commit completed checklist items as logical commits and push updates
+  - `4c230ce` `refactor(st-09055): modularize schema inspector runtime`
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+
+- Focused package validation:
+  - `pnpm --filter @agentforge/tools typecheck`
+  - `pnpm --filter @agentforge/tools exec eslint src/data/relational/schema/schema-inspector.ts src/data/relational/schema/schema-inspector-shared.ts src/data/relational/schema/schema-inspector-postgresql.ts src/data/relational/schema/schema-inspector-mysql.ts src/data/relational/schema/schema-inspector-sqlite.ts tests/data/relational/schema-inspector.test-utils.ts tests/data/relational/schema-inspector-postgresql.test.ts tests/data/relational/schema-inspector-cache.test.ts tests/data/relational/schema-inspector-filters.test.ts`
+- Baseline/quality gates:
+  - `pnpm lint:explicit-any:baseline` -> `84/289` workspace, `53/67` tools
+  - `git diff --check`
+- CI impact assessment:
+  - No CI workflow change required. Existing package typecheck, explicit-`any` baseline, workspace tests, and lint gates already cover the extracted runtime and test surfaces.
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2210,7 +2210,7 @@ Implementation notes:
   - Replaced `packages/tools/tests/data/relational/schema-inspector.test.ts` with focused PostgreSQL, cache, and filter suites plus `schema-inspector.test-utils.ts`
 - [x] Preserve existing schema-inspector behavior, metadata shape, caching semantics, and public imports
 - [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-  - `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts` -> `3` files passed, `3` tests passed
+  - `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts` -> `3` files passed, `4` tests passed
 - [x] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched schema-inspector modules in story docs
   - Recorded in `docs/st09055-schema-inspector-modularization.md`; explicit-`any` baseline remained stable at `workspace 84/289`, `tools 53/67`
 - [x] Add or update story documentation at `docs/st09055-schema-inspector-modularization.md` (or document why not required)

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1786,7 +1786,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 5 hours
 **Dependencies:** ST-03002
-**Status:** Ready
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/relational/schema/schema-inspector.ts` is reduced below the 300 line planning cutoff by extracting focused internal modules for vendor-specific inspection, schema normalization, cache/refresh orchestration, and shared metadata helpers behind a stable public facade, and the extracted production modules must also stay below `300` lines unless the story documents and justifies an explicit exception.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-05-29
-**Active Story:** None
+**Last Updated:** 2026-06-02
+**Active Story:** ST-09055 - Modularize Relational Schema Inspector and Tests (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-06-02
 
 ## Queue Status Summary
 
-- **Ready:** 6 stories
+- **Ready:** 5 stories
 - **In Progress:** 0 stories
-- **In Review:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09055` - Modularize Relational Schema Inspector and Tests
 - `ST-09056` - Modularize Skills Registry and Tests
 - `ST-09057` - Modularize Relational Transaction Flow and Tests
 - `ST-09058` - Modularize Core Tool Lifecycle and Tests
@@ -30,7 +29,7 @@ None currently.
 
 ## In Review
 
-_No stories currently in review_
+- `ST-09055` - Modularize Relational Schema Inspector and Tests
 
 ## Blocked
 


### PR DESCRIPTION
## Story

- `ST-09055` - Modularize Relational Schema Inspector and Tests

## What Changed

- reduced `packages/tools/src/data/relational/schema/schema-inspector.ts` from `725` lines to a `126` line public facade
- extracted focused internal modules for shared schema normalization plus PostgreSQL, MySQL, and SQLite inspection paths
- replaced the coupled schema-inspector test file with focused PostgreSQL, cache, and filter suites plus a shared test helper
- preserved public `SchemaInspector` behavior, metadata shape, cache semantics, and table filtering behavior

## Acceptance Criteria Coverage

- `schema-inspector.ts` is now below the `300` line planning cutoff and the extracted production modules are also below `300` lines
- schema-inspector coverage is split into focused suites instead of a single coupled file
- public imports and schema-inspection behavior were preserved behind the stable facade
- focused validation, `@agentforge/tools` typecheck, full test suite, lint, and explicit-`any` baseline all passed without baseline regression
- story documentation was added at `docs/st09055-schema-inspector-modularization.md`

## Test Strategy

- A structure-only failing test would not prove schema behavior; it would mostly prove repository layout.
- The practical test-first substitute was splitting the existing schema-inspector coverage into focused suites first, then using those suites as the regression net while extracting vendor-specific and shared runtime responsibilities.
- No CI workflow change was required because the existing package/workspace validation path already covers the changed surfaces.

## Validation Performed

- `pnpm test --run packages/tools/tests/data/relational/schema-inspector-postgresql.test.ts packages/tools/tests/data/relational/schema-inspector-cache.test.ts packages/tools/tests/data/relational/schema-inspector-filters.test.ts`
- `pnpm --filter @agentforge/tools typecheck`
- `pnpm --filter @agentforge/tools exec eslint src/data/relational/schema/schema-inspector.ts src/data/relational/schema/schema-inspector-shared.ts src/data/relational/schema/schema-inspector-postgresql.ts src/data/relational/schema/schema-inspector-mysql.ts src/data/relational/schema/schema-inspector-sqlite.ts tests/data/relational/schema-inspector.test-utils.ts tests/data/relational/schema-inspector-postgresql.test.ts tests/data/relational/schema-inspector-cache.test.ts tests/data/relational/schema-inspector-filters.test.ts`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`
- `git diff --check`

## Status

- Ready for review
