### PR TITLE
fix: ST-09060 tighten multi-agent schema payload contracts

### DIFF
--- a/docs/st09060-multi-agent-schema-payload-contracts.md
+++ b/docs/st09060-multi-agent-schema-payload-contracts.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-`ST-09060` tightens the multi-agent runtime schemas around message metadata, task-result metadata, and handoff context without changing multi-agent routing or execution behavior. Message and task-result metadata now require JSON-safe structures, while handoff context remains unknown-first so worker-to-worker coordination can still pass through richer runtime values when needed.
+`ST-09060` tightens the multi-agent runtime schemas around message metadata, task-result metadata, and handoff context without changing multi-agent routing or execution behavior. Message and task-result metadata now require JSON-safe structures, while handoff context remains unknown-first so worker-to-worker coordination can still pass through richer runtime values when needed. During review, the JSON-safe object validator was extracted into a shared helper and ReAct message/thought metadata now use that same contract, which also rejects non-plain runtime objects while still allowing normal objects and null-prototype JSON maps.
 
 ## Test Strategy
 
@@ -18,12 +18,14 @@ No CI change was required because the existing focused multi-agent state test, p
 - `AgentMessageSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
 - `TaskResultSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
 - `HandoffRequestSchema.context` now uses `z.unknown()` instead of `z.any()`
+- ReAct `MessageSchema.metadata` and `ThoughtSchema.metadata` now use the shared JSON-safe object contract as part of the review-driven helper extraction
 
 ## Behavior Preserved
 
 - Multi-agent routing, worker handoff, execution metadata, and context-passing behavior remain unchanged
 - handoff context remains unknown-first and continues to accept non-JSON values when runtime coordination needs that flexibility
 - message flow, task completion flow, and supervisor/worker coordination semantics remain unchanged
+- ReAct message and thought metadata remain optional, but now reject non-JSON-safe runtime objects such as class instances while accepting plain objects and null-prototype JSON maps
 
 ## Explicit-`any` Baseline
 
@@ -49,3 +51,4 @@ No CI change was required because the existing focused multi-agent state test, p
 
 - The story added one focused runtime regression in `packages/patterns/tests/multi-agent/state.test.ts` plus a dedicated type-level contract assertion file for the multi-agent schema boundary.
 - The workspace test count increased from `2310` to `2311` because this story added one focused multi-agent schema assertion in `packages/patterns/tests/multi-agent/state.test.ts`.
+- Review follow-ups extracted `packages/patterns/src/shared/json-schemas.ts`, switched ReAct metadata fields to that helper, tightened plain-object enforcement, and then widened it to preserve support for `Object.create(null)` JSON maps.

--- a/docs/st09060-multi-agent-schema-payload-contracts.md
+++ b/docs/st09060-multi-agent-schema-payload-contracts.md
@@ -1,0 +1,51 @@
+# ST-09060: Multi-Agent Schema Payload Contracts
+
+## Summary
+
+`ST-09060` tightens the multi-agent runtime schemas around message metadata, task-result metadata, and handoff context without changing multi-agent routing or execution behavior. Message and task-result metadata now require JSON-safe structures, while handoff context remains unknown-first so worker-to-worker coordination can still pass through richer runtime values when needed.
+
+## Test Strategy
+
+This story had a practical test-first seam, so implementation started with focused multi-agent schema assertions before production changes:
+
+- add runtime schema assertions in `packages/patterns/tests/multi-agent/state.test.ts` for JSON-safe metadata acceptance/rejection boundaries and unknown-first handoff context compatibility
+- add compile-time assertions in `packages/patterns/tests/multi-agent/contracts.typecheck.ts` and wire them into the package typecheck config so inferred metadata and handoff context types no longer flow through broad `any`
+
+No CI change was required because the existing focused multi-agent state test, package typecheck, workspace test suite, lint, and explicit-`any` baseline gate already cover the touched surfaces once the compile-time assertions are included in `packages/patterns/tsconfig.typecheck.json`.
+
+## Contract Changes
+
+- `AgentMessageSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
+- `TaskResultSchema.metadata` now uses a JSON-safe object contract instead of `z.record(z.any())`
+- `HandoffRequestSchema.context` now uses `z.unknown()` instead of `z.any()`
+
+## Behavior Preserved
+
+- Multi-agent routing, worker handoff, execution metadata, and context-passing behavior remain unchanged
+- handoff context remains unknown-first and continues to accept non-JSON values when runtime coordination needs that flexibility
+- message flow, task completion flow, and supervisor/worker coordination semantics remain unchanged
+
+## Explicit-`any` Baseline
+
+- `pnpm lint:explicit-any:baseline` remained stable at `84/289` workspace warnings
+- `@agentforge/patterns` remained stable at `2/28`
+
+## Validation
+
+- Focused schema test:
+  - `pnpm test --run packages/patterns/tests/multi-agent/state.test.ts`
+  - initial failing result: `should reject non-JSON-safe metadata while preserving unknown-first handoff context`
+  - final result: `1` file passed, `23` tests passed
+- Package checks:
+  - `pnpm --filter @agentforge/patterns typecheck`
+  - `pnpm --filter @agentforge/patterns exec eslint src/multi-agent/schemas.ts tests/multi-agent/state.test.ts tests/multi-agent/contracts.typecheck.ts`
+- Workspace checks:
+  - `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
+  - `pnpm test --run` -> `210` files passed, `18` skipped; `2311` tests passed, `286` skipped
+  - `pnpm lint` -> passed with warnings only
+  - `git diff --check`
+
+## Notes
+
+- The story added one focused runtime regression in `packages/patterns/tests/multi-agent/state.test.ts` plus a dedicated type-level contract assertion file for the multi-agent schema boundary.
+- The workspace test count increased from `2310` to `2311` because this story added one focused multi-agent schema assertion in `packages/patterns/tests/multi-agent/state.test.ts`.

