### PR TITLE
ST-09069: Modularize Neo4j Embedding Manager and Tests

### DIFF
--- a/docs/st09069-neo4j-embedding-manager-modularization.md
+++ b/docs/st09069-neo4j-embedding-manager-modularization.md
@@ -64,6 +64,13 @@ No additional automated coverage was required beyond the new focused embedding-m
 - Explicit-`any` baseline:
   - `pnpm lint:explicit-any:baseline`
   - Passed with no regression
+- Full test suite:
+  - `pnpm test --run`
+  - `212` files passed, `18` files skipped
+  - `2340` tests passed, `286` tests skipped
+- Lint:
+  - `pnpm lint`
+  - Exit `0`; warnings only (`0` errors)
 
 ## CI Impact
 

--- a/docs/st09069-neo4j-embedding-manager-modularization.md
+++ b/docs/st09069-neo4j-embedding-manager-modularization.md
@@ -30,8 +30,8 @@ Modularized `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` from
 - Production files:
   - `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts`: `332 -> 151` lines
   - `packages/tools/src/data/neo4j/embeddings/embedding-manager-shared.ts`: `29` lines
-  - `packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts`: `47` lines
-  - `packages/tools/src/data/neo4j/embeddings/embedding-environment.ts`: `114` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts`: `56` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-environment.ts`: `120` lines
   - `packages/tools/src/data/neo4j/embeddings/embedding-generation.ts`: `56` lines
 
 ## Test Modularization Results

