### PR TITLE
ST-09066: Modularize Core Resource Pool and Tests

### DIFF
--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -30,7 +30,7 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 ## File Size Results
 
 - Current post-split file sizes:
-- `packages/core/src/resources/pool.ts`: `316 -> 97` lines
+- `packages/core/src/resources/pool.ts`: `316 -> 106` lines
 - Extracted modules:
   - `pool-types.ts`: `61` lines
   - `pool-runtime.ts`: `113` lines
@@ -48,7 +48,7 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 - Focused suites:
   - `packages/core/tests/resources/pool/acquisition.ts`: `163` lines
   - `packages/core/tests/resources/pool/eviction.ts`: `105` lines
-  - `packages/core/tests/resources/pool/lifecycle.ts`: `182` lines
+  - `packages/core/tests/resources/pool/lifecycle.ts`: `211` lines
 
 ## Residual Test Impact
 
@@ -58,7 +58,7 @@ No additional automated coverage was needed beyond the new direct pool suites an
 
 - Focused shared and wrapper pool coverage:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
-  - `3` files passed, `17` tests passed
+  - `3` files passed, `18` tests passed
 - Compatibility validation:
   - `pnpm --filter @agentforge/core typecheck`
 - Explicit-`any` baseline:

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -28,19 +28,21 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 
 ## File Size Results
 
-- `packages/core/src/resources/pool.ts`: `316 -> 79` lines
+- Current post-split file sizes:
+- `packages/core/src/resources/pool.ts`: `316 -> 82` lines
 - Extracted modules:
   - `pool-types.ts`: `60` lines
   - `pool-runtime.ts`: `72` lines
   - `pool-acquisition.ts`: `84` lines
   - `pool-eviction.ts`: `27` lines
-  - `pool-health.ts`: `44` lines
+  - `pool-health.ts`: `60` lines
   - `pool-lifecycle.ts`: `34` lines
 
 ## Test Modularization Results
 
-- Added `packages/core/tests/resources/pool.test.ts`: `3` line public entrypoint
-- Added focused suites:
+- Current test file sizes:
+- `packages/core/tests/resources/pool.test.ts`: `3` line public entrypoint
+- Focused suites:
   - `packages/core/tests/resources/pool/acquisition.ts`: `35` lines
   - `packages/core/tests/resources/pool/eviction.ts`: `40` lines
   - `packages/core/tests/resources/pool/lifecycle.ts`: `29` lines

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -43,6 +43,8 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 
 - Current test file sizes:
 - `packages/core/tests/resources/pool.test.ts`: `3` line public entrypoint
+- Shared fixture:
+  - `packages/core/tests/resources/pool/shared.ts`: `57` lines
 - Focused suites:
   - `packages/core/tests/resources/pool/acquisition.ts`: `81` lines
   - `packages/core/tests/resources/pool/eviction.ts`: `42` lines

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -30,14 +30,14 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 ## File Size Results
 
 - Current post-split file sizes:
-- `packages/core/src/resources/pool.ts`: `316 -> 83` lines
+- `packages/core/src/resources/pool.ts`: `316 -> 90` lines
 - Extracted modules:
   - `pool-types.ts`: `61` lines
-  - `pool-runtime.ts`: `72` lines
+  - `pool-runtime.ts`: `102` lines
   - `pool-acquisition.ts`: `89` lines
-  - `pool-eviction.ts`: `27` lines
-  - `pool-health.ts`: `60` lines
-  - `pool-lifecycle.ts`: `34` lines
+  - `pool-eviction.ts`: `43` lines
+  - `pool-health.ts`: `64` lines
+  - `pool-lifecycle.ts`: `40` lines
 
 ## Test Modularization Results
 
@@ -46,9 +46,9 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 - Shared fixture:
   - `packages/core/tests/resources/pool/shared.ts`: `57` lines
 - Focused suites:
-  - `packages/core/tests/resources/pool/acquisition.ts`: `81` lines
-  - `packages/core/tests/resources/pool/eviction.ts`: `42` lines
-  - `packages/core/tests/resources/pool/lifecycle.ts`: `31` lines
+  - `packages/core/tests/resources/pool/acquisition.ts`: `127` lines
+  - `packages/core/tests/resources/pool/eviction.ts`: `105` lines
+  - `packages/core/tests/resources/pool/lifecycle.ts`: `106` lines
 
 ## Residual Test Impact
 

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -1,0 +1,71 @@
+# ST-09066: Resource Pool Modularization
+
+## Summary
+
+Modularized the shared resource-pool runtime in `packages/core/src/resources/pool.ts` into focused acquisition, eviction, health-check, lifecycle, runtime-helper, and shared-type modules while preserving the public `ConnectionPool` and `createConnectionPool(...)` facade. Added a stable `packages/core/tests/resources/pool.test.ts` entrypoint with focused acquisition, eviction, and lifecycle suites so shared pool behavior is verified directly instead of only through the database and HTTP wrappers.
+
+## Test-First Evidence
+
+- Added the new shared pool entrypoint and focused suites before refactoring `pool.ts`.
+- First focused run:
+  - `pnpm test --run packages/core/tests/resources/pool.test.ts`
+  - Failed in `packages/core/tests/resources/pool/eviction.ts`
+  - Failure showed eviction dropped the pool below its configured `min`:
+    - expected stats `{ size: 1, available: 1, acquired: 0 }`
+    - received stats `{ size: 0, available: 0, acquired: 0 }`
+
+## Implementation Notes
+
+- Extracted focused runtime helpers:
+  - `packages/core/src/resources/pool-types.ts`
+  - `packages/core/src/resources/pool-runtime.ts`
+  - `packages/core/src/resources/pool-acquisition.ts`
+  - `packages/core/src/resources/pool-eviction.ts`
+  - `packages/core/src/resources/pool-health.ts`
+  - `packages/core/src/resources/pool-lifecycle.ts`
+- Kept the public `packages/core/src/resources/pool.ts` file as a thin facade over the extracted helpers.
+- Fixed the idle-eviction bug by limiting evictions to `connections.length - min` eligible idle connections instead of computing a fully-evictable set up front.
+
+## File Size Results
+
+- `packages/core/src/resources/pool.ts`: `316 -> 79` lines
+- Extracted modules:
+  - `pool-types.ts`: `60` lines
+  - `pool-runtime.ts`: `72` lines
+  - `pool-acquisition.ts`: `84` lines
+  - `pool-eviction.ts`: `27` lines
+  - `pool-health.ts`: `44` lines
+  - `pool-lifecycle.ts`: `34` lines
+
+## Test Modularization Results
+
+- Added `packages/core/tests/resources/pool.test.ts`: `3` line public entrypoint
+- Added focused suites:
+  - `packages/core/tests/resources/pool/acquisition.ts`: `35` lines
+  - `packages/core/tests/resources/pool/eviction.ts`: `40` lines
+  - `packages/core/tests/resources/pool/lifecycle.ts`: `29` lines
+
+## Residual Test Impact
+
+No additional automated coverage was needed beyond the new direct pool suites and the existing database/http wrapper tests. The split now exercises shared acquisition, eviction, and lifecycle behavior against `ConnectionPool` itself while the wrapper-specific resource tests continue to confirm the public adapters still delegate correctly.
+
+## Validation
+
+- Focused shared and wrapper pool coverage:
+  - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
+  - `3` files passed, `9` tests passed
+- Compatibility validation:
+  - `pnpm --filter @agentforge/core typecheck`
+- Explicit-`any` baseline:
+  - `pnpm lint:explicit-any:baseline`
+  - `84/289` warnings overall; `23/119` in `core`
+- Full test suite:
+  - `pnpm test --run`
+  - `211 passed | 18 skipped` files; `2314 passed | 286 skipped` tests
+- Lint:
+  - `pnpm lint`
+  - exit `0`; warnings only (`0` errors)
+
+## CI Impact
+
+No CI change required. The story keeps the existing public resource exports and validation commands intact.

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -30,11 +30,11 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 ## File Size Results
 
 - Current post-split file sizes:
-- `packages/core/src/resources/pool.ts`: `316 -> 90` lines
+- `packages/core/src/resources/pool.ts`: `316 -> 97` lines
 - Extracted modules:
   - `pool-types.ts`: `61` lines
-  - `pool-runtime.ts`: `102` lines
-  - `pool-acquisition.ts`: `89` lines
+  - `pool-runtime.ts`: `113` lines
+  - `pool-acquisition.ts`: `93` lines
   - `pool-eviction.ts`: `43` lines
   - `pool-health.ts`: `64` lines
   - `pool-lifecycle.ts`: `40` lines
@@ -46,9 +46,9 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 - Shared fixture:
   - `packages/core/tests/resources/pool/shared.ts`: `57` lines
 - Focused suites:
-  - `packages/core/tests/resources/pool/acquisition.ts`: `127` lines
+  - `packages/core/tests/resources/pool/acquisition.ts`: `163` lines
   - `packages/core/tests/resources/pool/eviction.ts`: `105` lines
-  - `packages/core/tests/resources/pool/lifecycle.ts`: `106` lines
+  - `packages/core/tests/resources/pool/lifecycle.ts`: `182` lines
 
 ## Residual Test Impact
 
@@ -58,7 +58,7 @@ No additional automated coverage was needed beyond the new direct pool suites an
 
 - Focused shared and wrapper pool coverage:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
-  - `3` files passed, `9` tests passed
+  - `3` files passed, `17` tests passed
 - Compatibility validation:
   - `pnpm --filter @agentforge/core typecheck`
 - Explicit-`any` baseline:

--- a/docs/st09066-resource-pool-modularization.md
+++ b/docs/st09066-resource-pool-modularization.md
@@ -25,15 +25,16 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
   - `packages/core/src/resources/pool-lifecycle.ts`
 - Kept the public `packages/core/src/resources/pool.ts` file as a thin facade over the extracted helpers.
 - Fixed the idle-eviction bug by limiting evictions to `connections.length - min` eligible idle connections instead of computing a fully-evictable set up front.
+- Follow-up review fixes also hardened concurrent `acquire()` calls so in-flight connection creation still respects the configured pool `max`.
 
 ## File Size Results
 
 - Current post-split file sizes:
-- `packages/core/src/resources/pool.ts`: `316 -> 82` lines
+- `packages/core/src/resources/pool.ts`: `316 -> 83` lines
 - Extracted modules:
-  - `pool-types.ts`: `60` lines
+  - `pool-types.ts`: `61` lines
   - `pool-runtime.ts`: `72` lines
-  - `pool-acquisition.ts`: `84` lines
+  - `pool-acquisition.ts`: `89` lines
   - `pool-eviction.ts`: `27` lines
   - `pool-health.ts`: `60` lines
   - `pool-lifecycle.ts`: `34` lines