--- a/packages/patterns/src/multi-agent/schemas.ts
+++ b/packages/patterns/src/multi-agent/schemas.ts
@@ -8,21 +8,8 @@
  * @module patterns/multi-agent/schemas
  */
 
-import type { JsonObject, JsonValue } from '@agentforge/core';
+import { JsonObjectSchema } from '../shared/json-schemas.js';
 import { z } from 'zod';
-
-const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number().finite(),
-    z.boolean(),
-    z.null(),
-    z.array(JsonValueSchema),
-    z.record(JsonValueSchema),
-  ])
-);
-
-const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);
 
 /**
  * Schema for agent roles in the system

--- a/packages/patterns/src/multi-agent/schemas.ts
+++ b/packages/patterns/src/multi-agent/schemas.ts
@@ -8,7 +8,21 @@
  * @module patterns/multi-agent/schemas
  */
 
+import type { JsonObject, JsonValue } from '@agentforge/core';
 import { z } from 'zod';
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ])
+);
+
+const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);
 
 /**
  * Schema for agent roles in the system
@@ -63,7 +77,7 @@ export const AgentMessageSchema = z.object({
   /**
    * Optional metadata
    */
-  metadata: z.record(z.any()).optional().describe('Additional message metadata'),
+  metadata: JsonObjectSchema.optional().describe('Additional message metadata'),
 
   /**
    * Timestamp when message was created
@@ -237,7 +251,7 @@ export const TaskResultSchema = z.object({
   /**
    * Optional metadata about execution
    */
-  metadata: z.record(z.any()).optional().describe('Execution metadata'),
+  metadata: JsonObjectSchema.optional().describe('Execution metadata'),
 });
 
 export type TaskResult = z.infer<typeof TaskResultSchema>;
