### PR TITLE
ST-09075: Harden ReAct Agent Detection Beyond Constructor Names

### DIFF
--- a/docs/st09075-react-agent-detection-hardening.md
+++ b/docs/st09075-react-agent-detection-hardening.md
@@ -1,0 +1,28 @@
+# ST-09075: Harden ReAct Agent Detection Beyond Constructor Names
+
+## Summary
+
+`isReActAgent(...)` previously treated `CompiledGraph` and `CompiledStateGraph` constructor names as the deciding runtime signal once `invoke` and `stream` were present. That works in today's LangGraph build, but it is brittle if those class names are minified or otherwise rewritten. This story hardens detection by preferring stable compiled-graph runtime shape evidence and keeping constructor names only as a compatibility fallback.
+
+## Implementation
+
+- Added layered detection in `packages/patterns/src/multi-agent/utils-react-detection.ts`.
+- The new primary path accepts objects that expose the compiled LangGraph runtime shape we actually depend on: `invoke`, `stream`, `getGraph`, `getGraphAsync`, and a `builder` with graph-construction methods.
+- Preserved the old `CompiledGraph` / `CompiledStateGraph` constructor-name check as a fallback so the existing characterization fixture and any lightweight compatible wrappers still pass unchanged.
+
+## Test Strategy
+
+This story used a focused red-first regression test because the public contract is small and directly testable. The new test creates a real compiled ReAct agent, masks its constructor name, and proves `isReActAgent(...)` should still return `true` when the compiled runtime shape remains intact. That assertion failed before the implementation change and passed afterward.
+
+## Validation
+
+- Red-first run: `./node_modules/.bin/vitest run --config .tmp/vitest.st09075.config.mjs` -> failed with `expected false to be true` for the masked-constructor compiled agent fixture
+- Focused utility suites: `./node_modules/.bin/vitest run --config .tmp/vitest.st09075.config.mjs` -> `2` passed files, `9` passed tests
+- Package typecheck: `pnpm --filter @agentforge/patterns typecheck` -> passed
+- Explicit-`any` baseline: `pnpm lint:explicit-any:baseline` -> passed at `workspace 80/289`, `patterns 2/28`
+
+## Compatibility Notes
+
+- Public imports and the `isReActAgent(...)` signature are unchanged.
+- Existing constructor-name-based positive fixtures still pass, but real compiled LangGraph instances no longer depend on those names staying stable.
+- No CI workflow change was required for this story; the existing validation surface was sufficient once the focused `.suite.ts` runner was invoked explicitly.

--- a/packages/patterns/src/multi-agent/utils-react-detection.ts
+++ b/packages/patterns/src/multi-agent/utils-react-detection.ts
@@ -1,5 +1,41 @@
 import type { ReActAgentGraph } from './utils-shared.js';
 