@@ -43,9 +44,9 @@ Modularized the shared resource-pool runtime in `packages/core/src/resources/poo
 - Current test file sizes:
 - `packages/core/tests/resources/pool.test.ts`: `3` line public entrypoint
 - Focused suites:
-  - `packages/core/tests/resources/pool/acquisition.ts`: `35` lines
-  - `packages/core/tests/resources/pool/eviction.ts`: `40` lines
-  - `packages/core/tests/resources/pool/lifecycle.ts`: `29` lines
+  - `packages/core/tests/resources/pool/acquisition.ts`: `81` lines
+  - `packages/core/tests/resources/pool/eviction.ts`: `42` lines
+  - `packages/core/tests/resources/pool/lifecycle.ts`: `31` lines
 
 ## Residual Test Impact
 

--- a/packages/core/src/resources/pool-acquisition.ts
+++ b/packages/core/src/resources/pool-acquisition.ts
@@ -1,0 +1,84 @@
+import type { ConnectionPoolRuntime } from './pool-types.js';
+import { createConnection, getPoolConfig } from './pool-runtime.js';
+
+export async function acquireConnection<T>(runtime: ConnectionPoolRuntime<T>): Promise<T> {
+  if (runtime.draining) {
+    throw new Error('Pool is draining');
+  }
+
+  const available = runtime.connections.find((connection) => !connection.inUse);
+  if (available) {
+    available.inUse = true;
+    available.lastUsedAt = Date.now();
+    runtime.stats.available--;
+    runtime.stats.acquired++;
+    runtime.options.onAcquire?.(available.connection);
+    return available.connection;
+  }
+
+  const poolConfig = getPoolConfig(runtime);
+  const max = poolConfig.max || 10;
+  if (runtime.connections.length < max) {
+    const connection = await createConnection(runtime);
+    const pooled = runtime.connections.find((item) => item.connection === connection);
+    if (!pooled) {
+      throw new Error('Newly created connection not found in pool');
+    }
+
+    pooled.inUse = true;
+    pooled.lastUsedAt = Date.now();
+    runtime.stats.available--;
+    runtime.stats.acquired++;
+    runtime.options.onAcquire?.(connection);
+    return connection;
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const timeout = poolConfig.acquireTimeout || 30000;
+    const timer = setTimeout(() => {
+      const index = runtime.pending.findIndex((pending) => pending.resolve === resolve);
+      if (index !== -1) {
+        runtime.pending.splice(index, 1);
+        runtime.stats.pending--;
+      }
+      reject(new Error('Acquire timeout'));
+    }, timeout);
+
+    runtime.pending.push({ resolve, reject, timeout: timer });
+    runtime.stats.pending++;
+  });
+}
+
+export async function releaseConnection<T>(
+  runtime: ConnectionPoolRuntime<T>,
+  connection: T
+): Promise<void> {
+  const pooled = runtime.connections.find((item) => item.connection === connection);
+  if (!pooled) {
+    throw new Error('Connection not found in pool');
+  }
+
+  if (!pooled.inUse) {
+    throw new Error('Connection is not in use');
+  }
+
+  pooled.inUse = false;
+  pooled.lastUsedAt = Date.now();
+  runtime.stats.available++;
+  runtime.stats.acquired--;
+  runtime.options.onRelease?.(connection);
+
+  const pending = runtime.pending.shift();
+  if (!pending) {
+    return;
+  }
+
+  clearTimeout(pending.timeout);
+  runtime.stats.pending--;
+  pooled.inUse = true;
+  pooled.lastUsedAt = Date.now();
+  runtime.stats.available--;
+  runtime.stats.acquired++;
+  runtime.options.onAcquire?.(connection);
+  pending.resolve(connection);
+}

--- a/packages/core/src/resources/pool-acquisition.ts
+++ b/packages/core/src/resources/pool-acquisition.ts
@@ -18,19 +18,24 @@ export async function acquireConnection<T>(runtime: ConnectionPoolRuntime<T>): P
 
   const poolConfig = getPoolConfig(runtime);
   const max = poolConfig.max || 10;
-  if (runtime.connections.length < max) {
-    const connection = await createConnection(runtime);
-    const pooled = runtime.connections.find((item) => item.connection === connection);
-    if (!pooled) {
-      throw new Error('Newly created connection not found in pool');
-    }
+  if (runtime.connections.length + runtime.creating < max) {
+    runtime.creating++;
+    try {
+      const connection = await createConnection(runtime);
+      const pooled = runtime.connections.find((item) => item.connection === connection);
+      if (!pooled) {
+        throw new Error('Newly created connection not found in pool');
+      }
 
-    pooled.inUse = true;
-    pooled.lastUsedAt = Date.now();
-    runtime.stats.available--;
-    runtime.stats.acquired++;
-    runtime.options.onAcquire?.(connection);
-    return connection;
+      pooled.inUse = true;
+      pooled.lastUsedAt = Date.now();
+      runtime.stats.available--;
+      runtime.stats.acquired++;
+      runtime.options.onAcquire?.(connection);
+      return connection;
+    } finally {
+      runtime.creating--;
+    }
   }
 
   return new Promise<T>((resolve, reject) => {

--- a/packages/core/src/resources/pool-acquisition.ts
+++ b/packages/core/src/resources/pool-acquisition.ts
@@ -1,5 +1,5 @@
 import type { ConnectionPoolRuntime } from './pool-types.js';
-import { createConnection, getPoolConfig } from './pool-runtime.js';
+import { createConnection, destroyConnection, getPoolConfig } from './pool-runtime.js';
 
 export async function acquireConnection<T>(runtime: ConnectionPoolRuntime<T>): Promise<T> {
   if (runtime.draining) {
@@ -25,6 +25,10 @@ export async function acquireConnection<T>(runtime: ConnectionPoolRuntime<T>): P
       const pooled = runtime.connections.find((item) => item.connection === connection);
       if (!pooled) {
         throw new Error('Newly created connection not found in pool');
+      }
+      if (runtime.draining) {
+        await destroyConnection(runtime, pooled);
+        throw new Error('Pool is draining');
       }
 
       pooled.inUse = true;

--- a/packages/core/src/resources/pool-eviction.ts
+++ b/packages/core/src/resources/pool-eviction.ts
@@ -1,0 +1,27 @@
+import type { ConnectionPoolRuntime, PooledConnection } from './pool-types.js';
+import { destroyConnection, getPoolConfig } from './pool-runtime.js';
+
+function selectIdleConnectionsForEviction<T>(
+  runtime: ConnectionPoolRuntime<T>,
+  idleTimeout: number,
+  min: number,
+  now: number
+): PooledConnection<T>[] {
+  const idleConnections = runtime.connections.filter(
+    (connection) => !connection.inUse && now - connection.lastUsedAt > idleTimeout
+  );
+  const evictableCount = Math.max(0, runtime.connections.length - min);
+  return idleConnections.slice(0, evictableCount);
+}
+
+export async function evictIdleConnections<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  const poolConfig = getPoolConfig(runtime);
+  const idleTimeout = poolConfig.idleTimeout || 60000;
+  const min = poolConfig.min || 0;
+  const now = Date.now();
+
+  const toEvict = selectIdleConnectionsForEviction(runtime, idleTimeout, min, now);
+  for (const pooled of toEvict) {
+    await destroyConnection(runtime, pooled);
+  }
+}

--- a/packages/core/src/resources/pool-eviction.ts
+++ b/packages/core/src/resources/pool-eviction.ts
@@ -22,6 +22,22 @@ export async function evictIdleConnections<T>(runtime: ConnectionPoolRuntime<T>)
 
   const toEvict = selectIdleConnectionsForEviction(runtime, idleTimeout, min, now);
   for (const pooled of toEvict) {
+    if (!runtime.connections.includes(pooled)) {
+      continue;
+    }
+
+    if (pooled.inUse) {
+      continue;
+    }
+
+    if (runtime.connections.length <= min) {
+      break;
+    }
+
+    if (Date.now() - pooled.lastUsedAt <= idleTimeout) {
+      continue;
+    }
+
     await destroyConnection(runtime, pooled);
   }
 }

--- a/packages/core/src/resources/pool-health.ts
+++ b/packages/core/src/resources/pool-health.ts
@@ -1,6 +1,27 @@
 import type { ConnectionPoolRuntime } from './pool-types.js';
 import { destroyConnection, getHealthCheckConfig } from './pool-runtime.js';
 
+async function runHealthCheckWithTimeout<T>(
+  runtime: ConnectionPoolRuntime<T>,
+  connection: T,
+  timeout: number
+): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      runtime.options.validator!(connection),
+      new Promise<boolean>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('Health check timeout')), timeout);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 export async function performHealthChecks<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
   if (!runtime.options.validator) {
     return;
@@ -18,12 +39,7 @@ export async function performHealthChecks<T>(runtime: ConnectionPoolRuntime<T>):
     let healthy = false;
     for (let attempt = 0; attempt < retries; attempt++) {
       try {
-        const result = await Promise.race([
-          runtime.options.validator(pooled.connection),
-          new Promise<boolean>((_, reject) =>
-            setTimeout(() => reject(new Error('Health check timeout')), timeout)
-          ),
-        ]);
+        const result = await runHealthCheckWithTimeout(runtime, pooled.connection, timeout);
         if (result) {
           healthy = true;
           break;

--- a/packages/core/src/resources/pool-health.ts
+++ b/packages/core/src/resources/pool-health.ts
@@ -1,0 +1,44 @@
+import type { ConnectionPoolRuntime } from './pool-types.js';
+import { destroyConnection, getHealthCheckConfig } from './pool-runtime.js';
+
+export async function performHealthChecks<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  if (!runtime.options.validator) {
+    return;
+  }
+
+  const healthCheck = getHealthCheckConfig(runtime);
+  const timeout = healthCheck.timeout || 5000;
+  const retries = healthCheck.retries || 1;
+
+  for (const pooled of [...runtime.connections]) {
+    if (pooled.inUse) {
+      continue;
+    }
+
+    let healthy = false;
+    for (let attempt = 0; attempt < retries; attempt++) {
+      try {
+        const result = await Promise.race([
+          runtime.options.validator(pooled.connection),
+          new Promise<boolean>((_, reject) =>
+            setTimeout(() => reject(new Error('Health check timeout')), timeout)
+          ),
+        ]);
+        if (result) {
+          healthy = true;
+          break;
+        }
+      } catch {
+        // Continue to the next retry.
+      }
+    }
+
+    if (healthy) {
+      runtime.stats.healthChecksPassed++;
+      continue;
+    }
+
+    runtime.stats.healthChecksFailed++;
+    await destroyConnection(runtime, pooled);
+  }
+}

--- a/packages/core/src/resources/pool-health.ts
+++ b/packages/core/src/resources/pool-health.ts
@@ -54,6 +54,10 @@ export async function performHealthChecks<T>(runtime: ConnectionPoolRuntime<T>):
       continue;
     }
 
+    if (!runtime.connections.includes(pooled) || pooled.inUse) {
+      continue;
+    }
+
     runtime.stats.healthChecksFailed++;
     await destroyConnection(runtime, pooled);
   }

--- a/packages/core/src/resources/pool-lifecycle.ts
+++ b/packages/core/src/resources/pool-lifecycle.ts
@@ -1,0 +1,34 @@
+import type { ConnectionPoolRuntime } from './pool-types.js';
+import { destroyConnection } from './pool-runtime.js';
+
+export async function drainPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  runtime.draining = true;
+
+  for (const pending of runtime.pending) {
+    clearTimeout(pending.timeout);
+    pending.reject(new Error('Pool is draining'));
+  }
+  runtime.pending = [];
+  runtime.stats.pending = 0;
+
+  while (runtime.connections.some((connection) => connection.inUse)) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+export async function clearPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  if (runtime.evictionTimer) {
+    clearInterval(runtime.evictionTimer);
+    runtime.evictionTimer = undefined;
+  }
+
+  if (runtime.healthCheckTimer) {
+    clearInterval(runtime.healthCheckTimer);
+    runtime.healthCheckTimer = undefined;
+  }
+
+  const connections = [...runtime.connections];
+  for (const pooled of connections) {
+    await destroyConnection(runtime, pooled);
+  }
+}

--- a/packages/core/src/resources/pool-lifecycle.ts
+++ b/packages/core/src/resources/pool-lifecycle.ts
@@ -1,15 +1,18 @@
 import type { ConnectionPoolRuntime } from './pool-types.js';
 import { destroyConnection } from './pool-runtime.js';
 
-export async function drainPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
-  runtime.draining = true;
-
+function rejectPendingAcquisitions<T>(runtime: ConnectionPoolRuntime<T>, message: string): void {
   for (const pending of runtime.pending) {
     clearTimeout(pending.timeout);
-    pending.reject(new Error('Pool is draining'));
+    pending.reject(new Error(message));
   }
   runtime.pending = [];
   runtime.stats.pending = 0;
+}
+
+export async function drainPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  runtime.draining = true;
+  rejectPendingAcquisitions(runtime, 'Pool is draining');
 
   while (runtime.connections.some((connection) => connection.inUse)) {
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -17,6 +20,9 @@ export async function drainPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<v
 }
 
 export async function clearPool<T>(runtime: ConnectionPoolRuntime<T>): Promise<void> {
+  runtime.draining = true;
+  rejectPendingAcquisitions(runtime, 'Pool is draining');
+
   if (runtime.evictionTimer) {
     clearInterval(runtime.evictionTimer);
     runtime.evictionTimer = undefined;

--- a/packages/core/src/resources/pool-runtime.ts
+++ b/packages/core/src/resources/pool-runtime.ts
@@ -1,0 +1,72 @@
+import type { ConnectionPoolRuntime, PooledConnection, PoolStats } from './pool-types.js';
+
+export function createInitialPoolStats(): PoolStats {
+  return {
+    size: 0,
+    available: 0,
+    pending: 0,
+    acquired: 0,
+    created: 0,
+    destroyed: 0,
+    healthChecksPassed: 0,
+    healthChecksFailed: 0,
+  };
+}
+
+export async function initializeConnections<T>(
+  runtime: ConnectionPoolRuntime<T>,
+  count: number
+): Promise<void> {
+  const promises = Array.from({ length: count }, () => createConnection(runtime));
+  await Promise.all(promises);
+}
+
+export async function createConnection<T>(runtime: ConnectionPoolRuntime<T>): Promise<T> {
+  const connection = await runtime.options.factory();
+  const now = Date.now();
+
+  runtime.connections.push({
+    connection,
+    createdAt: now,
+    lastUsedAt: now,
+    inUse: false,
+  });
+  runtime.stats.created++;
+  runtime.stats.size++;
+  runtime.stats.available++;
+
+  return connection;
+}
+
+export async function destroyConnection<T>(
+  runtime: ConnectionPoolRuntime<T>,
+  pooled: PooledConnection<T>
+): Promise<void> {
+  const index = runtime.connections.indexOf(pooled);
+  if (index !== -1) {
+    runtime.connections.splice(index, 1);
+  }
+
+  if (runtime.options.destroyer) {
+    await runtime.options.destroyer(pooled.connection);
+  }
+
+  runtime.options.onDestroy?.(pooled.connection);
+  runtime.stats.destroyed++;
+  runtime.stats.size--;
+  if (!pooled.inUse) {
+    runtime.stats.available--;
+  }
+}
+
+export function getPoolConfig<T>(runtime: ConnectionPoolRuntime<T>) {
+  return runtime.options.pool || {};
+}
+
+export function getHealthCheckConfig<T>(runtime: ConnectionPoolRuntime<T>) {
+  return runtime.options.healthCheck || {};
+}
+
+export function clonePoolStats<T>(runtime: ConnectionPoolRuntime<T>): PoolStats {
+  return { ...runtime.stats };
+}

--- a/packages/core/src/resources/pool-runtime.ts
+++ b/packages/core/src/resources/pool-runtime.ts
@@ -21,6 +21,15 @@ export async function initializeConnections<T>(
   const promises = Array.from({ length: count }, async () => {
     try {
       const connection = await createConnection(runtime);
+      const pooled = runtime.connections.find((item) => item.connection === connection);
+      if (!pooled) {
+        throw new Error('Newly created connection not found in pool');
+      }
+      if (runtime.draining) {
+        await destroyConnection(runtime, pooled);
+        return;
+      }
+
       assignConnectionToPendingAcquire(runtime, connection);
     } finally {
       runtime.creating--;
@@ -84,7 +93,9 @@ export async function destroyConnection<T>(
   runtime.options.onDestroy?.(pooled.connection);
   runtime.stats.destroyed++;
   runtime.stats.size--;
-  if (!pooled.inUse) {
+  if (pooled.inUse) {
+    runtime.stats.acquired--;
+  } else {
     runtime.stats.available--;
   }
 }

--- a/packages/core/src/resources/pool-runtime.ts
+++ b/packages/core/src/resources/pool-runtime.ts
@@ -17,8 +17,38 @@ export async function initializeConnections<T>(
   runtime: ConnectionPoolRuntime<T>,
   count: number
 ): Promise<void> {
-  const promises = Array.from({ length: count }, () => createConnection(runtime));
+  runtime.creating += count;
+  const promises = Array.from({ length: count }, async () => {
+    try {
+      const connection = await createConnection(runtime);
+      assignConnectionToPendingAcquire(runtime, connection);
+    } finally {
+      runtime.creating--;
+    }
+  });
   await Promise.all(promises);
+}
+
+function assignConnectionToPendingAcquire<T>(runtime: ConnectionPoolRuntime<T>, connection: T): void {
+  const pending = runtime.pending.shift();
+  if (!pending) {
+    return;
+  }
+
+  const pooled = runtime.connections.find((item) => item.connection === connection);
+  if (!pooled) {
+    runtime.pending.unshift(pending);
+    return;
+  }
+
+  clearTimeout(pending.timeout);
+  runtime.stats.pending--;
+  pooled.inUse = true;
+  pooled.lastUsedAt = Date.now();
+  runtime.stats.available--;
+  runtime.stats.acquired++;
+  runtime.options.onAcquire?.(connection);
+  pending.resolve(connection);
 }
 
 export async function createConnection<T>(runtime: ConnectionPoolRuntime<T>): Promise<T> {

--- a/packages/core/src/resources/pool-types.ts
+++ b/packages/core/src/resources/pool-types.ts
@@ -1,0 +1,60 @@
+export interface PoolConfig {
+  min?: number;
+  max?: number;
+  acquireTimeout?: number;
+  idleTimeout?: number;
+  evictionInterval?: number;
+}
+
+export interface HealthCheckConfig {
+  enabled?: boolean;
+  interval?: number;
+  timeout?: number;
+  retries?: number;
+}
+
+export interface ConnectionPoolOptions<T> {
+  factory: () => Promise<T>;
+  destroyer?: (connection: T) => Promise<void>;
+  validator?: (connection: T) => Promise<boolean>;
+  pool?: PoolConfig;
+  healthCheck?: HealthCheckConfig;
+  onAcquire?: (connection: T) => void;
+  onRelease?: (connection: T) => void;
+  onDestroy?: (connection: T) => void;
+  onHealthCheckFail?: (error: Error) => void;
+}
+
+export interface PoolStats {
+  size: number;
+  available: number;
+  pending: number;
+  acquired: number;
+  created: number;
+  destroyed: number;
+  healthChecksPassed: number;
+  healthChecksFailed: number;
+}
+
+export interface PooledConnection<T> {
+  connection: T;
+  createdAt: number;
+  lastUsedAt: number;
+  inUse: boolean;
+}
+
+export interface PendingAcquisition<T> {
+  resolve: (connection: T) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export interface ConnectionPoolRuntime<T> {
+  connections: PooledConnection<T>[];
+  pending: PendingAcquisition<T>[];
+  stats: PoolStats;
+  options: ConnectionPoolOptions<T>;
+  draining: boolean;
+  evictionTimer?: NodeJS.Timeout;
+  healthCheckTimer?: NodeJS.Timeout;
+}

--- a/packages/core/src/resources/pool-types.ts
+++ b/packages/core/src/resources/pool-types.ts
@@ -55,6 +55,7 @@ export interface ConnectionPoolRuntime<T> {
   stats: PoolStats;
   options: ConnectionPoolOptions<T>;
   draining: boolean;
+  creating: number;
   evictionTimer?: NodeJS.Timeout;
   healthCheckTimer?: NodeJS.Timeout;
 }

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -26,6 +26,7 @@ export class ConnectionPool<T> {
       pending: [],
       stats: createInitialPoolStats(),
       draining: false,
+      creating: 0,
       options,
     };
 

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -31,6 +31,14 @@ function toErrorPayload(error: unknown): { error: string; stack?: string } {
   return { error: String(error) };
 }
 
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
 export class ConnectionPool<T> {
   private readonly runtime: ConnectionPoolRuntime<T>;
 
@@ -64,8 +72,9 @@ export class ConnectionPool<T> {
       const interval = healthCheck.interval || 30000;
       this.runtime.healthCheckTimer = setInterval(() => {
         performHealthChecks(this.runtime).catch((error) => {
-          logger.error('Health check failed', toErrorPayload(error));
-          options.onHealthCheckFail?.(error);
+          const normalizedError = toError(error);
+          logger.error('Health check failed', toErrorPayload(normalizedError));
+          options.onHealthCheckFail?.(normalizedError);
         });
       }, interval);
     }

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -2,315 +2,78 @@
  * Connection pooling for database and HTTP clients
  */
 
-export interface PoolConfig {
-  min?: number;
-  max?: number;
-  acquireTimeout?: number;
-  idleTimeout?: number;
-  evictionInterval?: number;
-}
+import { acquireConnection, releaseConnection } from './pool-acquisition.js';
+import { evictIdleConnections } from './pool-eviction.js';
+import { performHealthChecks } from './pool-health.js';
+import { clearPool, drainPool } from './pool-lifecycle.js';
+import {
+  clonePoolStats,
+  createInitialPoolStats,
+  getHealthCheckConfig,
+  getPoolConfig,
+  initializeConnections,
+} from './pool-runtime.js';
+import type { ConnectionPoolRuntime, ConnectionPoolOptions, PoolStats } from './pool-types.js';
 
-export interface HealthCheckConfig {
-  enabled?: boolean;
-  interval?: number;
-  timeout?: number;
-  retries?: number;
-}
+export type { ConnectionPoolOptions, HealthCheckConfig, PoolConfig, PoolStats } from './pool-types.js';
 
-export interface ConnectionPoolOptions<T> {
-  factory: () => Promise<T>;
-  destroyer?: (connection: T) => Promise<void>;
-  validator?: (connection: T) => Promise<boolean>;
-  pool?: PoolConfig;
-  healthCheck?: HealthCheckConfig;
-  onAcquire?: (connection: T) => void;
-  onRelease?: (connection: T) => void;
-  onDestroy?: (connection: T) => void;
-  onHealthCheckFail?: (error: Error) => void;
-}
+export class ConnectionPool<T> implements ConnectionPoolRuntime<T> {
+  connections: ConnectionPoolRuntime<T>['connections'] = [];
+  pending: ConnectionPoolRuntime<T>['pending'] = [];
+  stats: PoolStats = createInitialPoolStats();
+  draining = false;
+  evictionTimer?: NodeJS.Timeout;
+  healthCheckTimer?: NodeJS.Timeout;
 
-export interface PoolStats {
-  size: number;
-  available: number;
-  pending: number;
-  acquired: number;
-  created: number;
-  destroyed: number;
-  healthChecksPassed: number;
-  healthChecksFailed: number;
-}
-
-interface PooledConnection<T> {
-  connection: T;
-  createdAt: number;
-  lastUsedAt: number;
-  inUse: boolean;
-}
-
-interface PendingAcquisition<T> {
-  resolve: (connection: T) => void;
-  reject: (error: Error) => void;
-  timeout: NodeJS.Timeout;
-}
-
-export class ConnectionPool<T> {
-  private connections: PooledConnection<T>[] = [];
-  private pending: PendingAcquisition<T>[] = [];
-  private stats: PoolStats = {
-    size: 0,
-    available: 0,
-    pending: 0,
-    acquired: 0,
-    created: 0,
-    destroyed: 0,
-    healthChecksPassed: 0,
-    healthChecksFailed: 0,
-  };
-  private evictionTimer?: NodeJS.Timeout;
-  private healthCheckTimer?: NodeJS.Timeout;
-  private draining = false;
-
-  constructor(private options: ConnectionPoolOptions<T>) {
-    const poolConfig = options.pool || {};
+  constructor(public options: ConnectionPoolOptions<T>) {
+    const poolConfig = getPoolConfig(this);
     const min = poolConfig.min || 0;
-
-    // Initialize minimum connections
     if (min > 0) {
-      this.initialize(min).catch((error) => {
+      initializeConnections(this, min).catch((error) => {
         console.error('Failed to initialize pool:', error);
       });
     }
 
-    // Start eviction timer
     const evictionInterval = poolConfig.evictionInterval || 60000;
     this.evictionTimer = setInterval(() => {
-      this.evictIdleConnections().catch((error) => {
+      evictIdleConnections(this).catch((error) => {
         console.error('Failed to evict idle connections:', error);
       });
     }, evictionInterval);
 
-    // Start health check timer
-    const healthCheck = options.healthCheck || {};
+    const healthCheck = getHealthCheckConfig(this);
     if (healthCheck.enabled) {
       const interval = healthCheck.interval || 30000;
       this.healthCheckTimer = setInterval(() => {
-        this.performHealthChecks().catch((error) => {
+        performHealthChecks(this).catch((error) => {
           console.error('Health check failed:', error);
-          options.onHealthCheckFail?.(error);
+          this.options.onHealthCheckFail?.(error);
         });
       }, interval);
     }
   }
 
-  private async initialize(count: number): Promise<void> {
-    const promises = Array.from({ length: count }, () => this.createConnection());
-    await Promise.all(promises);
-  }
-
-  private async createConnection(): Promise<T> {
-    const connection = await this.options.factory();
-    this.connections.push({
-      connection,
-      createdAt: Date.now(),
-      lastUsedAt: Date.now(),
-      inUse: false,
-    });
-    this.stats.created++;
-    this.stats.size++;
-    this.stats.available++;
-    return connection;
-  }
-
-  private async destroyConnection(pooled: PooledConnection<T>): Promise<void> {
-    const index = this.connections.indexOf(pooled);
-    if (index !== -1) {
-      this.connections.splice(index, 1);
-    }
-
-    if (this.options.destroyer) {
-      await this.options.destroyer(pooled.connection);
-    }
-
-    this.options.onDestroy?.(pooled.connection);
-    this.stats.destroyed++;
-    this.stats.size--;
-    if (!pooled.inUse) {
-      this.stats.available--;
-    }
-  }
-
   async acquire(): Promise<T> {
-    if (this.draining) {
-      throw new Error('Pool is draining');
-    }
-
-    // Try to find an available connection
-    const available = this.connections.find((c) => !c.inUse);
-    if (available) {
-      available.inUse = true;
-      available.lastUsedAt = Date.now();
-      this.stats.available--;
-      this.stats.acquired++;
-      this.options.onAcquire?.(available.connection);
-      return available.connection;
-    }
-
-    // Try to create a new connection if under max
-    const poolConfig = this.options.pool || {};
-    const max = poolConfig.max || 10;
-    if (this.connections.length < max) {
-      const connection = await this.createConnection();
-      const pooled = this.connections.find((c) => c.connection === connection)!;
-      pooled.inUse = true;
-      this.stats.available--;
-      this.stats.acquired++;
-      this.options.onAcquire?.(connection);
-      return connection;
-    }
-
-    // Wait for a connection to become available
-    return new Promise<T>((resolve, reject) => {
-      const timeout = poolConfig.acquireTimeout || 30000;
-      const timer = setTimeout(() => {
-        const index = this.pending.findIndex((p) => p.resolve === resolve);
-        if (index !== -1) {
-          this.pending.splice(index, 1);
-          this.stats.pending--;
-        }
-        reject(new Error('Acquire timeout'));
-      }, timeout);
-
-      this.pending.push({ resolve, reject, timeout: timer });
-      this.stats.pending++;
-    });
+    return acquireConnection(this);
   }
 
   async release(connection: T): Promise<void> {
-    const pooled = this.connections.find((c) => c.connection === connection);
-    if (!pooled) {
-      throw new Error('Connection not found in pool');
-    }
-
-    if (!pooled.inUse) {
-      throw new Error('Connection is not in use');
-    }
-
-    pooled.inUse = false;
-    pooled.lastUsedAt = Date.now();
-    this.stats.available++;
-    this.stats.acquired--;
-    this.options.onRelease?.(connection);
-
-    // Fulfill pending acquisition if any
-    const pending = this.pending.shift();
-    if (pending) {
-      clearTimeout(pending.timeout);
-      this.stats.pending--;
-      pooled.inUse = true;
-      this.stats.available--;
-      this.stats.acquired++;
-      this.options.onAcquire?.(connection);
-      pending.resolve(connection);
-    }
-  }
-
-  private async evictIdleConnections(): Promise<void> {
-    const poolConfig = this.options.pool || {};
-    const idleTimeout = poolConfig.idleTimeout || 60000;
-    const min = poolConfig.min || 0;
-    const now = Date.now();
-
-    const toEvict = this.connections.filter(
-      (c) => !c.inUse && now - c.lastUsedAt > idleTimeout && this.connections.length > min
-    );
-
-    for (const pooled of toEvict) {
-      await this.destroyConnection(pooled);
-    }
-  }
-
-  private async performHealthChecks(): Promise<void> {
-    if (!this.options.validator) {
-      return;
-    }
-
-    const healthCheck = this.options.healthCheck || {};
-    const timeout = healthCheck.timeout || 5000;
-    const retries = healthCheck.retries || 1;
-
-    for (const pooled of this.connections) {
-      if (pooled.inUse) {
-        continue;
-      }
-
-      let healthy = false;
-      for (let i = 0; i < retries; i++) {
-        try {
-          const result = await Promise.race([
-            this.options.validator(pooled.connection),
-            new Promise<boolean>((_, reject) =>
-              setTimeout(() => reject(new Error('Health check timeout')), timeout)
-            ),
-          ]);
-          if (result) {
-            healthy = true;
-            break;
-          }
-        } catch (error) {
-          // Continue to next retry
-        }
-      }
-
-      if (healthy) {
-        this.stats.healthChecksPassed++;
-      } else {
-        this.stats.healthChecksFailed++;
-        await this.destroyConnection(pooled);
-      }
-    }
+    return releaseConnection(this, connection);
   }
 
   async drain(): Promise<void> {
-    this.draining = true;
-
-    // Reject all pending acquisitions
-    for (const pending of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error('Pool is draining'));
-    }
-    this.pending = [];
-    this.stats.pending = 0;
-
-    // Wait for all connections to be released
-    while (this.connections.some((c) => c.inUse)) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
+    return drainPool(this);
   }
 
   async clear(): Promise<void> {
-    // Stop timers
-    if (this.evictionTimer) {
-      clearInterval(this.evictionTimer);
-      this.evictionTimer = undefined;
-    }
-    if (this.healthCheckTimer) {
-      clearInterval(this.healthCheckTimer);
-      this.healthCheckTimer = undefined;
-    }
-
-    // Destroy all connections
-    const connections = [...this.connections];
-    for (const pooled of connections) {
-      await this.destroyConnection(pooled);
-    }
+    return clearPool(this);
   }
 
   getStats(): PoolStats {
-    return { ...this.stats };
+    return clonePoolStats(this);
   }
 }
 
 export function createConnectionPool<T>(options: ConnectionPoolOptions<T>): ConnectionPool<T> {
   return new ConnectionPool(options);
 }
-

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -20,7 +20,7 @@ export type { ConnectionPoolOptions, HealthCheckConfig, PoolConfig, PoolStats } 
 export class ConnectionPool<T> {
   private readonly runtime: ConnectionPoolRuntime<T>;
 
-  constructor(private readonly options: ConnectionPoolOptions<T>) {
+  constructor(options: ConnectionPoolOptions<T>) {
     this.runtime = {
       connections: [],
       pending: [],

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -17,60 +17,63 @@ import type { ConnectionPoolRuntime, ConnectionPoolOptions, PoolStats } from './
 
 export type { ConnectionPoolOptions, HealthCheckConfig, PoolConfig, PoolStats } from './pool-types.js';
 
-export class ConnectionPool<T> implements ConnectionPoolRuntime<T> {
-  connections: ConnectionPoolRuntime<T>['connections'] = [];
-  pending: ConnectionPoolRuntime<T>['pending'] = [];
-  stats: PoolStats = createInitialPoolStats();
-  draining = false;
-  evictionTimer?: NodeJS.Timeout;
-  healthCheckTimer?: NodeJS.Timeout;
+export class ConnectionPool<T> {
+  private readonly runtime: ConnectionPoolRuntime<T>;
 
-  constructor(public options: ConnectionPoolOptions<T>) {
-    const poolConfig = getPoolConfig(this);
+  constructor(private readonly options: ConnectionPoolOptions<T>) {
+    this.runtime = {
+      connections: [],
+      pending: [],
+      stats: createInitialPoolStats(),
+      draining: false,
+      options,
+    };
+
+    const poolConfig = getPoolConfig(this.runtime);
     const min = poolConfig.min || 0;
     if (min > 0) {
-      initializeConnections(this, min).catch((error) => {
+      initializeConnections(this.runtime, min).catch((error) => {
         console.error('Failed to initialize pool:', error);
       });
     }
 
     const evictionInterval = poolConfig.evictionInterval || 60000;
-    this.evictionTimer = setInterval(() => {
-      evictIdleConnections(this).catch((error) => {
+    this.runtime.evictionTimer = setInterval(() => {
+      evictIdleConnections(this.runtime).catch((error) => {
         console.error('Failed to evict idle connections:', error);
       });
     }, evictionInterval);
 
-    const healthCheck = getHealthCheckConfig(this);
+    const healthCheck = getHealthCheckConfig(this.runtime);
     if (healthCheck.enabled) {
       const interval = healthCheck.interval || 30000;
-      this.healthCheckTimer = setInterval(() => {
-        performHealthChecks(this).catch((error) => {
+      this.runtime.healthCheckTimer = setInterval(() => {
+        performHealthChecks(this.runtime).catch((error) => {
           console.error('Health check failed:', error);
-          this.options.onHealthCheckFail?.(error);
+          options.onHealthCheckFail?.(error);
         });
       }, interval);
     }
   }
 
   async acquire(): Promise<T> {
-    return acquireConnection(this);
+    return acquireConnection(this.runtime);
   }
 
   async release(connection: T): Promise<void> {
-    return releaseConnection(this, connection);
+    return releaseConnection(this.runtime, connection);
   }
 
   async drain(): Promise<void> {
-    return drainPool(this);
+    return drainPool(this.runtime);
   }
 
   async clear(): Promise<void> {
-    return clearPool(this);
+    return clearPool(this.runtime);
   }
 
   getStats(): PoolStats {
-    return clonePoolStats(this);
+    return clonePoolStats(this.runtime);
   }
 }
 

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -2,6 +2,7 @@
  * Connection pooling for database and HTTP clients
  */
 
+import { createLogger } from '../langgraph/observability/logger.js';
 import { acquireConnection, releaseConnection } from './pool-acquisition.js';
 import { evictIdleConnections } from './pool-eviction.js';
 import { performHealthChecks } from './pool-health.js';
@@ -16,6 +17,12 @@ import {
 import type { ConnectionPoolRuntime, ConnectionPoolOptions, PoolStats } from './pool-types.js';
 
 export type { ConnectionPoolOptions, HealthCheckConfig, PoolConfig, PoolStats } from './pool-types.js';
+
+const logger = createLogger('agentforge:core:resources:pool');
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export class ConnectionPool<T> {
   private readonly runtime: ConnectionPoolRuntime<T>;
@@ -34,14 +41,14 @@ export class ConnectionPool<T> {
     const min = poolConfig.min || 0;
     if (min > 0) {
       initializeConnections(this.runtime, min).catch((error) => {
-        console.error('Failed to initialize pool:', error);
+        logger.error('Failed to initialize pool', { error: toErrorMessage(error) });
       });
     }
 
     const evictionInterval = poolConfig.evictionInterval || 60000;
     this.runtime.evictionTimer = setInterval(() => {
       evictIdleConnections(this.runtime).catch((error) => {
-        console.error('Failed to evict idle connections:', error);
+        logger.error('Failed to evict idle connections', { error: toErrorMessage(error) });
       });
     }, evictionInterval);
 
@@ -50,7 +57,7 @@ export class ConnectionPool<T> {
       const interval = healthCheck.interval || 30000;
       this.runtime.healthCheckTimer = setInterval(() => {
         performHealthChecks(this.runtime).catch((error) => {
-          console.error('Health check failed:', error);
+          logger.error('Health check failed', { error: toErrorMessage(error) });
           options.onHealthCheckFail?.(error);
         });
       }, interval);

--- a/packages/core/src/resources/pool.ts
+++ b/packages/core/src/resources/pool.ts
@@ -20,8 +20,15 @@ export type { ConnectionPoolOptions, HealthCheckConfig, PoolConfig, PoolStats } 
 
 const logger = createLogger('agentforge:core:resources:pool');
 
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function toErrorPayload(error: unknown): { error: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      error: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return { error: String(error) };
 }
 
 export class ConnectionPool<T> {
@@ -41,14 +48,14 @@ export class ConnectionPool<T> {
     const min = poolConfig.min || 0;
     if (min > 0) {
       initializeConnections(this.runtime, min).catch((error) => {
-        logger.error('Failed to initialize pool', { error: toErrorMessage(error) });
+        logger.error('Failed to initialize pool', toErrorPayload(error));
       });
     }
 
     const evictionInterval = poolConfig.evictionInterval || 60000;
     this.runtime.evictionTimer = setInterval(() => {
       evictIdleConnections(this.runtime).catch((error) => {
-        logger.error('Failed to evict idle connections', { error: toErrorMessage(error) });
+        logger.error('Failed to evict idle connections', toErrorPayload(error));
       });
     }, evictionInterval);
 
@@ -57,7 +64,7 @@ export class ConnectionPool<T> {
       const interval = healthCheck.interval || 30000;
       this.runtime.healthCheckTimer = setInterval(() => {
         performHealthChecks(this.runtime).catch((error) => {
-          logger.error('Health check failed', { error: toErrorMessage(error) });
+          logger.error('Health check failed', toErrorPayload(error));
           options.onHealthCheckFail?.(error);
         });
       }, interval);

--- a/packages/core/tests/resources/pool.test.ts
+++ b/packages/core/tests/resources/pool.test.ts
@@ -1,0 +1,3 @@
+import './pool/acquisition.js';
+import './pool/eviction.js';
+import './pool/lifecycle.js';

--- a/packages/core/tests/resources/pool/acquisition.ts
+++ b/packages/core/tests/resources/pool/acquisition.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createMockPool } from './shared.js';
+
+describe('ConnectionPool acquisition flow', () => {
+  it('reuses released connections for pending acquires and keeps stats in sync', async () => {
+    const { pool } = await createMockPool({
+      pool: { max: 1, acquireTimeout: 100 },
+    });
+
+    const first = await pool.acquire();
+    const secondPromise = pool.acquire();
+    await Promise.resolve();
+
+    expect(pool.getStats()).toMatchObject({
+      size: 1,
+      available: 0,
+      pending: 1,
+      acquired: 1,
+    });
+
+    await pool.release(first);
+    const second = await secondPromise;
+
+    expect(second).toBe(first);
+    expect(pool.getStats()).toMatchObject({
+      size: 1,
+      available: 0,
+      pending: 0,
+      acquired: 1,
+    });
+
+    await pool.release(second);
+    await pool.clear();
+  });
+});

--- a/packages/core/tests/resources/pool/acquisition.ts
+++ b/packages/core/tests/resources/pool/acquisition.ts
@@ -1,3 +1,4 @@
+import { createConnectionPool } from '../../../src/resources/index.js';
 import { describe, expect, it } from 'vitest';
 import { createMockPool } from './shared.js';
 
@@ -7,29 +8,74 @@ describe('ConnectionPool acquisition flow', () => {
       pool: { max: 1, acquireTimeout: 100 },
     });
 
-    const first = await pool.acquire();
-    const secondPromise = pool.acquire();
-    await Promise.resolve();
+    try {
+      const first = await pool.acquire();
+      const secondPromise = pool.acquire();
+      await Promise.resolve();
 
-    expect(pool.getStats()).toMatchObject({
-      size: 1,
-      available: 0,
-      pending: 1,
-      acquired: 1,
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 0,
+        pending: 1,
+        acquired: 1,
+      });
+
+      await pool.release(first);
+      const second = await secondPromise;
+
+      expect(second).toBe(first);
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 0,
+        pending: 0,
+        acquired: 1,
+      });
+
+      await pool.release(second);
+    } finally {
+      await pool.clear();
+    }
+  });
+
+  it('does not exceed max when concurrent acquires race while creating a connection', async () => {
+    let resolveFactory: ((connection: { id: number }) => void) | undefined;
+    const created: Array<{ id: number }> = [];
+    let nextId = 1;
+    const pool = createConnectionPool({
+      factory: async () =>
+        new Promise<{ id: number }>((resolve) => {
+          resolveFactory = (connection) => {
+            created.push(connection);
+            resolve(connection);
+          };
+        }),
+      pool: { max: 1, acquireTimeout: 100 },
     });
 
-    await pool.release(first);
-    const second = await secondPromise;
+    try {
+      const firstPromise = pool.acquire();
+      const secondPromise = pool.acquire();
+      await Promise.resolve();
 
-    expect(second).toBe(first);
-    expect(pool.getStats()).toMatchObject({
-      size: 1,
-      available: 0,
-      pending: 0,
-      acquired: 1,
-    });
+      expect(resolveFactory).toBeDefined();
+      resolveFactory!({ id: nextId++ });
 
-    await pool.release(second);
-    await pool.clear();
+      const first = await firstPromise;
+      await Promise.resolve();
+
+      expect(created).toHaveLength(1);
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 0,
+        pending: 1,
+        acquired: 1,
+      });
+
+      await pool.release(first);
+      const second = await secondPromise;
+      expect(second).toBe(first);
+    } finally {
+      await pool.clear();
+    }
   });
 });

--- a/packages/core/tests/resources/pool/acquisition.ts
+++ b/packages/core/tests/resources/pool/acquisition.ts
@@ -78,4 +78,50 @@ describe('ConnectionPool acquisition flow', () => {
       await pool.clear();
     }
   });
+
+  it('does not exceed max while min-size initialization is still creating connections', async () => {
+    let releaseInitialConnection: (() => void) | undefined;
+    let createdCount = 0;
+    let nextId = 1;
+
+    const pool = createConnectionPool({
+      factory: async () => {
+        createdCount++;
+        const connection = { id: nextId++ };
+        if (createdCount === 1) {
+          await new Promise<void>((resolve) => {
+            releaseInitialConnection = resolve;
+          });
+        }
+        return connection;
+      },
+      pool: { min: 1, max: 1, acquireTimeout: 50 },
+    });
+
+    try {
+      await Promise.resolve();
+      const pendingAcquire = pool.acquire();
+      await Promise.resolve();
+
+      expect(pool.getStats()).toMatchObject({
+        size: 0,
+        pending: 1,
+        acquired: 0,
+      });
+      expect(createdCount).toBe(1);
+
+      releaseInitialConnection?.();
+      const acquired = await pendingAcquire;
+
+      expect(acquired.id).toBe(1);
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        pending: 0,
+        acquired: 1,
+      });
+    } finally {
+      releaseInitialConnection?.();
+      await pool.clear();
+    }
+  });
 });

--- a/packages/core/tests/resources/pool/acquisition.ts
+++ b/packages/core/tests/resources/pool/acquisition.ts
@@ -124,4 +124,40 @@ describe('ConnectionPool acquisition flow', () => {
       await pool.clear();
     }
   });
+
+  it('rejects an acquire whose connection finishes creating after the pool starts clearing', async () => {
+    let resolveFactory: ((connection: { id: number }) => void) | undefined;
+    const destroyed: Array<{ id: number }> = [];
+    const pool = createConnectionPool({
+      factory: async () =>
+        new Promise<{ id: number }>((resolve) => {
+          resolveFactory = resolve;
+        }),
+      destroyer: async (connection) => {
+        destroyed.push(connection);
+      },
+      pool: { max: 1, acquireTimeout: 100 },
+    });
+
+    try {
+      const pendingAcquire = pool.acquire();
+      await Promise.resolve();
+
+      const clearPromise = pool.clear();
+      resolveFactory?.({ id: 1 });
+
+      await expect(pendingAcquire).rejects.toThrow('Pool is draining');
+      await clearPromise;
+
+      expect(destroyed).toEqual([{ id: 1 }]);
+      expect(pool.getStats()).toMatchObject({
+        size: 0,
+        available: 0,
+        acquired: 0,
+        destroyed: 1,
+      });
+    } finally {
+      await pool.clear();
+    }
+  });
 });

--- a/packages/core/tests/resources/pool/eviction.ts
+++ b/packages/core/tests/resources/pool/eviction.ts
@@ -47,6 +47,8 @@ describe('ConnectionPool eviction flow', () => {
     const destroyed: Array<{ id: number }> = [];
     let nextId = 1;
 
+    vi.useFakeTimers();
+
     const pool = createConnectionPool({
       factory: async () => ({ id: nextId++ }),
       destroyer: async (connection: { id: number }) => {
@@ -64,8 +66,6 @@ describe('ConnectionPool eviction flow', () => {
         evictionInterval: 10,
       },
     });
-
-    vi.useFakeTimers();
 
     try {
       const first = await pool.acquire();

--- a/packages/core/tests/resources/pool/eviction.ts
+++ b/packages/core/tests/resources/pool/eviction.ts
@@ -63,7 +63,7 @@ describe('ConnectionPool eviction flow', () => {
         min: 1,
         max: 3,
         idleTimeout: 10,
-        evictionInterval: 10,
+        evictionInterval: 1_000,
       },
     });
 

--- a/packages/core/tests/resources/pool/eviction.ts
+++ b/packages/core/tests/resources/pool/eviction.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockPool } from './shared.js';
+
+describe('ConnectionPool eviction flow', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retains the configured minimum number of idle connections during eviction', async () => {
+    vi.useFakeTimers();
+
+    const { pool, destroyed } = await createMockPool({
+      pool: {
+        min: 1,
+        max: 3,
+        idleTimeout: 10,
+        evictionInterval: 10,
+      },
+    });
+
+    const first = await pool.acquire();
+    const second = await pool.acquire();
+    const third = await pool.acquire();
+
+    await pool.release(first);
+    await pool.release(second);
+    await pool.release(third);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(pool.getStats()).toMatchObject({
+      size: 1,
+      available: 1,
+      acquired: 0,
+    });
+    expect(destroyed).toHaveLength(2);
+
+    await pool.clear();
+  });
+});

--- a/packages/core/tests/resources/pool/eviction.ts
+++ b/packages/core/tests/resources/pool/eviction.ts
@@ -18,23 +18,25 @@ describe('ConnectionPool eviction flow', () => {
       },
     });
 
-    const first = await pool.acquire();
-    const second = await pool.acquire();
-    const third = await pool.acquire();
+    try {
+      const first = await pool.acquire();
+      const second = await pool.acquire();
+      const third = await pool.acquire();
 
-    await pool.release(first);
-    await pool.release(second);
-    await pool.release(third);
+      await pool.release(first);
+      await pool.release(second);
+      await pool.release(third);
 
-    await vi.advanceTimersByTimeAsync(25);
+      await vi.advanceTimersByTimeAsync(25);
 
-    expect(pool.getStats()).toMatchObject({
-      size: 1,
-      available: 1,
-      acquired: 0,
-    });
-    expect(destroyed).toHaveLength(2);
-
-    await pool.clear();
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 1,
+        acquired: 0,
+      });
+      expect(destroyed).toHaveLength(2);
+    } finally {
+      await pool.clear();
+    }
   });
 });

--- a/packages/core/tests/resources/pool/eviction.ts
+++ b/packages/core/tests/resources/pool/eviction.ts
@@ -1,3 +1,5 @@
+import { evictIdleConnections } from '../../../src/resources/pool-eviction.js';
+import { createConnectionPool } from '../../../src/resources/index.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockPool } from './shared.js';
 
@@ -36,6 +38,67 @@ describe('ConnectionPool eviction flow', () => {
       });
       expect(destroyed).toHaveLength(2);
     } finally {
+      await pool.clear();
+    }
+  });
+
+  it('does not evict a connection that becomes in use while eviction is in flight', async () => {
+    let releaseDestroyer: (() => void) | undefined;
+    const destroyed: Array<{ id: number }> = [];
+    let nextId = 1;
+
+    const pool = createConnectionPool({
+      factory: async () => ({ id: nextId++ }),
+      destroyer: async (connection: { id: number }) => {
+        destroyed.push(connection);
+        if (destroyed.length === 1) {
+          await new Promise<void>((resolve) => {
+            releaseDestroyer = resolve;
+          });
+        }
+      },
+      pool: {
+        min: 1,
+        max: 3,
+        idleTimeout: 10,
+        evictionInterval: 10,
+      },
+    });
+
+    vi.useFakeTimers();
+
+    try {
+      const first = await pool.acquire();
+      const second = await pool.acquire();
+      const third = await pool.acquire();
+
+      await pool.release(first);
+      await pool.release(second);
+      await pool.release(third);
+
+      vi.advanceTimersByTime(11);
+      const evictionTick = evictIdleConnections(
+        (pool as unknown as { runtime: Parameters<typeof evictIdleConnections<{ id: number }>>[0] }).runtime
+      );
+      await Promise.resolve();
+
+      const reacquired = await pool.acquire();
+      expect(reacquired.id).toBe(2);
+
+      releaseDestroyer?.();
+      await evictionTick;
+
+      expect(pool.getStats()).toMatchObject({
+        size: 2,
+        available: 1,
+        acquired: 1,
+      });
+      expect(destroyed).toHaveLength(1);
+      expect(destroyed[0]?.id).toBe(1);
+
+      await pool.release(reacquired);
+    } finally {
+      releaseDestroyer?.();
       await pool.clear();
     }
   });

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -179,4 +179,33 @@ describe('ConnectionPool lifecycle flow', () => {
       await pool.clear();
     }
   });
+
+  it('normalizes health-check failures before invoking onHealthCheckFail', async () => {
+    vi.useFakeTimers();
+
+    let receivedError: Error | undefined;
+    const pool = createConnectionPool({
+      factory: async () => ({ id: 1 }),
+      destroyer: async () => {
+        throw 'health-check exploded';
+      },
+      validator: async () => false,
+      pool: { max: 1 },
+      healthCheck: { enabled: true, interval: 1 },
+      onHealthCheckFail: (error) => {
+        receivedError = error;
+      },
+    });
+
+    try {
+      const connection = await pool.acquire();
+      await pool.release(connection);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(receivedError).toBeInstanceOf(Error);
+      expect(receivedError?.message).toBe('health-check exploded');
+    } finally {
+      await pool.clear();
+    }
+  });
 });

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockPool } from './shared.js';
+
+describe('ConnectionPool lifecycle flow', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects pending and future acquires once draining starts', async () => {
+    const { pool } = await createMockPool({
+      pool: { max: 1, acquireTimeout: 100 },
+    });
+
+    const first = await pool.acquire();
+    const pendingAcquire = pool.acquire();
+    await Promise.resolve();
+
+    const drainPromise = pool.drain();
+
+    await expect(pendingAcquire).rejects.toThrow('Pool is draining');
+
+    await pool.release(first);
+    await drainPromise;
+
+    await expect(pool.acquire()).rejects.toThrow('Pool is draining');
+
+    await pool.clear();
+  });
+});

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -28,4 +28,24 @@ describe('ConnectionPool lifecycle flow', () => {
       await pool.clear();
     }
   });
+
+  it('rejects pending acquires immediately when the pool is cleared', async () => {
+    const { pool } = await createMockPool({
+      pool: { max: 1, acquireTimeout: 100 },
+    });
+
+    try {
+      const first = await pool.acquire();
+      const pendingAcquire = pool.acquire();
+      await Promise.resolve();
+
+      await pool.clear();
+      await expect(pendingAcquire).rejects.toThrow('Pool is draining');
+
+      await expect(pool.acquire()).rejects.toThrow('Pool is draining');
+      await expect(pool.release(first)).rejects.toThrow('Connection not found in pool');
+    } finally {
+      await pool.clear();
+    }
+  });
 });

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -1,3 +1,4 @@
+import { createConnectionPool } from '../../../src/resources/index.js';
 import { performHealthChecks } from '../../../src/resources/pool-health.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockPool } from './shared.js';
@@ -45,6 +46,81 @@ describe('ConnectionPool lifecycle flow', () => {
 
       await expect(pool.acquire()).rejects.toThrow('Pool is draining');
       await expect(pool.release(first)).rejects.toThrow('Connection not found in pool');
+    } finally {
+      await pool.clear();
+    }
+  });
+
+  it('destroys late min-size connections that finish creating after clear starts', async () => {
+    let releaseInitialConnection: (() => void) | undefined;
+    const destroyed: Array<{ id: number }> = [];
+    const pool = createConnectionPool({
+      factory: async () => {
+        const connection = { id: 1 };
+        await new Promise<void>((resolve) => {
+          releaseInitialConnection = resolve;
+        });
+        return connection;
+      },
+      destroyer: async (connection) => {
+        destroyed.push(connection);
+      },
+      pool: { min: 1, max: 1 },
+    });
+
+    try {
+      const runtime = (pool as unknown as {
+        runtime: {
+          creating: number;
+        };
+      }).runtime;
+
+      await Promise.resolve();
+
+      const clearPromise = pool.clear();
+      releaseInitialConnection?.();
+      await clearPromise;
+
+      for (let attempt = 0; attempt < 10 && runtime.creating > 0; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      expect(destroyed).toEqual([{ id: 1 }]);
+      expect(pool.getStats()).toMatchObject({
+        size: 0,
+        available: 0,
+        acquired: 0,
+        destroyed: 1,
+      });
+    } finally {
+      releaseInitialConnection?.();
+      await pool.clear();
+    }
+  });
+
+  it('resets acquired stats when clearing an in-use connection', async () => {
+    const { pool, destroyed } = await createMockPool({
+      pool: { max: 1, acquireTimeout: 100 },
+    });
+
+    try {
+      const connection = await pool.acquire();
+
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 0,
+        acquired: 1,
+      });
+
+      await pool.clear();
+
+      expect(destroyed).toEqual([connection]);
+      expect(pool.getStats()).toMatchObject({
+        size: 0,
+        available: 0,
+        acquired: 0,
+        destroyed: 1,
+      });
     } finally {
       await pool.clear();
     }

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -11,19 +11,21 @@ describe('ConnectionPool lifecycle flow', () => {
       pool: { max: 1, acquireTimeout: 100 },
     });
 
-    const first = await pool.acquire();
-    const pendingAcquire = pool.acquire();
-    await Promise.resolve();
+    try {
+      const first = await pool.acquire();
+      const pendingAcquire = pool.acquire();
+      await Promise.resolve();
 
-    const drainPromise = pool.drain();
+      const drainPromise = pool.drain();
 
-    await expect(pendingAcquire).rejects.toThrow('Pool is draining');
+      await expect(pendingAcquire).rejects.toThrow('Pool is draining');
 
-    await pool.release(first);
-    await drainPromise;
+      await pool.release(first);
+      await drainPromise;
 
-    await expect(pool.acquire()).rejects.toThrow('Pool is draining');
-
-    await pool.clear();
+      await expect(pool.acquire()).rejects.toThrow('Pool is draining');
+    } finally {
+      await pool.clear();
+    }
   });
 });

--- a/packages/core/tests/resources/pool/lifecycle.ts
+++ b/packages/core/tests/resources/pool/lifecycle.ts
@@ -1,3 +1,4 @@
+import { performHealthChecks } from '../../../src/resources/pool-health.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockPool } from './shared.js';
 
@@ -45,6 +46,60 @@ describe('ConnectionPool lifecycle flow', () => {
       await expect(pool.acquire()).rejects.toThrow('Pool is draining');
       await expect(pool.release(first)).rejects.toThrow('Connection not found in pool');
     } finally {
+      await pool.clear();
+    }
+  });
+
+  it('does not destroy a connection that becomes in use during a failing health check', async () => {
+    let resumeValidator: (() => void) | undefined;
+    const { pool, destroyed } = await createMockPool({
+      pool: { min: 1, max: 1 },
+      validator: async () => {
+        await new Promise<void>((resolve) => {
+          resumeValidator = resolve;
+        });
+        return false;
+      },
+    });
+
+    try {
+      const runtime = (pool as unknown as {
+        runtime: {
+          connections: Array<{
+            connection: { id: number };
+            inUse: boolean;
+          }>;
+          stats: {
+            available: number;
+            acquired: number;
+          };
+        };
+      }).runtime;
+      const pooled = runtime.connections[0];
+      if (!pooled) {
+        throw new Error('Expected initialized pooled connection');
+      }
+
+      const healthCheckPromise = performHealthChecks(
+        (pool as unknown as { runtime: Parameters<typeof performHealthChecks<{ id: number }>>[0] }).runtime
+      );
+      await Promise.resolve();
+
+      pooled.inUse = true;
+      runtime.stats.available--;
+      runtime.stats.acquired++;
+      resumeValidator?.();
+
+      await healthCheckPromise;
+
+      expect(destroyed).toHaveLength(0);
+      expect(pool.getStats()).toMatchObject({
+        size: 1,
+        available: 0,
+        acquired: 1,
+      });
+    } finally {
+      resumeValidator?.();
       await pool.clear();
     }
   });

--- a/packages/core/tests/resources/pool/shared.ts
+++ b/packages/core/tests/resources/pool/shared.ts
@@ -21,6 +21,8 @@ async function waitForMinimumConnections(
 
     await Promise.resolve();
   }
+
+  throw new Error(`Pool failed to initialize the configured minimum size of ${min}`);
 }
 
 export async function createMockPool(options: {

--- a/packages/core/tests/resources/pool/shared.ts
+++ b/packages/core/tests/resources/pool/shared.ts
@@ -10,6 +10,19 @@ export interface MockPoolContext {
   destroyed: MockConnection[];
 }
 
+async function waitForMinimumConnections(
+  pool: ConnectionPool<MockConnection>,
+  min: number
+): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (pool.getStats().size >= min) {
+      return;
+    }
+
+    await Promise.resolve();
+  }
+}
+
 export async function createMockPool(options: {
   pool?: PoolConfig;
   healthCheck?: HealthCheckConfig;
@@ -33,8 +46,10 @@ export async function createMockPool(options: {
     healthCheck: options.healthCheck,
   });
 
-  await Promise.resolve();
-  await Promise.resolve();
+  const min = options.pool?.min || 0;
+  if (min > 0) {
+    await waitForMinimumConnections(pool, min);
+  }
 
   return { pool, created, destroyed };
 }

--- a/packages/core/tests/resources/pool/shared.ts
+++ b/packages/core/tests/resources/pool/shared.ts
@@ -1,0 +1,40 @@
+import { createConnectionPool, type ConnectionPool, type HealthCheckConfig, type PoolConfig } from '../../../src/resources/index.js';
+
+export interface MockConnection {
+  id: number;
+}
+
+export interface MockPoolContext {
+  pool: ConnectionPool<MockConnection>;
+  created: MockConnection[];
+  destroyed: MockConnection[];
+}
+
+export async function createMockPool(options: {
+  pool?: PoolConfig;
+  healthCheck?: HealthCheckConfig;
+  validator?: (connection: MockConnection) => Promise<boolean>;
+} = {}): Promise<MockPoolContext> {
+  let nextId = 1;
+  const created: MockConnection[] = [];
+  const destroyed: MockConnection[] = [];
+
+  const pool = createConnectionPool<MockConnection>({
+    factory: async () => {
+      const connection = { id: nextId++ };
+      created.push(connection);
+      return connection;
+    },
+    destroyer: async (connection) => {
+      destroyed.push(connection);
+    },
+    validator: options.validator,
+    pool: options.pool,
+    healthCheck: options.healthCheck,
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  return { pool, created, destroyed };
+}

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2829,15 +2829,15 @@ Implementation notes:
   - `1` file failed, `1` test failed, `2` tests passed
   - Failure: idle eviction dropped pool stats below configured `min` (`size 0`, `available 0`) instead of retaining one idle connection
 - Runtime file-size result:
-  - `packages/core/src/resources/pool.ts`: `316 -> 90` lines
-  - extracted modules: `61`, `102`, `89`, `43`, `64`, and `40` lines
+  - `packages/core/src/resources/pool.ts`: `316 -> 97` lines
+  - extracted modules: `61`, `113`, `93`, `43`, `64`, and `40` lines
 - Test modularization result:
   - `packages/core/tests/resources/pool.test.ts`: `3` line entrypoint
   - shared fixture: `57` lines
-  - focused suites: `127`, `105`, and `106` lines
+  - focused suites: `163`, `105`, and `182` lines
 - Focused validation after production split:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
-  - `3` files passed, `9` tests passed
+  - `3` files passed, `17` tests passed
 - Compatibility validation:
   - `pnpm --filter @agentforge/core typecheck`
 - Explicit-`any` baseline check:

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2812,8 +2812,8 @@ Implementation notes:
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
 - [x] Run full test suite before finalizing the PR and record results
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+- [x] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 Implementation notes:
@@ -2852,6 +2852,11 @@ Implementation notes:
 - Lint:
   - `pnpm lint`
   - exit `0`; warnings only (`0` errors)
+- Commits and pushes:
+  - `60da5b93` `refactor(st-09066): modularize resource pool runtime`
+  - `5d835972` `docs(st-09066): move resource pool story to in-review`
+- Ready for review:
+  - PR #135 body refreshed from `.tmp/pr-st09066.md` and draft status cleared with `gh pr ready 135`
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2799,19 +2799,19 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `refactor/st-09066-resource-pool-modularization`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
 - [x] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove pool behavior remains stable while the oversized runtime and test files are split
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Reduce `packages/core/src/resources/pool.ts` below the 300 line planning cutoff by extracting focused internal modules for acquisition/release flow, eviction/reaping behavior, metrics/introspection helpers, and shared pool types behind a stable facade
-- [ ] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
-- [ ] Split pool coverage into focused test modules so acquisition, eviction, and lifecycle behavior no longer depends on a single oversized test surface
-- [ ] Preserve existing pool behavior, lifecycle semantics, and public imports
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched pool modules in story docs
-- [ ] Add or update story documentation at `docs/st09066-resource-pool-modularization.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+- [x] Reduce `packages/core/src/resources/pool.ts` below the 300 line planning cutoff by extracting focused internal modules for acquisition/release flow, eviction/reaping behavior, metrics/introspection helpers, and shared pool types behind a stable facade
+- [x] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
+- [x] Split pool coverage into focused test modules so acquisition, eviction, and lifecycle behavior no longer depends on a single oversized test surface
+- [x] Preserve existing pool behavior, lifecycle semantics, and public imports
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+- [x] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched pool modules in story docs
+- [x] Add or update story documentation at `docs/st09066-resource-pool-modularization.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Run full test suite before finalizing the PR and record results
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
@@ -2819,9 +2819,39 @@ Implementation notes:
 Implementation notes:
 
 - Branch created from `main`: `refactor/st-09066-resource-pool-modularization`
+- PR:
+  - PR #135: https://github.com/TVScoundrel/agentforge/pull/135
 - Test-first strategy:
   - `packages/core/src/resources/pool.ts` is the only oversized runtime file, but the current resource-pool assertions are split indirectly across `database-pool.test.ts` and `http-pool.test.ts` rather than a single shared `ConnectionPool` test seam.
   - Practical test-first substitute: introduce a stable `packages/core/tests/resources/pool.test.ts` entrypoint that exercises the shared `ConnectionPool` API directly, add failing acquisition/eviction/lifecycle coverage there first, and then modularize both the new pool test entrypoint and `pool.ts` behind the same public resource exports.
+- First focused failing run before production split:
+  - `pnpm test --run packages/core/tests/resources/pool.test.ts`
+  - `1` file failed, `1` test failed, `2` tests passed
+  - Failure: idle eviction dropped pool stats below configured `min` (`size 0`, `available 0`) instead of retaining one idle connection
+- Runtime file-size result:
+  - `packages/core/src/resources/pool.ts`: `316 -> 79` lines
+  - extracted modules: `60`, `72`, `84`, `27`, `44`, and `34` lines
+- Test modularization result:
+  - `packages/core/tests/resources/pool.test.ts`: `3` line entrypoint
+  - focused suites: `35`, `40`, and `29` lines
+- Focused validation after production split:
+  - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
+  - `3` files passed, `9` tests passed
+- Compatibility validation:
+  - `pnpm --filter @agentforge/core typecheck`
+- Explicit-`any` baseline check:
+  - `pnpm lint:explicit-any:baseline`
+  - `84/289` warnings overall; `23/119` in `core`
+- CI impact:
+  - No CI change required; the story keeps the existing public resource exports and validation commands intact.
+- Residual test impact:
+  - No additional automated coverage was needed beyond the new direct `pool.test.ts` suites and the existing database/http wrapper tests because acquisition, eviction, and lifecycle behavior are now exercised against the shared `ConnectionPool` seam directly while wrapper compatibility remains covered by the focused resource tests.
+- Full test suite:
+  - `pnpm test --run`
+  - `211 passed | 18 skipped` files; `2314 passed | 286 skipped` tests
+- Lint:
+  - `pnpm lint`
+  - exit `0`; warnings only (`0` errors)
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2829,11 +2829,12 @@ Implementation notes:
   - `1` file failed, `1` test failed, `2` tests passed
   - Failure: idle eviction dropped pool stats below configured `min` (`size 0`, `available 0`) instead of retaining one idle connection
 - Runtime file-size result:
-  - `packages/core/src/resources/pool.ts`: `316 -> 79` lines
-  - extracted modules: `60`, `72`, `84`, `27`, `44`, and `34` lines
+  - `packages/core/src/resources/pool.ts`: `316 -> 83` lines
+  - extracted modules: `61`, `72`, `89`, `27`, `60`, and `34` lines
 - Test modularization result:
   - `packages/core/tests/resources/pool.test.ts`: `3` line entrypoint
-  - focused suites: `35`, `40`, and `29` lines
+  - shared fixture: `57` lines
+  - focused suites: `81`, `42`, and `31` lines
 - Focused validation after production split:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
   - `3` files passed, `9` tests passed

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2798,9 +2798,9 @@ Implementation notes:
 **Branch:** `refactor/st-09066-resource-pool-modularization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09066-resource-pool-modularization`
+- [x] Create branch `refactor/st-09066-resource-pool-modularization`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove pool behavior remains stable while the oversized runtime and test files are split
+- [x] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove pool behavior remains stable while the oversized runtime and test files are split
 - [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
 - [ ] Reduce `packages/core/src/resources/pool.ts` below the 300 line planning cutoff by extracting focused internal modules for acquisition/release flow, eviction/reaping behavior, metrics/introspection helpers, and shared pool types behind a stable facade
 - [ ] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
@@ -2815,6 +2815,13 @@ Implementation notes:
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
+
+Implementation notes:
+
+- Branch created from `main`: `refactor/st-09066-resource-pool-modularization`
+- Test-first strategy:
+  - `packages/core/src/resources/pool.ts` is the only oversized runtime file, but the current resource-pool assertions are split indirectly across `database-pool.test.ts` and `http-pool.test.ts` rather than a single shared `ConnectionPool` test seam.
+  - Practical test-first substitute: introduce a stable `packages/core/tests/resources/pool.test.ts` entrypoint that exercises the shared `ConnectionPool` API directly, add failing acquisition/eviction/lifecycle coverage there first, and then modularize both the new pool test entrypoint and `pool.ts` behind the same public resource exports.
 
 ---
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2829,15 +2829,15 @@ Implementation notes:
   - `1` file failed, `1` test failed, `2` tests passed
   - Failure: idle eviction dropped pool stats below configured `min` (`size 0`, `available 0`) instead of retaining one idle connection
 - Runtime file-size result:
-  - `packages/core/src/resources/pool.ts`: `316 -> 97` lines
+  - `packages/core/src/resources/pool.ts`: `316 -> 106` lines
   - extracted modules: `61`, `113`, `93`, `43`, `64`, and `40` lines
 - Test modularization result:
   - `packages/core/tests/resources/pool.test.ts`: `3` line entrypoint
   - shared fixture: `57` lines
-  - focused suites: `163`, `105`, and `182` lines
+  - focused suites: `163`, `105`, and `211` lines
 - Focused validation after production split:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
-  - `3` files passed, `17` tests passed
+  - `3` files passed, `18` tests passed
 - Compatibility validation:
   - `pnpm --filter @agentforge/core typecheck`
 - Explicit-`any` baseline check:

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2829,12 +2829,12 @@ Implementation notes:
   - `1` file failed, `1` test failed, `2` tests passed
   - Failure: idle eviction dropped pool stats below configured `min` (`size 0`, `available 0`) instead of retaining one idle connection
 - Runtime file-size result:
-  - `packages/core/src/resources/pool.ts`: `316 -> 83` lines
-  - extracted modules: `61`, `72`, `89`, `27`, `60`, and `34` lines
+  - `packages/core/src/resources/pool.ts`: `316 -> 90` lines
+  - extracted modules: `61`, `102`, `89`, `43`, `64`, and `40` lines
 - Test modularization result:
   - `packages/core/tests/resources/pool.test.ts`: `3` line entrypoint
   - shared fixture: `57` lines
-  - focused suites: `81`, `42`, and `31` lines
+  - focused suites: `127`, `105`, and `106` lines
 - Focused validation after production split:
   - `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
   - `3` files passed, `9` tests passed

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1973,7 +1973,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/resources/pool.ts` is reduced below the 300 line planning cutoff by extracting focused internal modules for acquisition/release flow, eviction/reaping behavior, metrics/introspection helpers, and shared pool types behind a stable public facade, and the extracted production modules must also stay below `300` lines unless the story documents and justifies an explicit exception.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -1973,7 +1973,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** None
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/core/src/resources/pool.ts` is reduced below the 300 line planning cutoff by extracting focused internal modules for acquisition/release flow, eviction/reaping behavior, metrics/introspection helpers, and shared pool types behind a stable public facade, and the extracted production modules must also stay below `300` lines unless the story documents and justifies an explicit exception.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-15
-**Active Story:** ST-09066 - Modularize Core Resource Pool and Tests (In Progress)
+**Active Story:** ST-09066 - Modularize Core Resource Pool and Tests (In Review)
 
 ---
 
