### PR TITLE
fix: ST-09059 tighten ReAct schema payload contracts

### DIFF
--- a/docs/st09059-react-schema-payload-contracts.md
+++ b/docs/st09059-react-schema-payload-contracts.md
@@ -9,9 +9,9 @@
 This story had a practical test-first seam, so the implementation started with focused schema tests before production changes:
 
 - add runtime schema assertions in `packages/patterns/tests/react/state.test.ts` for JSON-safe metadata acceptance/rejection boundaries
-- add compile-time assertions in `packages/patterns/tests/react/contracts.typecheck.ts` so inferred metadata, arguments, and result types no longer flow through broad `any`
+- add compile-time assertions in `packages/patterns/tests/react/contracts.typecheck.ts` and wire them into the package typecheck config so inferred metadata, arguments, and result types no longer flow through broad `any`
 
-No CI change was required because the existing focused React state test, `@agentforge/patterns` typecheck, workspace test suite, lint, and explicit-`any` baseline gate already cover the touched surfaces.
+No CI change was required because the existing focused ReAct state test, package typecheck, workspace test suite, lint, and explicit-`any` baseline gate already cover the touched surfaces once the compile-time assertions are included in `packages/patterns/tsconfig.typecheck.json`.
 
 ## Contract Changes
 

--- a/docs/st09059-react-schema-payload-contracts.md
+++ b/docs/st09059-react-schema-payload-contracts.md
@@ -1,0 +1,52 @@
+# ST-09059: ReAct Schema Payload Contracts
+
+## Summary
+
+`ST-09059` tightens the ReAct runtime schemas around message metadata, thought metadata, tool-call arguments, and tool-result payloads without changing ReAct runtime behavior. Message and thought metadata now require JSON-safe structures, while tool-call arguments and tool results remain unknown-first so tool payloads stay flexible without relying on broad `z.any()` seams.
+
+## Test Strategy
+
+This story had a practical test-first seam, so the implementation started with focused schema tests before production changes:
+
+- add runtime schema assertions in `packages/patterns/tests/react/state.test.ts` for JSON-safe metadata acceptance/rejection boundaries
+- add compile-time assertions in `packages/patterns/tests/react/contracts.typecheck.ts` so inferred metadata, arguments, and result types no longer flow through broad `any`
+
+No CI change was required because the existing focused React state test, `@agentforge/patterns` typecheck, workspace test suite, lint, and explicit-`any` baseline gate already cover the touched surfaces.
+
+## Contract Changes
+
+- `MessageSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
+- `ThoughtSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
+- `ToolCallSchema.arguments` now uses `z.record(z.unknown())` instead of `z.record(z.any())`
+- `ToolResultSchema.result` now uses `z.unknown()` instead of `z.any()`
+
+## Behavior Preserved
+
+- ReAct reasoning, action, observation, and prompt behavior remain unchanged
+- tool-call arguments remain unknown-first and continue to accept non-JSON values such as `bigint` when runtime behavior depends on that flexibility
+- tool-result payloads remain unknown-first and continue to support non-JSON result values for downstream formatting/serialization paths
+- message/tool scratchpad behavior and observation stringification remain unchanged
+
+## Explicit-`any` Baseline
+
+- `pnpm lint:explicit-any:baseline` remained stable at `84/289` workspace warnings
+- `@agentforge/patterns` remained stable at `2/28`
+
+## Validation
+
+- Focused schema test:
+  - `pnpm test --run packages/patterns/tests/react/state.test.ts`
+  - initial failing result: `should reject non-JSON-safe metadata values`
+  - final result: `1` file passed, `15` tests passed
+- Package checks:
+  - `pnpm --filter @agentforge/patterns typecheck`
+  - `pnpm --filter @agentforge/patterns exec eslint src/react/schemas.ts tests/react/state.test.ts tests/react/contracts.typecheck.ts`
+- Workspace checks:
+  - `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
+  - `pnpm test --run` -> `210` files passed, `18` skipped; `2310` tests passed, `286` skipped
+  - `pnpm lint` -> passed with warnings only
+  - `git diff --check`
+
+## Notes
+
+- The workspace test count increased from `2307` to `2310` because this story added three focused ReAct schema assertions in `packages/patterns/tests/react/state.test.ts`.

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -21,7 +21,7 @@
     "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/packages/patterns/src/react/schemas.ts
+++ b/packages/patterns/src/react/schemas.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
     z.string(),
-    z.number(),
+    z.number().finite(),
     z.boolean(),
     z.null(),
     z.array(JsonValueSchema),

--- a/packages/patterns/src/react/schemas.ts
+++ b/packages/patterns/src/react/schemas.ts
@@ -7,7 +7,21 @@
  * @module langgraph/patterns/react/schemas
  */
 
+import type { JsonObject, JsonValue } from '@agentforge/core';
 import { z } from 'zod';
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ])
+);
+
+const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);
 
 /**
  * Message role types
@@ -26,7 +40,7 @@ export const MessageSchema = z.object({
   content: z.string(),
   name: z.string().optional(),
   tool_call_id: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: JsonObjectSchema.optional(),
 });
 
 export type Message = z.infer<typeof MessageSchema>;
@@ -37,7 +51,7 @@ export type Message = z.infer<typeof MessageSchema>;
 export const ThoughtSchema = z.object({
   content: z.string(),
   timestamp: z.number().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: JsonObjectSchema.optional(),
 });
 
 export type Thought = z.infer<typeof ThoughtSchema>;
@@ -48,7 +62,7 @@ export type Thought = z.infer<typeof ThoughtSchema>;
 export const ToolCallSchema = z.object({
   id: z.string(),
   name: z.string(),
-  arguments: z.record(z.any()),
+  arguments: z.record(z.unknown()),
   timestamp: z.number().optional(),
 });
 
@@ -59,7 +73,7 @@ export type ToolCall = z.infer<typeof ToolCallSchema>;
  */
 export const ToolResultSchema = z.object({
   toolCallId: z.string(),
-  result: z.any(),
+  result: z.unknown(),
   error: z.string().optional(),
   timestamp: z.number().optional(),
   isDuplicate: z.boolean().optional(), // Flag indicating this was a duplicate tool call
@@ -79,4 +93,3 @@ export const ScratchpadEntrySchema = z.object({
 });
 
 export type ScratchpadEntry = z.infer<typeof ScratchpadEntrySchema>;
-

--- a/packages/patterns/tests/react/contracts.typecheck.ts
+++ b/packages/patterns/tests/react/contracts.typecheck.ts
@@ -1,10 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import type { CompiledStateGraph, BaseCheckpointSaver } from '@langchain/langgraph';
+import type { JsonObject } from '@agentforge/core';
 import type { Tool, ToolRegistry } from '@agentforge/core';
 import { ReActAgentBuilder } from '../../src/react/builder.js';
 import { createReActAgent } from '../../src/react/agent.js';
 import { formatToolsForPrompt } from '../../src/react/prompts.js';
 import type { ReActStateType } from '../../src/react/state.js';
 import type { ReActToolInput } from '../../src/react/types.js';
+import type { Message, Thought, ToolCall, ToolResult } from '../../src/react/index.js';
 import { z, type ZodSchema } from 'zod';
 
 type Equal<Left, Right> =
@@ -33,6 +37,18 @@ type _builderToolsArrayIsPublicToolInputArray = AssertTrue<
 >;
 type _promptToolDescriptorSchemaMatchesContract = AssertTrue<
   Equal<PromptToolDescriptor['schema'], ZodSchema<unknown>>
+>;
+type _messageMetadataIsJsonObject = AssertTrue<
+  Equal<Message['metadata'], JsonObject | undefined>
+>;
+type _thoughtMetadataIsJsonObject = AssertTrue<
+  Equal<Thought['metadata'], JsonObject | undefined>
+>;
+type _toolCallArgumentsAreUnknownFirst = AssertTrue<
+  Equal<ToolCall['arguments'], Record<string, unknown>>
+>;
+type _toolResultPayloadIsUnknownFirst = AssertTrue<
+  Equal<ToolResult['result'], unknown>
 >;
 
 declare const typedTool: Tool<{ input: string }, { ok: boolean }>;

--- a/packages/patterns/tests/react/state.test.ts
+++ b/packages/patterns/tests/react/state.test.ts
@@ -30,7 +30,7 @@ describe('ReAct State Definition', () => {
 
   it('should work with LangGraph StateGraph', () => {
     // This tests that our state annotation is compatible with LangGraph
-    const testNode = (state: ReActStateType) => ({
+    const testNode = (_state: ReActStateType) => ({
       messages: [{ role: 'assistant' as const, content: 'test' }],
       iteration: 1,
     });
@@ -175,6 +175,48 @@ describe('ReAct Schemas', () => {
     expect(parsed.tool_call_id).toBe('call_123');
   });
 
+  it('should allow JSON-safe metadata on messages and thoughts', () => {
+    const messageWithMetadata = {
+      role: 'assistant',
+      content: 'Structured message',
+      metadata: {
+        tags: ['react', 'schema'],
+        nested: { score: 0.9, ok: true },
+      },
+    };
+
+    const thoughtWithMetadata = {
+      content: 'I should preserve nested JSON-safe metadata',
+      metadata: {
+        source: 'unit-test',
+        details: { attempts: 2, complete: false },
+      },
+    };
+
+    expect(() => MessageSchema.parse(messageWithMetadata)).not.toThrow();
+    expect(() => ThoughtSchema.parse(thoughtWithMetadata)).not.toThrow();
+  });
+
+  it('should reject non-JSON-safe metadata values', () => {
+    const invalidMessage = {
+      role: 'assistant',
+      content: 'Bad metadata',
+      metadata: {
+        callback: () => 'nope',
+      },
+    };
+
+    const invalidThought = {
+      content: 'This should fail',
+      metadata: {
+        symbol: Symbol('bad'),
+      },
+    };
+
+    expect(() => MessageSchema.parse(invalidMessage)).toThrow();
+    expect(() => ThoughtSchema.parse(invalidThought)).toThrow();
+  });
+
   it('should validate Thought schema', () => {
     const validThought = {
       content: 'I need to search for information',
@@ -203,6 +245,22 @@ describe('ReAct Schemas', () => {
     expect(() => ToolResultSchema.parse(validResult)).not.toThrow();
   });
 
+  it('should keep tool-call arguments and tool results unknown-first', () => {
+    const bigintToolCall = {
+      id: 'call_bigint',
+      name: 'calculator',
+      arguments: { input: 1n },
+    };
+
+    const bigintResult = {
+      toolCallId: 'call_bigint',
+      result: 1n,
+    };
+
+    expect(() => ToolCallSchema.parse(bigintToolCall)).not.toThrow();
+    expect(() => ToolResultSchema.parse(bigintResult)).not.toThrow();
+  });
+
   it('should validate ScratchpadEntry schema', () => {
     const validEntry = {
       step: 1,
@@ -214,4 +272,3 @@ describe('ReAct Schemas', () => {
     expect(() => ScratchpadEntrySchema.parse(validEntry)).not.toThrow();
   });
 });
-

--- a/packages/patterns/tests/react/state.test.ts
+++ b/packages/patterns/tests/react/state.test.ts
@@ -210,6 +210,7 @@ describe('ReAct Schemas', () => {
       content: 'This should fail',
       metadata: {
         symbol: Symbol('bad'),
+        infiniteScore: Number.POSITIVE_INFINITY,
       },
     };
 

--- a/packages/patterns/tsconfig.typecheck.json
+++ b/packages/patterns/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/react/contracts.typecheck.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2379,7 +2379,7 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09059-react-schema-payload-contracts`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Define test strategy before implementation: cover schema acceptance/rejection boundaries, tool-call payload handling, and result serialization compatibility; first failing test should assert ReAct schemas no longer rely on broad `z.any()` payload seams
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
 - [x] Replace broad metadata, arguments, and result `z.any()` seams in `packages/patterns/src/react/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
@@ -2390,8 +2390,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2378,21 +2378,44 @@ Implementation notes:
 **Branch:** `fix/st-09059-react-schema-payload-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09059-react-schema-payload-contracts`
+- [x] Create branch `fix/st-09059-react-schema-payload-contracts`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover schema acceptance/rejection boundaries, tool-call payload handling, and result serialization compatibility; first failing test should assert ReAct schemas no longer rely on broad `z.any()` payload seams
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad metadata, arguments, and result `z.any()` seams in `packages/patterns/src/react/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
-- [ ] Preserve ReAct reasoning, action, observation, and prompt behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09059-react-schema-payload-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Define test strategy before implementation: cover schema acceptance/rejection boundaries, tool-call payload handling, and result serialization compatibility; first failing test should assert ReAct schemas no longer rely on broad `z.any()` payload seams
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad metadata, arguments, and result `z.any()` seams in `packages/patterns/src/react/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
+- [x] Preserve ReAct reasoning, action, observation, and prompt behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09059-react-schema-payload-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+
+- Test-first plan:
+  - Add focused ReAct schema runtime tests for JSON-safe metadata acceptance/rejection boundaries in `packages/patterns/tests/react/state.test.ts`.
+  - Add type-level assertions in `packages/patterns/tests/react/contracts.typecheck.ts` so message metadata, thought metadata, tool-call arguments, and tool-result payload inference no longer flow through broad `any`.
+- Focused failing test:
+  - `pnpm test --run packages/patterns/tests/react/state.test.ts`
+  - initial failure: `should reject non-JSON-safe metadata values`
+- Focused passing test:
+  - `pnpm test --run packages/patterns/tests/react/state.test.ts`
+  - `1` file passed, `15` tests passed
+- Package checks:
+  - `pnpm --filter @agentforge/patterns typecheck`
+  - `pnpm --filter @agentforge/patterns exec eslint src/react/schemas.ts tests/react/state.test.ts tests/react/contracts.typecheck.ts`
+- Explicit-`any` baseline:
+  - `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
+- Workspace checks:
+  - `pnpm test --run` -> `210` files passed, `18` skipped; `2310` tests passed, `286` skipped
+  - `pnpm lint` -> passed with warnings only
+  - `git diff --check`
+- Residual impact:
+  - Added three focused ReAct schema assertions in `packages/patterns/tests/react/state.test.ts`; no additional CI workflow change is required.
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1854,7 +1854,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09037
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/schemas.ts` replaces broad `z.any()` metadata, arguments, and result payload seams with unknown-first or JSON-safe contracts where behavior allows.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1854,7 +1854,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09037
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/react/schemas.ts` replaces broad `z.any()` metadata, arguments, and result payload seams with unknown-first or JSON-safe contracts where behavior allows.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-08
-**Active Story:** ST-09059 - Tighten ReAct Schema Payload Contracts (In Progress)
+**Active Story:** ST-09059 - Tighten ReAct Schema Payload Contracts (In Review)
 
 ---
 