--- a/docs/st09069-neo4j-embedding-manager-modularization.md
+++ b/docs/st09069-neo4j-embedding-manager-modularization.md
@@ -1,0 +1,70 @@
+# ST-09069: Neo4j Embedding Manager Modularization
+
+## Summary
+
+Modularized `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` from a mixed-responsibility runtime into a thin public facade backed by focused provider-factory, environment-resolution, generation-flow, and shared state/assertion helpers. Split the embedding-manager coverage into a public entrypoint plus focused initialization, provider-selection, and generation suites under `packages/tools/tests/data/neo4j/embedding-manager/`.
+
+## Test-First Evidence
+
+- This story is behavior-preserving refactor work rather than a new capability, so a red-first test would only have failed by asserting on temporary file structure instead of stable public behavior.
+- The practical test-first path was characterization-first coverage:
+  - added a stable public entrypoint at `packages/tools/tests/data/neo4j/embedding-manager.test.ts`
+  - added focused suites for initialization, provider selection, and generation behavior before completing the runtime split
+- First focused run after the new suites were added:
+  - `pnpm test --run packages/tools/tests/data/neo4j/embedding-manager.test.ts`
+  - Failed because the shared test harness re-exported the imported runtime symbols in a way Vitest did not bind correctly under the mocked dependency graph.
+- Fixed the shared harness export wiring, reran the focused suite, and then used the passing characterization coverage as the refactor safety net.
+
+## Implementation Notes
+
+- Extracted focused runtime helpers:
+  - `packages/tools/src/data/neo4j/embeddings/embedding-manager-shared.ts`
+  - `packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts`
+  - `packages/tools/src/data/neo4j/embeddings/embedding-environment.ts`
+  - `packages/tools/src/data/neo4j/embeddings/embedding-generation.ts`
+- Kept `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` as the stable public facade that still exports `EmbeddingManager`, the singleton helpers, and the same public generation API.
+- Preserved public behavior around provider defaults, required environment variables, singleton initialization helpers, model override precedence, and batch/single generation delegation.
+
+## File Size Results
+
+- Production files:
+  - `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts`: `332 -> 151` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-manager-shared.ts`: `29` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts`: `47` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-environment.ts`: `114` lines
+  - `packages/tools/src/data/neo4j/embeddings/embedding-generation.ts`: `56` lines
+
+## Test Modularization Results
+
+- Test files:
+  - `packages/tools/tests/data/neo4j/embedding-manager.test.ts`: `7` lines
+  - `packages/tools/tests/data/neo4j/embedding-manager/shared.ts`: `195` lines
+  - `packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts`: `98` lines
+  - `packages/tools/tests/data/neo4j/embedding-manager/provider-selection.suite.ts`: `62` lines
+  - `packages/tools/tests/data/neo4j/embedding-manager/generation.suite.ts`: `58` lines
+
+## Explicit-`any` Baseline
+
+- `pnpm lint:explicit-any:baseline`
+- Result: `80/289` warnings overall, `53/67` in `tools`
+- Delta: unchanged from the pre-story baseline; no regression introduced
+
+## Residual Test Impact
+
+No additional automated coverage was required beyond the new focused embedding-manager suites. The new entrypoint now isolates environment initialization, provider selection, and single/batch generation behavior while the existing `packages/tools/tests/data/neo4j.test.ts` integration surface remains available for broader Neo4j tool coverage.
+
+## Validation
+
+- Focused embedding-manager coverage:
+  - `pnpm test --run packages/tools/tests/data/neo4j/embedding-manager.test.ts`
+  - `1` file passed, `16` tests passed
+- Package compatibility:
+  - `pnpm --filter @agentforge/tools typecheck`
+  - Passed
+- Explicit-`any` baseline:
+  - `pnpm lint:explicit-any:baseline`
+  - Passed with no regression
+
+## CI Impact
+
+No CI change required. The story preserves the public embedding-manager facade and stays within the repository's existing `typecheck`, `test`, `lint`, and explicit-`any` baseline validation paths.

--- a/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
@@ -1,0 +1,114 @@
+import type { EmbeddingConfig, EmbeddingProvider } from './types.js';
+import {
+  getEmbeddingProvider,
+  getEmbeddingModel,
+  getOpenAIApiKey,
+  getCohereApiKey,
+  getHuggingFaceApiKey,
+  getVoyageApiKey,
+  getOllamaBaseUrl,
+} from './utils.js';
+import { getDefaultEmbeddingModel } from './embedding-provider-factory.js';
+import { embeddingLogger } from './embedding-manager-shared.js';
+
+export interface ResolvedEmbeddingEnvironment {
+  apiKey: string;
+  baseUrl?: string;
+  config: EmbeddingConfig;
+  providerName: EmbeddingProvider;
+}
+
+export function resolveEmbeddingEnvironment(): ResolvedEmbeddingEnvironment {
+  const providerName = getEmbeddingProvider() as EmbeddingProvider;
+  const model = getEmbeddingModel() ?? getDefaultEmbeddingModel(providerName);
+
+  embeddingLogger.debug('Initializing embedding manager from environment', {
+    provider: providerName,
+    model,
+  });
+
+  switch (providerName) {
+    case 'openai':
+      return createCredentialEnvironment(
+        providerName,
+        model,
+        getOpenAIApiKey(),
+        'OPENAI_API_KEY environment variable is required for OpenAI embeddings',
+        'OPENAI_API_KEY environment variable not set'
+      );
+    case 'cohere':
+      return createCredentialEnvironment(
+        providerName,
+        model,
+        getCohereApiKey(),
+        'COHERE_API_KEY environment variable is required for Cohere embeddings',
+        'COHERE_API_KEY environment variable not set'
+      );
+    case 'huggingface':
+      return createCredentialEnvironment(
+        providerName,
+        model,
+        getHuggingFaceApiKey(),
+        'HUGGINGFACE_API_KEY environment variable is required for HuggingFace embeddings',
+        'HUGGINGFACE_API_KEY environment variable not set'
+      );
+    case 'voyage':
+      return createCredentialEnvironment(
+        providerName,
+        model,
+        getVoyageApiKey(),
+        'VOYAGE_API_KEY environment variable is required for Voyage AI embeddings',
+        'VOYAGE_API_KEY environment variable not set'
+      );
+    case 'ollama': {
+      const baseUrl = getOllamaBaseUrl();
+      embeddingLogger.debug('Using Ollama (local, no API key required)', {
+        baseUrl,
+      });
+
+      return {
+        providerName,
+        apiKey: '',
+        baseUrl,
+        config: {
+          provider: providerName,
+          model,
+          apiKey: '',
+        },
+      };
+    }
+    default:
+      embeddingLogger.error('Unknown embedding provider', {
+        provider: providerName,
+      });
+      throw new Error(`Unknown embedding provider: ${providerName}`);
+  }
+}
+
+function createCredentialEnvironment(
+  providerName: EmbeddingProvider,
+  model: string,
+  apiKey: string | undefined,
+  missingKeyError: string,
+  missingKeyLog: string
+): ResolvedEmbeddingEnvironment {
+  if (!apiKey) {
+    embeddingLogger.error(missingKeyLog, {
+      provider: providerName,
+      required: true,
+    });
+    throw new Error(missingKeyError);
+  }
+
+  embeddingLogger.debug(`${providerName} API key found`);
+
+  return {
+    providerName,
+    apiKey,
+    config: {
+      provider: providerName,
+      model,
+      apiKey: '',
+    },
+  };
+}

--- a/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
@@ -8,7 +8,7 @@ import {
   getVoyageApiKey,
   getOllamaBaseUrl,
 } from './utils.js';
-import { getDefaultEmbeddingModel } from './embedding-provider-factory.js';
+import { getDefaultEmbeddingModel, parseEmbeddingProvider } from './embedding-provider-factory.js';
 import { embeddingLogger } from './embedding-manager-shared.js';
 
 export interface ResolvedEmbeddingEnvironment {
@@ -19,7 +19,7 @@ export interface ResolvedEmbeddingEnvironment {
 }
 
 export function resolveEmbeddingEnvironment(): ResolvedEmbeddingEnvironment {
-  const providerName = getEmbeddingProvider() as EmbeddingProvider;
+  const providerName = validateEmbeddingProvider(getEmbeddingProvider());
   const model = getEmbeddingModel() ?? getDefaultEmbeddingModel(providerName);
 
   embeddingLogger.debug('Initializing embedding manager from environment', {
@@ -77,11 +77,17 @@ export function resolveEmbeddingEnvironment(): ResolvedEmbeddingEnvironment {
         },
       };
     }
-    default:
-      embeddingLogger.error('Unknown embedding provider', {
-        provider: providerName,
-      });
-      throw new Error(`Unknown embedding provider: ${providerName}`);
+  }
+}
+
+function validateEmbeddingProvider(providerName: string): EmbeddingProvider {
+  try {
+    return parseEmbeddingProvider(providerName);
+  } catch (error) {
+    embeddingLogger.error('Unknown embedding provider', {
+      provider: providerName,
+    });
+    throw error;
   }
 }
 

--- a/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-environment.ts
@@ -20,7 +20,7 @@ export interface ResolvedEmbeddingEnvironment {
 
 export function resolveEmbeddingEnvironment(): ResolvedEmbeddingEnvironment {
   const providerName = validateEmbeddingProvider(getEmbeddingProvider());
-  const model = getEmbeddingModel() ?? getDefaultEmbeddingModel(providerName);
+  const model = getEmbeddingModel() || getDefaultEmbeddingModel(providerName);
 
   embeddingLogger.debug('Initializing embedding manager from environment', {
     provider: providerName,

--- a/packages/tools/src/data/neo4j/embeddings/embedding-generation.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-generation.ts
@@ -1,0 +1,56 @@
+import type { BatchEmbeddingResult, EmbeddingResult } from './types.js';
+import type { InitializedEmbeddingState } from './embedding-manager-shared.js';
+import { embeddingLogger } from './embedding-manager-shared.js';
+
+export async function generateManagedEmbedding(
+  state: InitializedEmbeddingState,
+  text: string,
+  model?: string
+): Promise<EmbeddingResult> {
+  const startTime = Date.now();
+  const modelToUse = model || state.config.model;
+
+  embeddingLogger.debug('Generating embedding', {
+    provider: state.provider.name,
+    model: modelToUse,
+    textLength: text.length,
+  });
+
+  const result = await state.provider.generateEmbedding(text, modelToUse);
+
+  embeddingLogger.info('Embedding generated', {
+    provider: state.provider.name,
+    model: result.model,
+    dimensions: result.dimensions,
+    duration: Date.now() - startTime,
+  });
+
+  return result;
+}
+
+export async function generateManagedBatchEmbeddings(
+  state: InitializedEmbeddingState,
+  texts: string[],
+  model?: string
+): Promise<BatchEmbeddingResult> {
+  const startTime = Date.now();
+  const modelToUse = model || state.config.model;
+
+  embeddingLogger.debug('Generating batch embeddings', {
+    provider: state.provider.name,
+    model: modelToUse,
+    count: texts.length,
+  });
+
+  const result = await state.provider.generateBatchEmbeddings(texts, modelToUse);
+
+  embeddingLogger.info('Batch embeddings generated', {
+    provider: state.provider.name,
+    model: result.model,
+    dimensions: result.dimensions,
+    count: texts.length,
+    duration: Date.now() - startTime,
+  });
+
+  return result;
+}

--- a/packages/tools/src/data/neo4j/embeddings/embedding-manager-shared.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-manager-shared.ts
@@ -1,0 +1,29 @@
+import { createLogger } from '@agentforge/core';
+
+import type { EmbeddingConfig, IEmbeddingProvider } from './types.js';
+
+export const embeddingLogger = createLogger('agentforge:tools:neo4j:embeddings');
+
+export interface InitializedEmbeddingState {
+  config: EmbeddingConfig;
+  provider: IEmbeddingProvider;
+}
+
+const NOT_INITIALIZED_ERROR =
+  'Embedding manager not initialized. Call initialize() or initializeFromEnv() first.';
+
+export function requireEmbeddingProvider(provider: IEmbeddingProvider | null): IEmbeddingProvider {
+  if (!provider) {
+    throw new Error(NOT_INITIALIZED_ERROR);
+  }
+
+  return provider;
+}
+
+export function requireEmbeddingConfig(config: EmbeddingConfig | null): EmbeddingConfig {
+  if (!config) {
+    throw new Error(NOT_INITIALIZED_ERROR);
+  }
+
+  return config;
+}

--- a/packages/tools/src/data/neo4j/embeddings/embedding-manager.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-manager.ts
@@ -1,27 +1,18 @@
 /**
  * Embedding Manager
  *
- * Manages embedding generation across different providers
+ * Stable public facade for embedding provider initialization and generation.
  */
 
-import { createLogger } from '@agentforge/core';
-import type { IEmbeddingProvider, EmbeddingProvider, EmbeddingConfig, EmbeddingResult, BatchEmbeddingResult } from './types.js';
-import { OpenAIEmbeddingProvider } from './providers/openai.js';
-import { CohereEmbeddingProvider } from './providers/cohere.js';
-import { HuggingFaceEmbeddingProvider } from './providers/huggingface.js';
-import { VoyageEmbeddingProvider } from './providers/voyage.js';
-import { OllamaEmbeddingProvider } from './providers/ollama.js';
+import type { BatchEmbeddingResult, EmbeddingConfig, EmbeddingResult, IEmbeddingProvider } from './types.js';
 import {
-  getEmbeddingProvider,
-  getEmbeddingModel,
-  getOpenAIApiKey,
-  getCohereApiKey,
-  getHuggingFaceApiKey,
-  getVoyageApiKey,
-  getOllamaBaseUrl,
-} from './utils.js';
-
-const logger = createLogger('agentforge:tools:neo4j:embeddings');
+  embeddingLogger,
+  requireEmbeddingConfig,
+  requireEmbeddingProvider,
+} from './embedding-manager-shared.js';
+import { createEmbeddingProvider, getDefaultEmbeddingModel } from './embedding-provider-factory.js';
+import { resolveEmbeddingEnvironment } from './embedding-environment.js';
+import { generateManagedBatchEmbeddings, generateManagedEmbedding } from './embedding-generation.js';
 
 /**
  * Singleton embedding manager
@@ -34,17 +25,17 @@ export class EmbeddingManager {
    * Initialize with configuration
    */
   initialize(config: EmbeddingConfig): void {
-    logger.debug('Initializing embedding manager', {
+    embeddingLogger.debug('Initializing embedding manager', {
       provider: config.provider,
       model: config.model,
     });
 
     this.config = config;
-    this.provider = this.createProvider(config.provider, config.apiKey);
+    this.provider = createEmbeddingProvider(config.provider, config.apiKey);
 
-    logger.info('Embedding manager initialized', {
+    embeddingLogger.info('Embedding manager initialized', {
       provider: config.provider,
-      model: config.model || this.getDefaultModel(config.provider),
+      model: config.model || getDefaultEmbeddingModel(config.provider),
     });
   }
 
@@ -52,100 +43,18 @@ export class EmbeddingManager {
    * Initialize from environment variables
    */
   initializeFromEnv(): void {
-    const providerName = getEmbeddingProvider() as EmbeddingProvider;
-    const model = getEmbeddingModel();
+    const resolved = resolveEmbeddingEnvironment();
 
-    logger.debug('Initializing embedding manager from environment', {
-      provider: providerName,
-      model: model || this.getDefaultModel(providerName),
-    });
+    this.provider = createEmbeddingProvider(
+      resolved.providerName,
+      resolved.apiKey,
+      resolved.config.model,
+      resolved.baseUrl
+    );
+    this.config = resolved.config;
 
-    // Get API key based on provider
-    let apiKey = '';
-    let baseUrl = '';
-
-    switch (providerName) {
-      case 'openai': {
-        const key = getOpenAIApiKey();
-        if (!key) {
-          logger.error('OPENAI_API_KEY environment variable not set', {
-            provider: 'openai',
-            required: true,
-          });
-          throw new Error('OPENAI_API_KEY environment variable is required for OpenAI embeddings');
-        }
-        apiKey = key;
-        logger.debug('OpenAI API key found');
-        break;
-      }
-
-      case 'cohere': {
-        const key = getCohereApiKey();
-        if (!key) {
-          logger.error('COHERE_API_KEY environment variable not set', {
-            provider: 'cohere',
-            required: true,
-          });
-          throw new Error('COHERE_API_KEY environment variable is required for Cohere embeddings');
-        }
-        apiKey = key;
-        logger.debug('Cohere API key found');
-        break;
-      }
-
-      case 'huggingface': {
-        const key = getHuggingFaceApiKey();
-        if (!key) {
-          logger.error('HUGGINGFACE_API_KEY environment variable not set', {
-            provider: 'huggingface',
-            required: true,
-          });
-          throw new Error('HUGGINGFACE_API_KEY environment variable is required for HuggingFace embeddings');
-        }
-        apiKey = key;
-        logger.debug('HuggingFace API key found');
-        break;
-      }
-
-      case 'voyage': {
-        const key = getVoyageApiKey();
-        if (!key) {
-          logger.error('VOYAGE_API_KEY environment variable not set', {
-            provider: 'voyage',
-            required: true,
-          });
-          throw new Error('VOYAGE_API_KEY environment variable is required for Voyage AI embeddings');
-        }
-        apiKey = key;
-        logger.debug('Voyage API key found');
-        break;
-      }
-
-      case 'ollama':
-        baseUrl = getOllamaBaseUrl();
-        logger.debug('Using Ollama (local, no API key required)', {
-          baseUrl: baseUrl || 'http://localhost:11434',
-        });
-        // Ollama doesn't require an API key (local)
-        break;
-
-      default:
-        logger.error('Unknown embedding provider', {
-          provider: providerName,
-        });
-        throw new Error(`Unknown embedding provider: ${providerName}`);
-    }
-
-    // Create provider
-    this.provider = this.createProvider(providerName, apiKey, model, baseUrl);
-    this.config = {
-      provider: providerName,
-      model: model || this.getDefaultModel(providerName),
-      apiKey: '', // Not stored when using env
-    };
-
-    logger.info('Embedding manager initialized from environment', {
-      provider: providerName,
+    embeddingLogger.info('Embedding manager initialized from environment', {
+      provider: resolved.providerName,
       model: this.config.model,
     });
   }
@@ -161,131 +70,42 @@ export class EmbeddingManager {
    * Get current provider
    */
   getProvider(): IEmbeddingProvider {
-    if (!this.provider) {
-      throw new Error('Embedding manager not initialized. Call initialize() or initializeFromEnv() first.');
-    }
-    return this.provider;
+    return requireEmbeddingProvider(this.provider);
   }
 
   /**
    * Get current configuration
    */
   getConfig(): EmbeddingConfig {
-    if (!this.config) {
-      throw new Error('Embedding manager not initialized. Call initialize() or initializeFromEnv() first.');
-    }
-    return this.config;
+    return requireEmbeddingConfig(this.config);
   }
 
   /**
    * Generate embedding for a single text
    */
   async generateEmbedding(text: string, model?: string): Promise<EmbeddingResult> {
-    const startTime = Date.now();
-    const provider = this.getProvider();
-    const config = this.getConfig();
-
-    // Use provided model, fall back to configured model, then provider default
-    const modelToUse = model || config.model;
-
-    logger.debug('Generating embedding', {
-      provider: provider.name,
-      model: modelToUse,
-      textLength: text.length,
-    });
-
-    // Pass model parameter to provider
-    const result = await provider.generateEmbedding(text, modelToUse);
-
-    logger.info('Embedding generated', {
-      provider: provider.name,
-      model: result.model,
-      dimensions: result.dimensions,
-      duration: Date.now() - startTime,
-    });
-
-    return result;
+    return generateManagedEmbedding(
+      {
+        provider: this.getProvider(),
+        config: this.getConfig(),
+      },
+      text,
+      model
+    );
   }
 
   /**
    * Generate embeddings for multiple texts (batch)
    */
   async generateBatchEmbeddings(texts: string[], model?: string): Promise<BatchEmbeddingResult> {
-    const startTime = Date.now();
-    const provider = this.getProvider();
-    const config = this.getConfig();
-
-    // Use provided model, fall back to configured model, then provider default
-    const modelToUse = model || config.model;
-
-    logger.debug('Generating batch embeddings', {
-      provider: provider.name,
-      model: modelToUse,
-      count: texts.length,
-    });
-
-    // Pass model parameter to provider
-    const result = await provider.generateBatchEmbeddings(texts, modelToUse);
-
-    logger.info('Batch embeddings generated', {
-      provider: provider.name,
-      model: result.model,
-      dimensions: result.dimensions,
-      count: texts.length,
-      duration: Date.now() - startTime,
-    });
-
-    return result;
-  }
-
-  /**
-   * Get default model for a provider
-   */
-  private getDefaultModel(provider: EmbeddingProvider): string {
-    switch (provider) {
-      case 'openai':
-        return 'text-embedding-3-small';
-      case 'cohere':
-        return 'embed-english-v3.0';
-      case 'huggingface':
-        return 'sentence-transformers/all-MiniLM-L6-v2';
-      case 'voyage':
-        return 'voyage-2';
-      case 'ollama':
-        return 'nomic-embed-text';
-      default:
-        return 'text-embedding-3-small';
-    }
-  }
-
-  /**
-   * Create a provider instance
-   */
-  private createProvider(
-    providerName: EmbeddingProvider,
-    apiKey?: string,
-    model?: string,
-    baseUrl?: string
-  ): IEmbeddingProvider {
-    switch (providerName) {
-      case 'openai':
-        return new OpenAIEmbeddingProvider(apiKey);
-
-      case 'cohere':
-        return new CohereEmbeddingProvider(apiKey);
-
-      case 'huggingface':
-        return new HuggingFaceEmbeddingProvider(apiKey);
-
-      case 'voyage':
-        return new VoyageEmbeddingProvider(apiKey);
-
-      case 'ollama':
-        return new OllamaEmbeddingProvider(model, baseUrl || 'http://localhost:11434');
-
-      default:
-        throw new Error(`Unknown embedding provider: ${providerName}`);
-    }
+    return generateManagedBatchEmbeddings(
+      {
+        provider: this.getProvider(),
+        config: this.getConfig(),
+      },
+      texts,
+      model
+    );
   }
 
   /**
@@ -329,4 +149,3 @@ export async function generateEmbedding(text: string, model?: string): Promise<E
 export async function generateBatchEmbeddings(texts: string[], model?: string): Promise<BatchEmbeddingResult> {
   return embeddingManager.generateBatchEmbeddings(texts, model);
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
@@ -7,6 +7,19 @@ import { OllamaEmbeddingProvider } from './providers/ollama.js';
 
 export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
 
+export function parseEmbeddingProvider(providerName: string): EmbeddingProvider {
+  switch (providerName) {
+    case 'openai':
+    case 'cohere':
+    case 'huggingface':
+    case 'voyage':
+    case 'ollama':
+      return providerName;
+    default:
+      throw new Error(`Unknown embedding provider: ${providerName}`);
+  }
+}
+
 export function getDefaultEmbeddingModel(provider: EmbeddingProvider): string {
   switch (provider) {
     case 'openai':
@@ -19,8 +32,6 @@ export function getDefaultEmbeddingModel(provider: EmbeddingProvider): string {
       return 'voyage-2';
     case 'ollama':
       return 'nomic-embed-text';
-    default:
-      return 'text-embedding-3-small';
   }
 }
 
@@ -41,7 +52,5 @@ export function createEmbeddingProvider(
       return new VoyageEmbeddingProvider(apiKey);
     case 'ollama':
       return new OllamaEmbeddingProvider(model, baseUrl || DEFAULT_OLLAMA_BASE_URL);
-    default:
-      throw new Error(`Unknown embedding provider: ${providerName}`);
   }
 }

--- a/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
@@ -5,7 +5,7 @@ import { HuggingFaceEmbeddingProvider } from './providers/huggingface.js';
 import { VoyageEmbeddingProvider } from './providers/voyage.js';
 import { OllamaEmbeddingProvider } from './providers/ollama.js';
 
-export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
 
 export function parseEmbeddingProvider(providerName: string): EmbeddingProvider {
   switch (providerName) {

--- a/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
+++ b/packages/tools/src/data/neo4j/embeddings/embedding-provider-factory.ts
@@ -1,0 +1,47 @@
+import type { EmbeddingProvider, IEmbeddingProvider } from './types.js';
+import { OpenAIEmbeddingProvider } from './providers/openai.js';
+import { CohereEmbeddingProvider } from './providers/cohere.js';
+import { HuggingFaceEmbeddingProvider } from './providers/huggingface.js';
+import { VoyageEmbeddingProvider } from './providers/voyage.js';
+import { OllamaEmbeddingProvider } from './providers/ollama.js';
+
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+
+export function getDefaultEmbeddingModel(provider: EmbeddingProvider): string {
+  switch (provider) {
+    case 'openai':
+      return 'text-embedding-3-small';
+    case 'cohere':
+      return 'embed-english-v3.0';
+    case 'huggingface':
+      return 'sentence-transformers/all-MiniLM-L6-v2';
+    case 'voyage':
+      return 'voyage-2';
+    case 'ollama':
+      return 'nomic-embed-text';
+    default:
+      return 'text-embedding-3-small';
+  }
+}
+
+export function createEmbeddingProvider(
+  providerName: EmbeddingProvider,
+  apiKey?: string,
+  model?: string,
+  baseUrl?: string
+): IEmbeddingProvider {
+  switch (providerName) {
+    case 'openai':
+      return new OpenAIEmbeddingProvider(apiKey);
+    case 'cohere':
+      return new CohereEmbeddingProvider(apiKey);
+    case 'huggingface':
+      return new HuggingFaceEmbeddingProvider(apiKey);
+    case 'voyage':
+      return new VoyageEmbeddingProvider(apiKey);
+    case 'ollama':
+      return new OllamaEmbeddingProvider(model, baseUrl || DEFAULT_OLLAMA_BASE_URL);
+    default:
+      throw new Error(`Unknown embedding provider: ${providerName}`);
+  }
+}

--- a/packages/tools/tests/data/neo4j/embedding-manager.test.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Public embedding-manager test entrypoint.
+ */
+
+import './embedding-manager/initialization.suite.js';
+import './embedding-manager/provider-selection.suite.js';
+import './embedding-manager/generation.suite.js';

--- a/packages/tools/tests/data/neo4j/embedding-manager/generation.suite.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/generation.suite.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EmbeddingManager,
+  createEmbeddingConfig,
+  generateBatchEmbeddings,
+  generateEmbedding,
+  initializeEmbeddingsWithConfig,
+  providerStubs,
+} from './shared.js';
+
+describe('EmbeddingManager generation', () => {
+  it('passes an explicit model override to single embedding generation', async () => {
+    const manager = new EmbeddingManager();
+    manager.initialize(createEmbeddingConfig('openai', { model: 'configured-openai-model' }));
+
+    await manager.generateEmbedding('hello world', 'override-model');
+
+    expect(providerStubs.openai.generateEmbedding).toHaveBeenCalledWith('hello world', 'override-model');
+  });
+
+  it('falls back to the configured model for batch generation', async () => {
+    const manager = new EmbeddingManager();
+    manager.initialize(createEmbeddingConfig('cohere', { model: 'configured-cohere-model' }));
+
+    await manager.generateBatchEmbeddings(['first', 'second']);
+
+    expect(providerStubs.cohere.generateBatchEmbeddings).toHaveBeenCalledWith(
+      ['first', 'second'],
+      'configured-cohere-model'
+    );
+  });
+
+  it('delegates top-level helper exports to the singleton manager', async () => {
+    initializeEmbeddingsWithConfig(createEmbeddingConfig('voyage', { model: 'voyage-configured-model' }));
+
+    await generateEmbedding('singleton-single');
+    await generateBatchEmbeddings(['singleton-batch']);
+
+    expect(providerStubs.voyage.generateEmbedding).toHaveBeenCalledWith(
+      'singleton-single',
+      'voyage-configured-model'
+    );
+    expect(providerStubs.voyage.generateBatchEmbeddings).toHaveBeenCalledWith(
+      ['singleton-batch'],
+      'voyage-configured-model'
+    );
+  });
+
+  it('uses the resolved default env model when no model override is supplied', async () => {
+    const manager = new EmbeddingManager();
+    manager.initialize(createEmbeddingConfig('ollama', { model: 'nomic-embed-text', apiKey: '' }));
+
+    await manager.generateEmbedding('local text');
+
+    expect(providerStubs.ollama.generateEmbedding).toHaveBeenCalledWith('local text', 'nomic-embed-text');
+  });
+});

--- a/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
@@ -74,6 +74,15 @@ describe('EmbeddingManager initialization', () => {
     );
   });
 
+  it('rejects invalid env providers before model resolution', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('custom');
+
+    expect(() => manager.initializeFromEnv()).toThrow('Unknown embedding provider: custom');
+    expect(mockGetEmbeddingModel).not.toHaveBeenCalled();
+  });
+
   it('throws when configuration is requested before initialization', () => {
     const manager = new EmbeddingManager();
 

--- a/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EmbeddingManager,
+  createEmbeddingConfig,
+  embeddingManager,
+  initializeEmbeddings,
+  initializeEmbeddingsWithConfig,
+  mockGetEmbeddingModel,
+  mockGetEmbeddingProvider,
+  mockGetOllamaBaseUrl,
+  mockGetOpenAIApiKey,
+  mockOllamaEmbeddingProvider,
+  mockOpenAIEmbeddingProvider,
+} from './shared.js';
+
+describe('EmbeddingManager initialization', () => {
+  it('stores configuration and creates the configured provider', () => {
+    const manager = new EmbeddingManager();
+    const config = createEmbeddingConfig('openai');
+
+    manager.initialize(config);
+
+    expect(manager.isInitialized()).toBe(true);
+    expect(manager.getConfig()).toEqual(config);
+    expect(mockOpenAIEmbeddingProvider).toHaveBeenCalledWith('openai-api-key');
+  });
+
+  it('initializes from env using the configured provider and explicit env model', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('openai');
+    mockGetEmbeddingModel.mockReturnValue('env-openai-model');
+    mockGetOpenAIApiKey.mockReturnValue('env-key');
+
+    manager.initializeFromEnv();
+
+    expect(mockOpenAIEmbeddingProvider).toHaveBeenCalledWith('env-key');
+    expect(manager.getConfig()).toEqual({
+      provider: 'openai',
+      model: 'env-openai-model',
+      apiKey: '',
+    });
+  });
+
+  it('falls back to the provider default model for ollama env initialization', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('ollama');
+    mockGetEmbeddingModel.mockReturnValue(undefined);
+    mockGetOllamaBaseUrl.mockReturnValue('http://ollama.local:11434');
+
+    manager.initializeFromEnv();
+
+    expect(mockOllamaEmbeddingProvider).toHaveBeenCalledWith(
+      'nomic-embed-text',
+      'http://ollama.local:11434'
+    );
+    expect(manager.getConfig()).toEqual({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      apiKey: '',
+    });
+  });
+
+  it('throws a helpful error when required env credentials are missing', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('openai');
+    mockGetOpenAIApiKey.mockReturnValue(undefined);
+
+    expect(() => manager.initializeFromEnv()).toThrow(
+      'OPENAI_API_KEY environment variable is required for OpenAI embeddings'
+    );
+  });
+
+  it('throws when configuration is requested before initialization', () => {
+    const manager = new EmbeddingManager();
+
+    expect(() => manager.getConfig()).toThrow(
+      'Embedding manager not initialized. Call initialize() or initializeFromEnv() first.'
+    );
+    expect(() => manager.getProvider()).toThrow(
+      'Embedding manager not initialized. Call initialize() or initializeFromEnv() first.'
+    );
+  });
+
+  it('supports the singleton initialization helpers', () => {
+    initializeEmbeddingsWithConfig(createEmbeddingConfig('cohere'));
+
+    expect(embeddingManager.isInitialized()).toBe(true);
+
+    embeddingManager.reset();
+    initializeEmbeddings();
+
+    expect(embeddingManager.isInitialized()).toBe(true);
+  });
+});

--- a/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/initialization.suite.ts
@@ -63,6 +63,22 @@ describe('EmbeddingManager initialization', () => {
     });
   });
 
+  it('treats an empty env model as missing and falls back to the provider default', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('openai');
+    mockGetEmbeddingModel.mockReturnValue('');
+    mockGetOpenAIApiKey.mockReturnValue('env-key');
+
+    manager.initializeFromEnv();
+
+    expect(manager.getConfig()).toEqual({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      apiKey: '',
+    });
+  });
+
   it('throws a helpful error when required env credentials are missing', () => {
     const manager = new EmbeddingManager();
 

--- a/packages/tools/tests/data/neo4j/embedding-manager/provider-selection.suite.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/provider-selection.suite.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EmbeddingManager,
+  createEmbeddingConfig,
+  mockCohereEmbeddingProvider,
+  mockGetEmbeddingProvider,
+  mockHuggingFaceEmbeddingProvider,
+  mockOllamaEmbeddingProvider,
+  mockOpenAIEmbeddingProvider,
+  mockVoyageEmbeddingProvider,
+} from './shared.js';
+
+describe('EmbeddingManager provider selection', () => {
+  it('creates the OpenAI provider for openai configs', () => {
+    const manager = new EmbeddingManager();
+
+    manager.initialize(createEmbeddingConfig('openai'));
+
+    expect(mockOpenAIEmbeddingProvider).toHaveBeenCalledWith('openai-api-key');
+  });
+
+  it('creates the Cohere provider for cohere configs', () => {
+    const manager = new EmbeddingManager();
+
+    manager.initialize(createEmbeddingConfig('cohere'));
+
+    expect(mockCohereEmbeddingProvider).toHaveBeenCalledWith('cohere-api-key');
+  });
+
+  it('creates the HuggingFace provider for huggingface configs', () => {
+    const manager = new EmbeddingManager();
+
+    manager.initialize(createEmbeddingConfig('huggingface'));
+
+    expect(mockHuggingFaceEmbeddingProvider).toHaveBeenCalledWith('huggingface-api-key');
+  });
+
+  it('creates the Voyage provider for voyage configs', () => {
+    const manager = new EmbeddingManager();
+
+    manager.initialize(createEmbeddingConfig('voyage'));
+
+    expect(mockVoyageEmbeddingProvider).toHaveBeenCalledWith('voyage-api-key');
+  });
+
+  it('creates the Ollama provider for ollama configs', () => {
+    const manager = new EmbeddingManager();
+
+    manager.initialize(createEmbeddingConfig('ollama', { apiKey: '' }));
+
+    expect(mockOllamaEmbeddingProvider).toHaveBeenCalledWith(undefined, 'http://localhost:11434');
+  });
+
+  it('rejects unknown providers returned from environment resolution', () => {
+    const manager = new EmbeddingManager();
+
+    mockGetEmbeddingProvider.mockReturnValue('custom');
+
+    expect(() => manager.initializeFromEnv()).toThrow('Unknown embedding provider: custom');
+  });
+});

--- a/packages/tools/tests/data/neo4j/embedding-manager/shared.ts
+++ b/packages/tools/tests/data/neo4j/embedding-manager/shared.ts
@@ -1,0 +1,195 @@
+import { beforeEach, vi } from 'vitest';
+
+import type {
+  BatchEmbeddingResult,
+  EmbeddingConfig,
+  EmbeddingProvider,
+  EmbeddingResult,
+} from '../../../../src/data/neo4j/embeddings/types.js';
+
+type AvailabilityFn = () => boolean;
+type GenerateEmbeddingFn = (text: string, model?: string) => Promise<EmbeddingResult>;
+type GenerateBatchEmbeddingsFn = (texts: string[], model?: string) => Promise<BatchEmbeddingResult>;
+
+export interface ProviderStub {
+  readonly name: EmbeddingProvider;
+  readonly defaultModel: string;
+  readonly isAvailable: ReturnType<typeof vi.fn<AvailabilityFn>>;
+  readonly generateEmbedding: ReturnType<typeof vi.fn<GenerateEmbeddingFn>>;
+  readonly generateBatchEmbeddings: ReturnType<typeof vi.fn<GenerateBatchEmbeddingsFn>>;
+}
+
+function createProviderStub(name: EmbeddingProvider, defaultModel: string): ProviderStub {
+  return {
+    name,
+    defaultModel,
+    isAvailable: vi.fn<AvailabilityFn>(() => true),
+    generateEmbedding: vi.fn<GenerateEmbeddingFn>(),
+    generateBatchEmbeddings: vi.fn<GenerateBatchEmbeddingsFn>(),
+  };
+}
+
+const hoisted = vi.hoisted(() => {
+  const providerStubs = {
+    openai: createProviderStub('openai', 'text-embedding-3-small'),
+    cohere: createProviderStub('cohere', 'embed-english-v3.0'),
+    huggingface: createProviderStub('huggingface', 'sentence-transformers/all-MiniLM-L6-v2'),
+    voyage: createProviderStub('voyage', 'voyage-2'),
+    ollama: createProviderStub('ollama', 'nomic-embed-text'),
+  } satisfies Record<EmbeddingProvider, ProviderStub>;
+
+  return {
+    providerStubs,
+    mockOpenAIEmbeddingProvider: vi.fn<(apiKey?: string) => ProviderStub>(),
+    mockCohereEmbeddingProvider: vi.fn<(apiKey?: string) => ProviderStub>(),
+    mockHuggingFaceEmbeddingProvider: vi.fn<(apiKey?: string) => ProviderStub>(),
+    mockVoyageEmbeddingProvider: vi.fn<(apiKey?: string) => ProviderStub>(),
+    mockOllamaEmbeddingProvider: vi.fn<(model?: string, baseUrl?: string) => ProviderStub>(),
+    mockGetEmbeddingProvider: vi.fn<() => string>(),
+    mockGetEmbeddingModel: vi.fn<() => string | undefined>(),
+    mockGetOpenAIApiKey: vi.fn<() => string | undefined>(),
+    mockGetCohereApiKey: vi.fn<() => string | undefined>(),
+    mockGetHuggingFaceApiKey: vi.fn<() => string | undefined>(),
+    mockGetVoyageApiKey: vi.fn<() => string | undefined>(),
+    mockGetOllamaBaseUrl: vi.fn<() => string>(),
+  };
+});
+
+vi.mock('../../../../src/data/neo4j/embeddings/providers/openai.js', () => ({
+  OpenAIEmbeddingProvider: hoisted.mockOpenAIEmbeddingProvider,
+}));
+
+vi.mock('../../../../src/data/neo4j/embeddings/providers/cohere.js', () => ({
+  CohereEmbeddingProvider: hoisted.mockCohereEmbeddingProvider,
+}));
+
+vi.mock('../../../../src/data/neo4j/embeddings/providers/huggingface.js', () => ({
+  HuggingFaceEmbeddingProvider: hoisted.mockHuggingFaceEmbeddingProvider,
+}));
+
+vi.mock('../../../../src/data/neo4j/embeddings/providers/voyage.js', () => ({
+  VoyageEmbeddingProvider: hoisted.mockVoyageEmbeddingProvider,
+}));
+
+vi.mock('../../../../src/data/neo4j/embeddings/providers/ollama.js', () => ({
+  OllamaEmbeddingProvider: hoisted.mockOllamaEmbeddingProvider,
+}));
+
+vi.mock('../../../../src/data/neo4j/embeddings/utils.js', () => ({
+  getEmbeddingProvider: hoisted.mockGetEmbeddingProvider,
+  getEmbeddingModel: hoisted.mockGetEmbeddingModel,
+  getOpenAIApiKey: hoisted.mockGetOpenAIApiKey,
+  getCohereApiKey: hoisted.mockGetCohereApiKey,
+  getHuggingFaceApiKey: hoisted.mockGetHuggingFaceApiKey,
+  getVoyageApiKey: hoisted.mockGetVoyageApiKey,
+  getOllamaBaseUrl: hoisted.mockGetOllamaBaseUrl,
+}));
+
+import * as embeddingManagerModule from '../../../../src/data/neo4j/embeddings/embedding-manager.js';
+
+export const EmbeddingManager = embeddingManagerModule.EmbeddingManager;
+export const embeddingManager = embeddingManagerModule.embeddingManager;
+export const generateBatchEmbeddings = embeddingManagerModule.generateBatchEmbeddings;
+export const generateEmbedding = embeddingManagerModule.generateEmbedding;
+export const initializeEmbeddings = embeddingManagerModule.initializeEmbeddings;
+export const initializeEmbeddingsWithConfig = embeddingManagerModule.initializeEmbeddingsWithConfig;
+
+export const providerStubs = hoisted.providerStubs;
+export const mockOpenAIEmbeddingProvider = hoisted.mockOpenAIEmbeddingProvider;
+export const mockCohereEmbeddingProvider = hoisted.mockCohereEmbeddingProvider;
+export const mockHuggingFaceEmbeddingProvider = hoisted.mockHuggingFaceEmbeddingProvider;
+export const mockVoyageEmbeddingProvider = hoisted.mockVoyageEmbeddingProvider;
+export const mockOllamaEmbeddingProvider = hoisted.mockOllamaEmbeddingProvider;
+export const mockGetEmbeddingProvider = hoisted.mockGetEmbeddingProvider;
+export const mockGetEmbeddingModel = hoisted.mockGetEmbeddingModel;
+export const mockGetOpenAIApiKey = hoisted.mockGetOpenAIApiKey;
+export const mockGetCohereApiKey = hoisted.mockGetCohereApiKey;
+export const mockGetHuggingFaceApiKey = hoisted.mockGetHuggingFaceApiKey;
+export const mockGetVoyageApiKey = hoisted.mockGetVoyageApiKey;
+export const mockGetOllamaBaseUrl = hoisted.mockGetOllamaBaseUrl;
+
+export function createEmbeddingConfig(
+  provider: EmbeddingProvider,
+  overrides: Partial<EmbeddingConfig> = {}
+): EmbeddingConfig {
+  return {
+    provider,
+    model: overrides.model ?? `configured-${provider}-model`,
+    apiKey: overrides.apiKey ?? `${provider}-api-key`,
+    dimensions: overrides.dimensions,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  embeddingManager.reset();
+
+  hoisted.mockOpenAIEmbeddingProvider.mockImplementation(() => providerStubs.openai);
+  hoisted.mockCohereEmbeddingProvider.mockImplementation(() => providerStubs.cohere);
+  hoisted.mockHuggingFaceEmbeddingProvider.mockImplementation(() => providerStubs.huggingface);
+  hoisted.mockVoyageEmbeddingProvider.mockImplementation(() => providerStubs.voyage);
+  hoisted.mockOllamaEmbeddingProvider.mockImplementation(() => providerStubs.ollama);
+
+  hoisted.mockGetEmbeddingProvider.mockReturnValue('openai');
+  hoisted.mockGetEmbeddingModel.mockReturnValue(undefined);
+  hoisted.mockGetOpenAIApiKey.mockReturnValue('env-openai-key');
+  hoisted.mockGetCohereApiKey.mockReturnValue('env-cohere-key');
+  hoisted.mockGetHuggingFaceApiKey.mockReturnValue('env-huggingface-key');
+  hoisted.mockGetVoyageApiKey.mockReturnValue('env-voyage-key');
+  hoisted.mockGetOllamaBaseUrl.mockReturnValue('http://localhost:11434');
+
+  providerStubs.openai.generateEmbedding.mockResolvedValue({
+    embedding: [0.1, 0.2, 0.3],
+    model: 'text-embedding-3-small',
+    dimensions: 3,
+  });
+  providerStubs.openai.generateBatchEmbeddings.mockResolvedValue({
+    embeddings: [[0.1, 0.2, 0.3]],
+    model: 'text-embedding-3-small',
+    dimensions: 3,
+  });
+
+  providerStubs.cohere.generateEmbedding.mockResolvedValue({
+    embedding: [0.4, 0.5],
+    model: 'embed-english-v3.0',
+    dimensions: 2,
+  });
+  providerStubs.cohere.generateBatchEmbeddings.mockResolvedValue({
+    embeddings: [[0.4, 0.5]],
+    model: 'embed-english-v3.0',
+    dimensions: 2,
+  });
+
+  providerStubs.huggingface.generateEmbedding.mockResolvedValue({
+    embedding: [0.6],
+    model: 'sentence-transformers/all-MiniLM-L6-v2',
+    dimensions: 1,
+  });
+  providerStubs.huggingface.generateBatchEmbeddings.mockResolvedValue({
+    embeddings: [[0.6]],
+    model: 'sentence-transformers/all-MiniLM-L6-v2',
+    dimensions: 1,
+  });
+
+  providerStubs.voyage.generateEmbedding.mockResolvedValue({
+    embedding: [0.7, 0.8],
+    model: 'voyage-2',
+    dimensions: 2,
+  });
+  providerStubs.voyage.generateBatchEmbeddings.mockResolvedValue({
+    embeddings: [[0.7, 0.8]],
+    model: 'voyage-2',
+    dimensions: 2,
+  });
+
+  providerStubs.ollama.generateEmbedding.mockResolvedValue({
+    embedding: [0.9, 1.0],
+    model: 'nomic-embed-text',
+    dimensions: 2,
+  });
+  providerStubs.ollama.generateBatchEmbeddings.mockResolvedValue({
+    embeddings: [[0.9, 1.0]],
+    model: 'nomic-embed-text',
+    dimensions: 2,
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2923,18 +2923,22 @@ Implementation notes:
 **Branch:** `refactor/st-09069-neo4j-embedding-manager-modularization`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09069-neo4j-embedding-manager-modularization`