+function isKnownCompiledGraphName(name: unknown): boolean {
+  return name === 'CompiledGraph' || name === 'CompiledStateGraph';
+}
+
+function hasFunctionProperty(
+  value: Record<string, unknown>,
+  key: string
+): boolean {
+  return key in value && typeof value[key] === 'function';
+}
+
+function hasCompiledGraphBuilder(value: Record<string, unknown>): boolean {
+  if (!('builder' in value) || typeof value.builder !== 'object' || value.builder === null) {
+    return false;
+  }
+
+  const builder = value.builder as Record<string, unknown>;
+
+  return (
+    hasFunctionProperty(builder, 'addNode') &&
+    hasFunctionProperty(builder, 'addEdge') &&
+    hasFunctionProperty(builder, 'compile') &&
+    hasFunctionProperty(builder, 'validate')
+  );
+}
+
+function hasCompiledGraphRuntimeShape(value: Record<string, unknown>): boolean {
+  return (
+    hasFunctionProperty(value, 'invoke') &&
+    hasFunctionProperty(value, 'stream') &&
+    hasFunctionProperty(value, 'getGraph') &&
+    hasFunctionProperty(value, 'getGraphAsync') &&
+    hasCompiledGraphBuilder(value)
+  );
+}
+
 /**
  * Check if an object is a ReAct agent (CompiledStateGraph)
  *
@@ -10,14 +46,16 @@ import type { ReActAgentGraph } from './utils-shared.js';
  * @returns True if the object appears to be a ReAct agent
  */
 export function isReActAgent(obj: unknown): obj is ReActAgentGraph {
-  return Boolean(
-    obj &&
-      typeof obj === 'object' &&
-      'invoke' in obj &&
-      typeof obj.invoke === 'function' &&
-      'stream' in obj &&
-      typeof obj.stream === 'function' &&
-      (obj.constructor?.name === 'CompiledGraph' ||
-        obj.constructor?.name === 'CompiledStateGraph')
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+
+  const candidate = obj as Record<string, unknown>;
+
+  return (
+    hasCompiledGraphRuntimeShape(candidate) ||
+    (hasFunctionProperty(candidate, 'invoke') &&
+      hasFunctionProperty(candidate, 'stream') &&
+      isKnownCompiledGraphName(candidate.constructor?.name))
   );
 }

--- a/packages/patterns/tests/multi-agent/utils/detection.suite.ts
+++ b/packages/patterns/tests/multi-agent/utils/detection.suite.ts
@@ -6,6 +6,8 @@ import { isReActAgent } from '../../../src/multi-agent/utils.js';
 
 describe('Multi-Agent Utils detection', () => {
   it('accepts compiled state-graph shaped agents', () => {
+    // Keep the lightweight constructor-name fixture as a compatibility guard
+    // for wrappers that do not expose the full compiled-graph runtime shape.
     const compiledStateGraphLike = {
       invoke: vi.fn(),
       stream: vi.fn(),

--- a/packages/patterns/tests/multi-agent/utils/detection.suite.ts
+++ b/packages/patterns/tests/multi-agent/utils/detection.suite.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { ToolRegistry } from '@agentforge/core';
+import { createMockLLM } from '@agentforge/testing';
+import { createReActAgent } from '../../../src/react/agent.js';
 import { isReActAgent } from '../../../src/multi-agent/utils.js';
 
 describe('Multi-Agent Utils detection', () => {
@@ -10,6 +13,21 @@ describe('Multi-Agent Utils detection', () => {
     };
 
     expect(isReActAgent(compiledStateGraphLike)).toBe(true);
+  });
+
+  it('accepts compiled ReAct agents even when the constructor name is unstable', () => {
+    const compiledAgent = createReActAgent({
+      model: createMockLLM({ responses: ['Mock response'] }) as any,
+      tools: new ToolRegistry(),
+    });
+    const maskedConstructorAgent = Object.create(compiledAgent) as typeof compiledAgent;
+
+    Object.defineProperty(maskedConstructorAgent, 'constructor', {
+      value: { name: 'a' },
+      configurable: true,
+    });
+
+    expect(isReActAgent(maskedConstructorAgent)).toBe(true);
   });
 
   it('rejects objects that only partially match the interface', () => {

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3201,7 +3201,8 @@ Implementation notes:
   - `pnpm lint` -> passed with existing warning-only baseline; touched `patterns` package remained warning-only and the explicit-`any` baseline still held at `workspace 80/289`, `patterns 2/28`
 - [x] Commit completed checklist items as logical commits and push updates
   - Commit `5cd72ba9` (`refactor(st-09075): harden react agent detection`) pushed to `origin/refactor/st-09075-react-agent-detection-hardening`
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #145 marked ready for review on 2026-06-29 after validation, self-review, and tracker sync were complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3174,7 +3174,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `refactor/st-09075-react-agent-detection-hardening`
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - PR #145: https://github.com/TVScoundrel/agentforge/pull/145
 - [x] Define test strategy before implementation: cover the public `isReActAgent(...)` contract and prove the replacement detection path no longer depends solely on constructor names remaining stable
   - Selected a focused red-first regression path because the public contract is small and directly testable: mask a real compiled ReAct agent's constructor name, prove detection should still succeed, then harden the runtime guard behind the unchanged public API.
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
@@ -3198,7 +3199,8 @@ Implementation notes:
   - `pnpm test --run` -> passed with `222` files passed, `9` skipped; `2506` tests passed, `110` skipped
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> passed with existing warning-only baseline; touched `patterns` package remained warning-only and the explicit-`any` baseline still held at `workspace 80/289`, `patterns 2/28`
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
+  - Commit `5cd72ba9` (`refactor(st-09075): harden react agent detection`) pushed to `origin/refactor/st-09075-react-agent-detection-hardening`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3173,19 +3173,31 @@ Implementation notes:
 **Branch:** `refactor/st-09075-react-agent-detection-hardening`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09075-react-agent-detection-hardening`
+- [x] Create branch `refactor/st-09075-react-agent-detection-hardening`
 - [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover the public `isReActAgent(...)` contract and prove the replacement detection path no longer depends solely on constructor names remaining stable
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace the constructor-name-only `CompiledGraph`/`CompiledStateGraph` detection in `packages/patterns/src/multi-agent/utils-react-detection.ts` with a more durable runtime-shape check, compatibility helper, or layered strategy behind the same public API
-- [ ] Preserve existing supported ReAct-agent detection behavior and public imports while removing the minification-sensitive coupling
-- [ ] Add/update focused detection tests so positive and negative fixtures cover the new detection path and explicitly guard against silent constructor-name fallback regressions
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas and the runtime-detection compatibility rationale for touched modules in story docs
-- [ ] Add or update story documentation at `docs/st09075-react-agent-detection-hardening.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Define test strategy before implementation: cover the public `isReActAgent(...)` contract and prove the replacement detection path no longer depends solely on constructor names remaining stable
+  - Selected a focused red-first regression path because the public contract is small and directly testable: mask a real compiled ReAct agent's constructor name, prove detection should still succeed, then harden the runtime guard behind the unchanged public API.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Added a regression test that creates a real compiled ReAct agent, overrides its constructor name to simulate minification/rewriting, and initially failed with `expected false to be true`.
+- [x] Replace the constructor-name-only `CompiledGraph`/`CompiledStateGraph` detection in `packages/patterns/src/multi-agent/utils-react-detection.ts` with a more durable runtime-shape check, compatibility helper, or layered strategy behind the same public API
+  - `isReActAgent(...)` now prefers compiled LangGraph runtime-shape evidence (`invoke`, `stream`, `getGraph`, `getGraphAsync`, and a graph-like `builder`) while keeping constructor names only as a compatibility fallback.
+- [x] Preserve existing supported ReAct-agent detection behavior and public imports while removing the minification-sensitive coupling
+  - Existing constructor-name fixtures still pass, and the public `isReActAgent(...)` export/signature is unchanged.
+- [x] Add/update focused detection tests so positive and negative fixtures cover the new detection path and explicitly guard against silent constructor-name fallback regressions
+  - Added a regression guard for a real compiled ReAct agent with a masked constructor name alongside the existing positive and negative shape fixtures.
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+  - `./node_modules/.bin/vitest run --config .tmp/vitest.st09075.config.mjs` -> initial red run failed with `expected false to be true`; post-fix rerun passed with `2` files and `9` tests
+  - `pnpm --filter @agentforge/patterns typecheck` -> passed
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 80/289`, `patterns 2/28`
+- [x] Record explicit-`any` warning deltas and the runtime-detection compatibility rationale for touched modules in story docs
+  - Recorded in `docs/st09075-react-agent-detection-hardening.md`; explicit-`any` baseline remains flat at `workspace 80/289`, `patterns 2/28`
+- [x] Add or update story documentation at `docs/st09075-react-agent-detection-hardening.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - The focused detection regression plus the companion wrap-agent utility suite cover the changed runtime guard; no further targeted automation was required before broader repo validation.
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> passed with `222` files passed, `9` skipped; `2506` tests passed, `110` skipped
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with existing warning-only baseline; touched `patterns` package remained warning-only and the explicit-`any` baseline still held at `workspace 80/289`, `patterns 2/28`
 - [ ] Commit completed checklist items as logical commits and push updates
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2126,7 +2126,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-09070 (merged)
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/multi-agent/utils-react-detection.ts` replaces the current constructor-name-only `CompiledGraph`/`CompiledStateGraph` gate with a more durable runtime-shape check, compatibility helper, or layered detection strategy that does not rely solely on constructor names remaining stable.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-06-28
-**Active Story:** ST-09075 - Harden ReAct Agent Detection Beyond Constructor Names (Ready)
+**Active Story:** ST-09075 - Harden ReAct Agent Detection Beyond Constructor Names (In Progress)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-06-28
-**Active Story:** ST-09075 - Harden ReAct Agent Detection Beyond Constructor Names (In Progress)
+**Last Updated:** 2026-06-29
+**Active Story:** ST-09075 - Harden ReAct Agent Detection Beyond Constructor Names (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-06-28
+**Last Updated:** 2026-06-29
 
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -19,14 +19,14 @@
 
 ---
 
-## In Progress
+## In Review
 
 - `ST-09075` - Harden ReAct Agent Detection Beyond Constructor Names
   - Depends on: `ST-09070` (merged 2026-06-23)
 
 ---
 
-## In Review
+## In Progress
 
 None currently.
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-09075` - Harden ReAct Agent Detection Beyond Constructor Names
-  - Depends on: `ST-09070` (merged 2026-06-23)
 - `ST-09076` - Align Wrapped ReAct Error Assignment Selection
   - Depends on: `ST-09070` (merged 2026-06-23)
 
@@ -23,7 +21,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-09075` - Harden ReAct Agent Detection Beyond Constructor Names
+  - Depends on: `ST-09070` (merged 2026-06-23)
 
 ---
 


### PR DESCRIPTION
## Story
- ST-09075 - Harden ReAct Agent Detection Beyond Constructor Names

## What Changed
- hardened `isReActAgent(...)` so it prefers stable compiled-LangGraph runtime shape evidence instead of relying solely on `CompiledGraph` / `CompiledStateGraph` constructor names
- kept constructor-name detection as a compatibility fallback for existing lightweight fixtures and wrappers
- added a regression test that uses a real compiled ReAct agent with a masked constructor name to guard against minification-sensitive detection regressions
- recorded story evidence in `docs/st09075-react-agent-detection-hardening.md` and updated the EP-09 checklist / queue state

## Acceptance Criteria Coverage
- replaced constructor-name-only detection with a layered runtime-shape strategy in `packages/patterns/src/multi-agent/utils-react-detection.ts`
- preserved current supported detection behavior and public imports by retaining the compatibility fallback
- added focused regression coverage for constructor-name fragility plus existing positive/negative shape fixtures
- validated with package typecheck, focused utility suites, the explicit-any baseline, full test suite, and full lint run

## Test Strategy
- red-first regression path: add a failing assertion for a real compiled ReAct agent whose constructor name is masked, then harden the runtime guard until the public utility passes again
- broader safety net: rerun the focused multi-agent utility suites, `pnpm --filter @agentforge/patterns typecheck`, `pnpm lint:explicit-any:baseline`, `pnpm test --run`, and `pnpm lint`

## Validation Performed
- `./node_modules/.bin/vitest run --config .tmp/vitest.st09075.config.mjs` (initial red run before deleting the temp config) -> failed with `expected false to be true`
- focused utility rerun -> `2` files passed, `9` tests passed
- `pnpm --filter @agentforge/patterns typecheck` -> passed
- `pnpm lint:explicit-any:baseline` -> passed at `workspace 80/289`, `patterns 2/28`
- `pnpm test --run` -> passed with `222` files passed, `9` skipped; `2506` tests passed, `110` skipped
- `pnpm lint` -> passed with existing warning-only baseline

## Status
- Draft