@@ -100,7 +100,7 @@ Recent improvement snapshot:
 - `ST-09056` merged on 2026-06-05 after reducing `packages/skills/src/registry.ts` from `506` lines to a `101` line public facade, extracting focused discovery, event, prompt, query, and shared-type helpers while replacing the `419` line registry test monolith with focused discovery, query, event, and rescan suites. The story preserved `SkillRegistry` public behavior, absorbed review follow-ups for temp-dir cleanup, shared-type alignment, and documentation accuracy, and kept the explicit-`any` baseline flat at `workspace 84/289` and `skills 0/0`.
 - `ST-09061` through `ST-09066` were added on 2026-06-05 to keep EP-09 stocked beyond the current lane with another modularization-first batch, prioritizing large runtime files in `core` and `patterns` before the remaining schema-hardening slices so future fixes land on smaller modules instead of monoliths.
 - `ST-09058` merged on 2026-06-06 after shrinking `packages/core/src/tools/lifecycle.ts` from a `405` line mixed-responsibility runtime to an `11` line public facade, extracting focused managed-tool, hook, health, and shared-type modules, replacing the `574` line lifecycle test monolith with focused initialization, execution, cleanup, and health suites, and absorbing review follow-ups for direct implementation-type imports and cleaner internal initialize dependencies while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