+- [x] Create branch `refactor/st-09069-neo4j-embedding-manager-modularization`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove embedding-manager behavior remains stable while the oversized runtime and test files are split
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Reduce `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` below the 300 line planning cutoff by extracting focused internal modules for provider creation/default-model resolution, environment initialization, and single/batch generation flow behind a stable facade
-- [ ] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
-- [ ] Split embedding-manager coverage into focused test modules so initialization, provider-selection, and batch-generation behavior no longer depends on a single oversized test surface
-- [ ] Preserve existing embedding-manager behavior, provider defaults, environment variable semantics, and public imports
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched embedding-manager modules in story docs
-- [ ] Add or update story documentation at `docs/st09069-neo4j-embedding-manager-modularization.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [x] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove embedding-manager behavior remains stable while the oversized runtime and test files are split
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Test-first note: this story is a behavior-preserving modularization of an already implemented embedding runtime, so a red-first test would only fail by asserting temporary structure rather than stable public behavior. The practical path is characterization-first coverage: add focused public-entry tests for environment initialization, provider selection, and batch/single generation semantics before extracting modules, then use those passing tests as the safety net during the split.
+- [x] Reduce `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` below the 300 line planning cutoff by extracting focused internal modules for provider creation/default-model resolution, environment initialization, and single/batch generation flow behind a stable facade
+- [x] Keep extracted production modules below the 300 line planning cutoff as well; do not satisfy the story by only shrinking the public facade and moving the bulk into a new oversized helper unless an explicit exception is documented in the story notes
+- [x] Split embedding-manager coverage into focused test modules so initialization, provider-selection, and batch-generation behavior no longer depends on a single oversized test surface
+- [x] Preserve existing embedding-manager behavior, provider defaults, environment variable semantics, and public imports
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+  - `pnpm test --run packages/tools/tests/data/neo4j/embedding-manager.test.ts` -> `1` file passed, `16` tests passed
+  - `pnpm --filter @agentforge/tools typecheck` -> passed
+- [x] Record explicit-`any` warning deltas and file-size/responsibility improvements for touched embedding-manager modules in story docs
+- [x] Add or update story documentation at `docs/st09069-neo4j-embedding-manager-modularization.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - No additional automated coverage was required beyond the new focused embedding-manager suites; the broader Neo4j integration surface remains in `packages/tools/tests/data/neo4j.test.ts`.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2924,7 +2924,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `refactor/st-09069-neo4j-embedding-manager-modularization`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #138: https://github.com/TVScoundrel/agentforge/pull/138
 - [x] Define test strategy before implementation: cover runtime modularization and test-file modularization; first failing test should prove embedding-manager behavior remains stable while the oversized runtime and test files are split
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
   - Test-first note: this story is a behavior-preserving modularization of an already implemented embedding runtime, so a red-first test would only fail by asserting temporary structure rather than stable public behavior. The practical path is characterization-first coverage: add focused public-entry tests for environment initialization, provider selection, and batch/single generation semantics before extracting modules, then use those passing tests as the safety net during the split.