@@ -279,7 +293,7 @@ export const HandoffRequestSchema = z.object({
   /**
    * Context to pass to next agent
    */
-  context: z.any().describe('Context to pass to next agent'),
+  context: z.unknown().describe('Context to pass to next agent'),
 
   /**
    * Timestamp of handoff request
@@ -288,4 +302,3 @@ export const HandoffRequestSchema = z.object({
 });
 
 export type HandoffRequest = z.infer<typeof HandoffRequestSchema>;
-

--- a/packages/patterns/src/react/schemas.ts
+++ b/packages/patterns/src/react/schemas.ts
@@ -7,21 +7,8 @@
  * @module langgraph/patterns/react/schemas
  */
 
-import type { JsonObject, JsonValue } from '@agentforge/core';
+import { JsonObjectSchema } from '../shared/json-schemas.js';
 import { z } from 'zod';
-
-const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number().finite(),
-    z.boolean(),
-    z.null(),
-    z.array(JsonValueSchema),
-    z.record(JsonValueSchema),
-  ])
-);
-
-const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);
 
 /**
  * Message role types

--- a/packages/patterns/src/shared/index.ts
+++ b/packages/patterns/src/shared/index.ts
@@ -7,5 +7,5 @@
 export * from './agent-builder.js';
 export * from './deduplication.js';
 export * from './error-handling.js';
+export * from './json-schemas.js';
 export * from './state-fields.js';
-

--- a/packages/patterns/src/shared/json-schemas.ts
+++ b/packages/patterns/src/shared/json-schemas.ts
@@ -1,6 +1,15 @@
 import type { JsonObject, JsonValue } from '@agentforge/core';
 import { z } from 'zod';
 
+function isPlainJsonObject(value: unknown): value is JsonObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
 export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
     z.string(),
@@ -8,8 +17,12 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
     z.boolean(),
     z.null(),
     z.array(JsonValueSchema),
-    z.record(JsonValueSchema),
+    JsonObjectSchema,
   ])
 );
 
-export const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);
+export const JsonObjectSchema: z.ZodType<JsonObject> = z
+  .custom<JsonObject>(isPlainJsonObject, {
+    message: 'Expected a plain JSON object',
+  })
+  .pipe(z.record(JsonValueSchema));

--- a/packages/patterns/src/shared/json-schemas.ts
+++ b/packages/patterns/src/shared/json-schemas.ts
@@ -2,11 +2,14 @@ import type { JsonObject, JsonValue } from '@agentforge/core';
 import { z } from 'zod';
 
 function isPlainJsonObject(value: unknown): value is JsonObject {
+  const prototype =
+    typeof value === 'object' && value !== null ? Object.getPrototypeOf(value) : null;
+
   return (
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    Object.getPrototypeOf(value) === Object.prototype
+    (prototype === Object.prototype || prototype === null)
   );
 }
 

--- a/packages/patterns/src/shared/json-schemas.ts
+++ b/packages/patterns/src/shared/json-schemas.ts
@@ -1,0 +1,15 @@
+import type { JsonObject, JsonValue } from '@agentforge/core';
+import { z } from 'zod';
+
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ])
+);
+
+export const JsonObjectSchema: z.ZodType<JsonObject> = z.record(JsonValueSchema);

--- a/packages/patterns/tests/multi-agent/contracts.typecheck.ts
+++ b/packages/patterns/tests/multi-agent/contracts.typecheck.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import type { JsonObject } from '@agentforge/core';
+import type { AgentMessage, HandoffRequest, TaskResult } from '../../src/multi-agent/index.js';
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends
+  (<T>() => T extends Right ? 1 : 2) ? true : false;
+type AssertTrue<T extends true> = T;
+
+type _agentMessageMetadataIsJsonObject = AssertTrue<
+  Equal<AgentMessage['metadata'], JsonObject | undefined>
+>;
+type _taskResultMetadataIsJsonObject = AssertTrue<
+  Equal<TaskResult['metadata'], JsonObject | undefined>
+>;
+type _handoffContextIsUnknownFirst = AssertTrue<
+  Equal<HandoffRequest['context'], unknown>
+>;

--- a/packages/patterns/tests/multi-agent/state.test.ts
+++ b/packages/patterns/tests/multi-agent/state.test.ts
@@ -2,15 +2,16 @@ import { describe, it, expect } from 'vitest';
 import {
   MultiAgentState,
   MultiAgentStateConfig,
-  type MultiAgentStateType,
 } from '../../src/multi-agent/state.js';
 import {
   AgentRoleSchema,
+  type AgentMessage,
   MessageTypeSchema,
   AgentMessageSchema,
   RoutingStrategySchema,
   RoutingDecisionSchema,
   WorkerCapabilitiesSchema,
+  type WorkerCapabilities,
   TaskAssignmentSchema,
   TaskResultSchema,
   MultiAgentStatusSchema,
@@ -100,6 +101,43 @@ describe('Multi-Agent State', () => {
 
       const result = AgentMessageSchema.safeParse(validMessage);
       expect(result.success).toBe(true);
+    });
+
+    it('should reject non-JSON-safe metadata while preserving unknown-first handoff context', () => {
+      const invalidMessage = {
+        id: 'msg-4',
+        type: 'task_result',
+        from: 'worker-1',
+        to: 'supervisor',
+        content: 'Task completed',
+        metadata: {
+          callback: () => 'not-json-safe',
+        },
+        timestamp: Date.now(),
+      };
+
+      const invalidTaskResult = {
+        assignmentId: 'assignment-3',
+        workerId: 'worker-1',
+        success: true,
+        result: 'Completed',
+        completedAt: Date.now(),
+        metadata: {
+          score: Number.POSITIVE_INFINITY,
+        },
+      };
+
+      const flexibleHandoff = {
+        from: 'worker-1',
+        to: 'worker-2',
+        reason: 'Pass through rich runtime context',
+        context: { symbolToken: Symbol('handoff') },
+        timestamp: new Date().toISOString(),
+      };
+
+      expect(AgentMessageSchema.safeParse(invalidMessage).success).toBe(false);
+      expect(TaskResultSchema.safeParse(invalidTaskResult).success).toBe(false);
+      expect(HandoffRequestSchema.safeParse(flexibleHandoff).success).toBe(true);
     });
 
     it('should validate RoutingStrategy enum', () => {
@@ -273,9 +311,9 @@ describe('Multi-Agent State', () => {
       const messagesReducer = MultiAgentStateConfig.messages.reducer;
       expect(messagesReducer).toBeDefined();
       if (messagesReducer) {
-        const left = [{ id: '1', type: 'user_input', from: 'user', to: 'supervisor', content: 'test', timestamp: new Date().toISOString() }];
-        const right = [{ id: '2', type: 'task_assignment', from: 'supervisor', to: 'worker-1', content: 'task', timestamp: new Date().toISOString() }];
-        const result = messagesReducer(left as any, right as any);
+        const left: AgentMessage[] = [{ id: '1', type: 'user_input', from: 'user', to: 'supervisor', content: 'test', timestamp: new Date().toISOString() }];
+        const right: AgentMessage[] = [{ id: '2', type: 'task_assignment', from: 'supervisor', to: 'worker-1', content: 'task', timestamp: new Date().toISOString() }];
+        const result = messagesReducer(left, right);
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('1');
         expect(result[1].id).toBe('2');
@@ -293,29 +331,23 @@ describe('Multi-Agent State', () => {
       const workersReducer = MultiAgentStateConfig.workers.reducer;
       expect(workersReducer).toBeDefined();
       if (workersReducer) {
-        const left = {
+        const left: Record<string, WorkerCapabilities> = {
           'worker-1': {
-            agentId: 'worker-1',
-            name: 'Worker 1',
-            description: 'Test',
             skills: [],
             tools: [],
             available: true,
-            workload: 0,
+            currentWorkload: 0,
           },
         };
-        const right = {
+        const right: Record<string, WorkerCapabilities> = {
           'worker-2': {
-            agentId: 'worker-2',
-            name: 'Worker 2',
-            description: 'Test',
             skills: [],
             tools: [],
             available: true,
-            workload: 0,
+            currentWorkload: 0,
           },
         };
-        const result = workersReducer(left as any, right as any);
+        const result = workersReducer(left, right);
         expect(Object.keys(result)).toHaveLength(2);
         expect(result['worker-1']).toBeDefined();
         expect(result['worker-2']).toBeDefined();
@@ -323,4 +355,3 @@ describe('Multi-Agent State', () => {
     });
   });
 });
-

--- a/packages/patterns/tests/multi-agent/state.test.ts
+++ b/packages/patterns/tests/multi-agent/state.test.ts
@@ -104,15 +104,28 @@ describe('Multi-Agent State', () => {
     });
 
     it('should reject non-JSON-safe metadata while preserving unknown-first handoff context', () => {
+      const nullPrototypeMetadata = Object.assign(Object.create(null), {
+        duration: 1500,
+        tokensUsed: 250,
+      });
+
       const invalidMessage = {
         id: 'msg-4',
         type: 'task_result',
         from: 'worker-1',
         to: 'supervisor',
         content: 'Task completed',
-        metadata: {
-          callback: () => 'not-json-safe',
-        },
+        metadata: { callback: () => 'not-json-safe' },
+        timestamp: Date.now(),
+      };
+
+      const validNullPrototypeMessage = {
+        id: 'msg-4b',
+        type: 'task_result',
+        from: 'worker-1',
+        to: 'supervisor',
+        content: 'Task completed',
+        metadata: nullPrototypeMetadata,
         timestamp: Date.now(),
       };
 
@@ -136,6 +149,7 @@ describe('Multi-Agent State', () => {
       };
 
       expect(AgentMessageSchema.safeParse(invalidMessage).success).toBe(false);
+      expect(AgentMessageSchema.safeParse(validNullPrototypeMessage).success).toBe(true);
       expect(TaskResultSchema.safeParse(invalidTaskResult).success).toBe(false);
       expect(HandoffRequestSchema.safeParse(flexibleHandoff).success).toBe(true);
     });

--- a/packages/patterns/tests/multi-agent/state.test.ts
+++ b/packages/patterns/tests/multi-agent/state.test.ts
@@ -311,8 +311,8 @@ describe('Multi-Agent State', () => {
       const messagesReducer = MultiAgentStateConfig.messages.reducer;
       expect(messagesReducer).toBeDefined();
       if (messagesReducer) {
-        const left: AgentMessage[] = [{ id: '1', type: 'user_input', from: 'user', to: 'supervisor', content: 'test', timestamp: new Date().toISOString() }];
-        const right: AgentMessage[] = [{ id: '2', type: 'task_assignment', from: 'supervisor', to: 'worker-1', content: 'task', timestamp: new Date().toISOString() }];
+        const left: AgentMessage[] = [{ id: '1', type: 'user_input', from: 'user', to: 'supervisor', content: 'test', timestamp: Date.now() }];
+        const right: AgentMessage[] = [{ id: '2', type: 'task_assignment', from: 'supervisor', to: 'worker-1', content: 'task', timestamp: Date.now() }];
         const result = messagesReducer(left, right);
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('1');

--- a/packages/patterns/tsconfig.typecheck.json
+++ b/packages/patterns/tsconfig.typecheck.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src/**/*", "tests/react/contracts.typecheck.ts"],
+  "include": ["src/**/*", "tests/react/contracts.typecheck.ts", "tests/multi-agent/contracts.typecheck.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2427,7 +2427,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09060-multi-agent-schema-payload-contracts`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #129: https://github.com/TVScoundrel/agentforge/pull/129
 - [x] Define test strategy before implementation: cover schema acceptance/rejection boundaries, context payload handling, and metadata compatibility; first failing test should assert multi-agent schemas no longer rely on broad `z.any()` payload seams
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
 - [x] Replace broad metadata/context `z.any()` seams in `packages/patterns/src/multi-agent/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
@@ -2438,8 +2439,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
@@ -2464,6 +2465,10 @@ Implementation notes:
   - `git diff --check`
 - Residual impact:
   - Added one focused multi-agent schema assertion in `packages/patterns/tests/multi-agent/state.test.ts` plus a dedicated multi-agent contract typecheck fixture; no additional CI workflow change is required.
+- PR workflow:
+  - Draft PR created with story ID in title: PR #129
+  - Branch pushed with implementation commit `be2cb272`
+  - Branch is ready to be marked `Ready for review`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2426,21 +2426,44 @@ Implementation notes:
 **Branch:** `fix/st-09060-multi-agent-schema-payload-contracts`
 
 ### Checklist
-- [ ] Create branch `fix/st-09060-multi-agent-schema-payload-contracts`
+- [x] Create branch `fix/st-09060-multi-agent-schema-payload-contracts`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover schema acceptance/rejection boundaries, context payload handling, and metadata compatibility; first failing test should assert multi-agent schemas no longer rely on broad `z.any()` payload seams
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace broad metadata/context `z.any()` seams in `packages/patterns/src/multi-agent/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
-- [ ] Preserve multi-agent routing, worker handoff, execution metadata, and context-passing behavior
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas for touched files in story docs
-- [ ] Add or update story documentation at `docs/st09060-multi-agent-schema-payload-contracts.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Define test strategy before implementation: cover schema acceptance/rejection boundaries, context payload handling, and metadata compatibility; first failing test should assert multi-agent schemas no longer rely on broad `z.any()` payload seams
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Replace broad metadata/context `z.any()` seams in `packages/patterns/src/multi-agent/schemas.ts` with unknown-first or JSON-safe payload contracts where behavior allows
+- [x] Preserve multi-agent routing, worker handoff, execution metadata, and context-passing behavior
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas for touched files in story docs
+- [x] Add or update story documentation at `docs/st09060-multi-agent-schema-payload-contracts.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+
+- Test-first plan:
+  - Add focused multi-agent schema runtime tests for JSON-safe metadata acceptance/rejection boundaries and unknown-first handoff context compatibility in `packages/patterns/tests/multi-agent/state.test.ts`.
+  - Add type-level assertions in `packages/patterns/tests/multi-agent/contracts.typecheck.ts` so message metadata, task-result metadata, and handoff context inference no longer flow through broad `any`.
+- Focused failing test:
+  - `pnpm test --run packages/patterns/tests/multi-agent/state.test.ts`
+  - initial failure: `should reject non-JSON-safe metadata while preserving unknown-first handoff context`
+- Focused passing test:
+  - `pnpm test --run packages/patterns/tests/multi-agent/state.test.ts`
+  - `1` file passed, `23` tests passed
+- Package checks:
+  - `pnpm --filter @agentforge/patterns typecheck`
+  - `pnpm --filter @agentforge/patterns exec eslint src/multi-agent/schemas.ts tests/multi-agent/state.test.ts tests/multi-agent/contracts.typecheck.ts`
+- Explicit-`any` baseline:
+  - `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
+- Workspace checks:
+  - `pnpm test --run` -> `210` files passed, `18` skipped; `2311` tests passed, `286` skipped
+  - `pnpm lint` -> passed with warnings only
+  - `git diff --check`
+- Residual impact:
+  - Added one focused multi-agent schema assertion in `packages/patterns/tests/multi-agent/state.test.ts` plus a dedicated multi-agent contract typecheck fixture; no additional CI workflow change is required.
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1871,7 +1871,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09045
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/multi-agent/schemas.ts` replaces broad metadata/context `z.any()` seams with unknown-first or JSON-safe contracts where behavior allows.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1871,7 +1871,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09045
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/multi-agent/schemas.ts` replaces broad metadata/context `z.any()` seams with unknown-first or JSON-safe contracts where behavior allows.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-08
-**Active Story:** ST-09060 - Tighten Multi-Agent Schema Payload Contracts (Ready)
+**Active Story:** ST-09060 - Tighten Multi-Agent Schema Payload Contracts (In Progress)
 
 ---
 
@@ -101,7 +101,7 @@ Recent improvement snapshot:
 - `ST-09061` through `ST-09066` were added on 2026-06-05 to keep EP-09 stocked beyond the current lane with another modularization-first batch, prioritizing large runtime files in `core` and `patterns` before the remaining schema-hardening slices so future fixes land on smaller modules instead of monoliths.
 - `ST-09058` merged on 2026-06-06 after shrinking `packages/core/src/tools/lifecycle.ts` from a `405` line mixed-responsibility runtime to an `11` line public facade, extracting focused managed-tool, hook, health, and shared-type modules, replacing the `574` line lifecycle test monolith with focused initialization, execution, cleanup, and health suites, and absorbing review follow-ups for direct implementation-type imports and cleaner internal initialize dependencies while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
 - `ST-09059` merged on 2026-06-08 after tightening ReAct schema payload contracts around JSON-safe metadata, finite numeric metadata values, unknown-first tool payload seams, and package-enforced contract typechecks while keeping the explicit-`any` baseline flat at `workspace 84/289` and `patterns 2/28`.
-- `EP-09` remains open as the daily hardening stream, with `ST-09060` now the next ready schema-hardening slice and the remaining ready lane still covering `ST-09061` through `ST-09066`.
+- `EP-09` remains open as the daily hardening stream, with `ST-09060` now the active schema-hardening slice and the remaining ready lane still covering `ST-09061` through `ST-09066`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-08
-**Active Story:** ST-09060 - Tighten Multi-Agent Schema Payload Contracts (In Progress)
+**Active Story:** ST-09060 - Tighten Multi-Agent Schema Payload Contracts (In Review)
 
 ---
 
@@ -101,7 +101,7 @@ Recent improvement snapshot:
 - `ST-09061` through `ST-09066` were added on 2026-06-05 to keep EP-09 stocked beyond the current lane with another modularization-first batch, prioritizing large runtime files in `core` and `patterns` before the remaining schema-hardening slices so future fixes land on smaller modules instead of monoliths.
 - `ST-09058` merged on 2026-06-06 after shrinking `packages/core/src/tools/lifecycle.ts` from a `405` line mixed-responsibility runtime to an `11` line public facade, extracting focused managed-tool, hook, health, and shared-type modules, replacing the `574` line lifecycle test monolith with focused initialization, execution, cleanup, and health suites, and absorbing review follow-ups for direct implementation-type imports and cleaner internal initialize dependencies while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
 - `ST-09059` merged on 2026-06-08 after tightening ReAct schema payload contracts around JSON-safe metadata, finite numeric metadata values, unknown-first tool payload seams, and package-enforced contract typechecks while keeping the explicit-`any` baseline flat at `workspace 84/289` and `patterns 2/28`.
-- `EP-09` remains open as the daily hardening stream, with `ST-09060` now the active schema-hardening slice and the remaining ready lane still covering `ST-09061` through `ST-09066`.
+- `EP-09` remains open as the daily hardening stream, with `ST-09060` now in review as the active schema-hardening slice and the remaining ready lane still covering `ST-09061` through `ST-09066`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 7 stories
-- **In Progress:** 0 stories
+- **Ready:** 6 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09060` - Tighten Multi-Agent Schema Payload Contracts
 - `ST-09061` - Modularize Core Tool Types and Tests
 - `ST-09062` - Modularize Core Tool Executor and Tests
 - `ST-09063` - Modularize Multi-Agent Worker Node and Tests
@@ -26,7 +25,7 @@
 
 ## In Progress
 
-None currently.
+- `ST-09060` - Tighten Multi-Agent Schema Payload Contracts
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 6 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -25,13 +25,13 @@
 
 ## In Progress
 
-- `ST-09060` - Tighten Multi-Agent Schema Payload Contracts
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09060` - Tighten Multi-Agent Schema Payload Contracts
 
 ## Blocked
 


### PR DESCRIPTION
## Story

`ST-09060` - Tighten Multi-Agent Schema Payload Contracts

## What Changed

- tightened `packages/patterns/src/multi-agent/schemas.ts` so `AgentMessage.metadata` and `TaskResult.metadata` are JSON-safe object contracts
- changed `HandoffRequestSchema.context` from broad `z.any()` to `z.unknown()` so handoff context stays unknown-first without leaking `any`
- added focused multi-agent schema runtime coverage in `packages/patterns/tests/multi-agent/state.test.ts`
- added `packages/patterns/tests/multi-agent/contracts.typecheck.ts` and wired it into `packages/patterns/tsconfig.typecheck.json`
- added story documentation and checklist evidence for the schema-boundary change

## Acceptance Criteria Coverage

- replaced broad metadata/context `z.any()` seams in `packages/patterns/src/multi-agent/schemas.ts` with JSON-safe metadata and unknown-first handoff context
- preserved multi-agent routing, worker handoff, execution metadata, and context-passing behavior
- added focused tests for schema acceptance/rejection boundaries, handoff context compatibility, and inferred contract typing
- kept the explicit-`any` baseline flat and recorded the outcome in the story documentation
- added `docs/st09060-multi-agent-schema-payload-contracts.md`

## Test Strategy

- test-first runtime boundary in `packages/patterns/tests/multi-agent/state.test.ts`
- compile-time contract assertions in `packages/patterns/tests/multi-agent/contracts.typecheck.ts`
- package typecheck updated to compile both the existing ReAct contract fixture and the new multi-agent fixture

## Validation Performed

- `pnpm test --run packages/patterns/tests/multi-agent/state.test.ts`
  - initial failure: `should reject non-JSON-safe metadata while preserving unknown-first handoff context`
  - final result: `1` file passed, `23` tests passed
- `pnpm --filter @agentforge/patterns typecheck`
- `pnpm --filter @agentforge/patterns exec eslint src/multi-agent/schemas.ts tests/multi-agent/state.test.ts tests/multi-agent/contracts.typecheck.ts`
- `pnpm lint:explicit-any:baseline` -> workspace `84/289`, `patterns 2/28`
- `pnpm test --run` -> `210` files passed, `18` skipped; `2311` tests passed, `286` skipped
- `pnpm lint` -> passed with warnings only
- `git diff --check`

## Status

Ready for review.