-- `EP-09` remains open as the daily hardening stream, with `ST-09059` now active as the next schema-hardening slice, and the remaining ready lane still covering `ST-09060` through `ST-09066`.
+- `EP-09` remains open as the daily hardening stream, with `ST-09059` now in review as the current schema-hardening slice, and the remaining ready lane still covering `ST-09060` through `ST-09066`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-06-06
-**Active Story:** None currently (post-merge sync complete)
+**Last Updated:** 2026-06-08
+**Active Story:** ST-09059 - Tighten ReAct Schema Payload Contracts (In Progress)
 
 ---
 
@@ -100,7 +100,7 @@ Recent improvement snapshot:
 - `ST-09056` merged on 2026-06-05 after reducing `packages/skills/src/registry.ts` from `506` lines to a `101` line public facade, extracting focused discovery, event, prompt, query, and shared-type helpers while replacing the `419` line registry test monolith with focused discovery, query, event, and rescan suites. The story preserved `SkillRegistry` public behavior, absorbed review follow-ups for temp-dir cleanup, shared-type alignment, and documentation accuracy, and kept the explicit-`any` baseline flat at `workspace 84/289` and `skills 0/0`.
 - `ST-09061` through `ST-09066` were added on 2026-06-05 to keep EP-09 stocked beyond the current lane with another modularization-first batch, prioritizing large runtime files in `core` and `patterns` before the remaining schema-hardening slices so future fixes land on smaller modules instead of monoliths.
 - `ST-09058` merged on 2026-06-06 after shrinking `packages/core/src/tools/lifecycle.ts` from a `405` line mixed-responsibility runtime to an `11` line public facade, extracting focused managed-tool, hook, health, and shared-type modules, replacing the `574` line lifecycle test monolith with focused initialization, execution, cleanup, and health suites, and absorbing review follow-ups for direct implementation-type imports and cleaner internal initialize dependencies while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