@@ -108,7 +108,7 @@ Recent improvement snapshot:
 - `ST-09067` through `ST-09074` were added on 2026-06-12 to replenish EP-09 beyond the current ready lane with another dependency-safe batch of modularization-first slices across relational batch/executor helpers, middleware caching, Neo4j embeddings, multi-agent utilities, and skill activation.
 - `ST-09064` merged on 2026-06-13 after shrinking `packages/core/src/langgraph/middleware/presets.ts` from `365` lines to a small public facade, extracting focused logging, retry/timing, composition, and shared preset modules, and replacing the `286` line preset test monolith with focused suites while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
 - `ST-09065` merged on 2026-06-13 after shrinking `packages/core/src/langgraph/state.ts` from `361` lines to a `13` line public facade, extracting focused state annotation, validation, merge, reducer/default, and shared-type helpers while replacing the `507` line `packages/core/tests/langgraph/state.test.ts` monolith with focused annotation, validation, merge, and workflow suites behind the same public entrypoint. The story preserved public state-helper behavior, kept the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`, and required no CI changes.
-- `EP-09` remains open as the daily hardening stream, with `ST-09066` now in progress, `ST-09067` through `ST-09071` still queued in the ready lane, and `ST-09072` through `ST-09074` still parked in backlog behind `ST-09067`.
+- `EP-09` remains open as the daily hardening stream, with `ST-09066` now in review, `ST-09067` through `ST-09071` still queued in the ready lane, and `ST-09072` through `ST-09074` still parked in backlog behind `ST-09067`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-06-13
-**Active Story:** ST-09066 - Modularize Core Resource Pool and Tests (Ready)
+**Last Updated:** 2026-06-15
+**Active Story:** ST-09066 - Modularize Core Resource Pool and Tests (In Progress)
 
 ---
 
@@ -108,7 +108,7 @@ Recent improvement snapshot:
 - `ST-09067` through `ST-09074` were added on 2026-06-12 to replenish EP-09 beyond the current ready lane with another dependency-safe batch of modularization-first slices across relational batch/executor helpers, middleware caching, Neo4j embeddings, multi-agent utilities, and skill activation.
 - `ST-09064` merged on 2026-06-13 after shrinking `packages/core/src/langgraph/middleware/presets.ts` from `365` lines to a small public facade, extracting focused logging, retry/timing, composition, and shared preset modules, and replacing the `286` line preset test monolith with focused suites while keeping the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`.
 - `ST-09065` merged on 2026-06-13 after shrinking `packages/core/src/langgraph/state.ts` from `361` lines to a `13` line public facade, extracting focused state annotation, validation, merge, reducer/default, and shared-type helpers while replacing the `507` line `packages/core/tests/langgraph/state.test.ts` monolith with focused annotation, validation, merge, and workflow suites behind the same public entrypoint. The story preserved public state-helper behavior, kept the explicit-`any` baseline flat at `workspace 84/289` and `core 23/119`, and required no CI changes.