@@ -2939,8 +2940,10 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09069-neo4j-embedding-manager-modularization.md` (or document why not required)
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
   - No additional automated coverage was required beyond the new focused embedding-manager suites; the broader Neo4j integration surface remains in `packages/tools/tests/data/neo4j.test.ts`.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `212 passed | 18 skipped` files; `2340 passed | 286 skipped` tests
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; warnings only (`0` errors)
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -2944,7 +2944,9 @@ Implementation notes:
   - `pnpm test --run` -> `212 passed | 18 skipped` files; `2340 passed | 286 skipped` tests
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; warnings only (`0` errors)
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
+  - `7da3a17e` refactor(st-09069): modularize neo4j embedding manager
+  - `64352b7f` docs(st-09069): record embedding manager validation
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2024,7 +2024,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** None
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` is reduced below the 300 line planning cutoff by extracting focused internal modules for provider creation/default-model resolution, environment-based initialization, and single/batch generation flow behind a stable public facade, and the extracted production modules must also stay below `300` lines unless the story documents and justifies an explicit exception.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2024,7 +2024,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 4 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` is reduced below the 300 line planning cutoff by extracting focused internal modules for provider creation/default-model resolution, environment-based initialization, and single/batch generation flow behind a stable public facade, and the extracted production modules must also stay below `300` lines unless the story documents and justifies an explicit exception.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-18
-**Active Story:** ST-09069 - Modularize Neo4j Embedding Manager and Tests (In Progress)
+**Active Story:** ST-09069 - Modularize Neo4j Embedding Manager and Tests (In Review)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-06-17
-**Active Story:** ST-09069 - Modularize Neo4j Embedding Manager and Tests (Ready)
+**Last Updated:** 2026-06-18
+**Active Story:** ST-09069 - Modularize Neo4j Embedding Manager and Tests (In Progress)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 5 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -24,13 +24,13 @@
 
 ## In Progress
 
-- `ST-09069` - Modularize Neo4j Embedding Manager and Tests
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09069` - Modularize Neo4j Embedding Manager and Tests
 
 ## Blocked
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-06-17
+**Last Updated:** 2026-06-18
 
 ## Queue Status Summary
 