-- `EP-09` remains open as the daily hardening stream, with no active story immediately after the ST-09058 merge sync and an expanded ready lane that now includes `ST-09059` through `ST-09066` because all remaining backlog dependencies are satisfied.
+- `EP-09` remains open as the daily hardening stream, with `ST-09059` now active as the next schema-hardening slice, and the remaining ready lane still covering `ST-09060` through `ST-09066`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-06-06
+**Last Updated:** 2026-06-08
 
 ## Queue Status Summary
 
-- **Ready:** 8 stories
-- **In Progress:** 0 stories
+- **Ready:** 7 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09059` - Tighten ReAct Schema Payload Contracts
 - `ST-09060` - Tighten Multi-Agent Schema Payload Contracts
 - `ST-09061` - Modularize Core Tool Types and Tests
 - `ST-09062` - Modularize Core Tool Executor and Tests
@@ -27,7 +26,7 @@
 
 ## In Progress
 
-None currently.
+- `ST-09059` - Tighten ReAct Schema Payload Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 7 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -26,13 +26,13 @@
 
 ## In Progress
 
-- `ST-09059` - Tighten ReAct Schema Payload Contracts
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09059` - Tighten ReAct Schema Payload Contracts
 
 ## Blocked
 


### PR DESCRIPTION
## Story