-- `EP-09` remains open as the daily hardening stream, with `ST-09066` now active as the next ready story, `ST-09067` through `ST-09071` still queued in the ready lane, and `ST-09072` through `ST-09074` still parked in backlog behind `ST-09067`.
+- `EP-09` remains open as the daily hardening stream, with `ST-09066` now in progress, `ST-09067` through `ST-09071` still queued in the ready lane, and `ST-09072` through `ST-09074` still parked in backlog behind `ST-09067`.
 - The refreshed follow-on queue now extends beyond the current Ready lane so another few weeks of small SOLID/DRY and modularization work can be pulled without re-planning the epic.
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-06-13
+**Last Updated:** 2026-06-15
 
 ## Queue Status Summary
 
 - **Ready:** 5 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
 
@@ -24,13 +24,13 @@
 
 ## In Progress
 
-- `ST-09066` - Modularize Core Resource Pool and Tests
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09066` - Modularize Core Resource Pool and Tests
 
 ## Blocked
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 6 stories
-- **In Progress:** 0 stories
+- **Ready:** 5 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 3 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09066` - Modularize Core Resource Pool and Tests
 - `ST-09067` - Modularize Relational Batch Executor and Tests
 - `ST-09068` - Modularize LangGraph Caching Middleware and Tests
 - `ST-09069` - Modularize Neo4j Embedding Manager and Tests