-- **Ready:** 6 stories
-- **In Progress:** 0 stories
+- **Ready:** 5 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09069` - Modularize Neo4j Embedding Manager and Tests
 - `ST-09070` - Modularize Multi-Agent Utilities and Tests
 - `ST-09071` - Modularize Skill Activation Runtime and Tests
 - `ST-09072` - Modularize Relational Insert Executor and Tests
@@ -25,7 +24,7 @@
 
 ## In Progress
 
-None currently.
+- `ST-09069` - Modularize Neo4j Embedding Manager and Tests
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09069 - Modularize Neo4j Embedding Manager and Tests

## What Changed
- split `packages/tools/src/data/neo4j/embeddings/embedding-manager.ts` into a stable public facade plus focused provider-factory, environment-resolution, generation-flow, and shared state helpers
- added focused embedding-manager characterization coverage at `packages/tools/tests/data/neo4j/embedding-manager.test.ts` with dedicated initialization, provider-selection, and generation suites
- updated the EP-09 tracker, checklist, and story documentation for the review-ready modularization slice

## Acceptance Criteria Coverage
- reduced `embedding-manager.ts` below the 300-line planning cutoff while keeping all extracted runtime helpers below the same threshold
- replaced the single embedding-manager test surface with focused suites for initialization, provider selection, and batch/single generation behavior
- preserved public embedding-manager behavior, provider defaults, environment-variable semantics, and public imports behind the existing facade
- recorded file-size and explicit-`any` baseline evidence in `docs/st09069-neo4j-embedding-manager-modularization.md`

## Test Strategy
- characterization-first refactor coverage: add focused public-entry tests before completing the runtime split, then use those passing tests as the refactor guardrail
- no red-first behavior assertion was practical because this story is structural and the existing runtime already implemented the target behavior

## Validation Performed
- `pnpm test --run packages/tools/tests/data/neo4j/embedding-manager.test.ts`
- `pnpm --filter @agentforge/tools typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status
- Ready for review
- Full validation passed: `212 passed | 18 skipped` files, `2340 passed | 286 skipped` tests
- Lint passed with warnings only and no errors