- `ST-09059` - Tighten ReAct Schema Payload Contracts

## What Changed

- replaced broad `z.any()` seams in `packages/patterns/src/react/schemas.ts`
- tightened message and thought metadata to JSON-safe object payloads
- kept tool-call arguments and tool-result payloads unknown-first so ReAct tool payloads stay flexible
- added focused runtime schema tests and compile-time contract assertions for the new payload boundaries
- updated EP-09 checklist, queue, feature-plan, and story evidence docs for review handoff

## Acceptance Criteria Coverage

- `packages/patterns/src/react/schemas.ts` no longer relies on broad `z.any()` for metadata, arguments, or result payload seams
- ReAct reasoning, action, observation, and prompt behavior remain unchanged
- focused tests now cover JSON-safe metadata acceptance/rejection plus unknown-first payload compatibility
- touched files did not regress the explicit-`any` baseline; workspace remains `84/289` and `patterns` remains `2/28`
- story documentation is recorded in `docs/st09059-react-schema-payload-contracts.md`

## Test Strategy

- used a practical test-first path
- first added a focused failing schema test for rejecting non-JSON-safe metadata
- added compile-time assertions so inferred metadata, arguments, and result types no longer flow through broad `any`

## Validation Performed

- `pnpm test --run packages/patterns/tests/react/state.test.ts`
- `pnpm --filter @agentforge/patterns typecheck`
- `pnpm --filter @agentforge/patterns exec eslint src/react/schemas.ts tests/react/state.test.ts tests/react/contracts.typecheck.ts`
- `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
- `pnpm test --run` -> `210` files passed, `18` skipped; `2310` tests passed, `286` skipped
- `pnpm lint` -> passed with warnings only
- `git diff --check`

## Status

- ready for review
- full-suite test count increased from `2307` to `2310` because this story added three focused ReAct schema assertions