@@ -25,7 +24,7 @@
 
 ## In Progress
 
-None currently.
+- `ST-09066` - Modularize Core Resource Pool and Tests
 
 ---
 


### PR DESCRIPTION
# Story

`ST-09066` - Modularize Core Resource Pool and Tests

# What Changed

- Split `packages/core/src/resources/pool.ts` into focused runtime helpers for shared pool types, runtime/state helpers, acquisition, eviction, health checks, and lifecycle cleanup while keeping `ConnectionPool` and `createConnectionPool(...)` as the stable public facade.
- Added a direct `packages/core/tests/resources/pool.test.ts` entrypoint with focused acquisition, eviction, and lifecycle suites plus a shared pool fixture so shared pool behavior is exercised directly instead of only through wrapper-specific tests.
- Fixed an uncovered idle-eviction bug so periodic cleanup preserves the configured pool `min` instead of evicting every eligible idle connection.
- Recorded the modularization, validation evidence, and no-CI-change decision in `docs/st09066-resource-pool-modularization.md`.

# Acceptance Criteria Coverage

- `packages/core/src/resources/pool.ts` is now a `79` line facade, and all extracted runtime helpers remain below the `300` line cutoff.
- Pool coverage is modularized behind the stable `packages/core/tests/resources/pool.test.ts` public entrypoint with focused acquisition, eviction, and lifecycle suites.
- Existing pool behavior and public imports remain intact while the new eviction regression test confirms the shared pool runtime now preserves `min` idle capacity.
- Story documentation is captured in `docs/st09066-resource-pool-modularization.md`.

# Test Strategy

- Test-first substitute: add direct shared-pool coverage before refactoring because the existing assertions were split indirectly across wrapper tests.
- First failing run:
  - `pnpm test --run packages/core/tests/resources/pool.test.ts`
  - Failed because idle eviction dropped the pool below its configured `min`.
- No additional automated coverage was needed after the split because the new direct pool suites now cover the shared seam and the existing database/http wrapper tests still cover the adapters.

# Validation Performed

- `pnpm test --run packages/core/tests/resources/pool.test.ts packages/core/tests/resources/database-pool.test.ts packages/core/tests/resources/http-pool.test.ts`
- `pnpm --filter @agentforge/core typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

# Status

- Ready for review
