### PR TITLE
ST-09088: harden multi-agent runnable config and GraphInterrupt detection

### DIFF
--- a/docs/st09088-multi-agent-runtime-boundary-hardening.md
+++ b/docs/st09088-multi-agent-runtime-boundary-hardening.md
@@ -11,13 +11,13 @@ This story hardens both seams without changing the public multi-agent or shared 
 
 ## Implementation
 
-- Replaced the bare `RunnableConfig` cast in [packages/patterns/src/multi-agent/utils-shared.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/src/multi-agent/utils-shared.ts) with LangChain's own `pickRunnableConfigKeys(...)` helper.
+- Replaced the bare `RunnableConfig` cast in [`packages/patterns/src/multi-agent/utils-shared.ts`](../packages/patterns/src/multi-agent/utils-shared.ts) with LangChain's own `pickRunnableConfigKeys(...)` helper.
 - Added undefined-value cleanup so malformed worker config records collapse to `undefined` instead of forwarding an inert object full of unsupported keys.
 - Preserved supported runtime forwarding for real runnable options such as `configurable.thread_id`, `tags`, `metadata`, and `recursionLimit`.
-- Hardened [packages/patterns/src/shared/error-handling.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/src/shared/error-handling.ts) so interrupt detection accepts either `error.name === 'GraphInterrupt'` or the existing constructor-name compatibility path.
+- Hardened [`packages/patterns/src/shared/error-handling.ts`](../packages/patterns/src/shared/error-handling.ts) so interrupt detection accepts either `error.name === 'GraphInterrupt'` or the existing constructor-name compatibility path.
 - Added focused regression coverage in:
-  - [packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts)
-  - [packages/patterns/tests/shared/error-handling.test.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/tests/shared/error-handling.test.ts)
+  - [`packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts`](../packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts)
+  - [`packages/patterns/tests/shared/error-handling.test.ts`](../packages/patterns/tests/shared/error-handling.test.ts)
 
 ## Test Strategy
 

--- a/docs/st09088-multi-agent-runtime-boundary-hardening.md
+++ b/docs/st09088-multi-agent-runtime-boundary-hardening.md
@@ -1,0 +1,43 @@
+# ST-09088: Harden Multi-Agent Runnable Config and GraphInterrupt Detection
+
+## Summary
+
+The multi-agent patterns layer still had two brittle runtime-boundary shortcuts after the earlier modularization work:
+
+- `toRunnableConfig(...)` accepted any record and cast it straight to `RunnableConfig`, which could leak arbitrary caller keys into wrapped ReAct agent invocation.
+- `isGraphInterrupt(...)` depended on `constructor.name === 'GraphInterrupt'`, which breaks if a compatible interrupt class arrives through a different package boundary or has an unstable constructor name.
+
+This story hardens both seams without changing the public multi-agent or shared error-handling APIs.
+
+## Implementation
+
+- Replaced the bare `RunnableConfig` cast in [packages/patterns/src/multi-agent/utils-shared.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/src/multi-agent/utils-shared.ts) with LangChain's own `pickRunnableConfigKeys(...)` helper.
+- Added undefined-value cleanup so malformed worker config records collapse to `undefined` instead of forwarding an inert object full of unsupported keys.
+- Preserved supported runtime forwarding for real runnable options such as `configurable.thread_id`, `tags`, `metadata`, and `recursionLimit`.
+- Hardened [packages/patterns/src/shared/error-handling.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/src/shared/error-handling.ts) so interrupt detection accepts either `error.name === 'GraphInterrupt'` or the existing constructor-name compatibility path.
+- Added focused regression coverage in:
+  - [packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts)
+  - [packages/patterns/tests/shared/error-handling.test.ts](/Users/tomvanschoor/Projects/Paymentology/agents/langgraph/learning/deepagents/packages/patterns/tests/shared/error-handling.test.ts)
+
+## Test Strategy
+
+This story used red-first focused coverage because both hardening seams are small public runtime boundaries:
+
+- Added a `withErrorHandling(...)` regression that throws a `GraphInterrupt`-named error whose constructor name is unstable.
+- Added wrapped ReAct coverage that proves supported runnable config keys survive worker-thread namespacing while arbitrary caller keys are dropped.
+- Added a malformed-config case to prove arbitrary worker config records now collapse away instead of reaching `agent.invoke(...)`.
+
+## Validation
+
+- Red-first run: `pnpm --filter @agentforge/patterns test --run packages/patterns/tests/multi-agent/utils.test.ts packages/patterns/tests/shared/error-handling.test.ts` -> failed in `rethrows GraphInterrupt-like errors when the constructor name is unstable` because the wrapper returned `{ status: 'failed', error: 'pause for human input' }` instead of rethrowing
+- Focused patterns tests: `pnpm --filter @agentforge/patterns test --run packages/patterns/tests/multi-agent/utils.test.ts packages/patterns/tests/shared/error-handling.test.ts` -> `2` passed files, `15` passed tests
+- Package typecheck: `pnpm --filter @agentforge/patterns typecheck` -> passed
+- Explicit-`any` baseline: `pnpm lint:explicit-any:baseline` -> passed at `workspace 80/289`, `patterns 2/28`
+- Workspace lint: `pnpm lint` -> passed with warnings only (`0` errors); touched `patterns` package remained warning-only
+- Full suite: `pnpm test --run` -> `224` passed, `9` skipped files; `2516` passed, `110` skipped tests
+
+## Compatibility Notes
+
+- Public imports and signatures for `wrapReActAgent(...)`, `toRunnableConfig(...)`, `isGraphInterrupt(...)`, and `withErrorHandling(...)` are unchanged.
+- The old constructor-name compatibility fixture still passes, but interrupt detection no longer depends solely on that fragile signal.
+- No CI workflow change is required for this story because the existing patterns-scoped and workspace validation commands already cover the touched surface.

--- a/packages/patterns/src/multi-agent/utils-shared.ts
+++ b/packages/patterns/src/multi-agent/utils-shared.ts
@@ -1,4 +1,4 @@
-import type { RunnableConfig } from '@langchain/core/runnables';
+import { pickRunnableConfigKeys, type RunnableConfig } from '@langchain/core/runnables';
 import type { CompiledStateGraph } from '@langchain/langgraph';
 import type { WorkerExecutionConfig } from './types.js';
 
@@ -18,6 +18,16 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function removeUndefinedEntries<T extends Record<string, unknown>>(
+  value: T
+): Partial<T> | undefined {
+  const filtered = Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined)
+  ) as Partial<T>;
+
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
 export function toRunnableConfig(
   config: WorkerExecutionConfig | undefined
 ): RunnableConfig | undefined {
@@ -25,7 +35,26 @@ export function toRunnableConfig(
     return undefined;
   }
 
-  return config as RunnableConfig;
+  const runnableConfig = pickRunnableConfigKeys(config);
+
+  if (!runnableConfig || !isRecord(runnableConfig)) {
+    return undefined;
+  }
+
+  const cleanedConfig = removeUndefinedEntries(runnableConfig);
+  if (!cleanedConfig) {
+    return undefined;
+  }
+
+  const { configurable, ...restConfig } = cleanedConfig;
+  const cleanedConfigurable = isRecord(configurable)
+    ? removeUndefinedEntries(configurable)
+    : undefined;
+
+  return {
+    ...restConfig,
+    ...(cleanedConfigurable !== undefined ? { configurable: cleanedConfigurable } : {}),
+  };
 }
 
 export function getReActResultShape(value: unknown): ReActResultShape {

--- a/packages/patterns/src/shared/error-handling.ts
+++ b/packages/patterns/src/shared/error-handling.ts
@@ -13,12 +13,33 @@
  * @param error - The error to check
  * @returns True if the error is a GraphInterrupt
  */
+function getErrorName(error: Record<string, unknown>): string | undefined {
+  return typeof error.name === 'string' ? error.name : undefined;
+}
+
+function getConstructorName(error: Record<string, unknown>): string | undefined {
+  if (!('constructor' in error)) {
+    return undefined;
+  }
+
+  const { constructor } = error;
+  if (constructor !== null && typeof constructor === 'object' && 'name' in constructor) {
+    const constructorName = (constructor as { name?: unknown }).name;
+    return typeof constructorName === 'string' ? constructorName : undefined;
+  }
+
+  return typeof constructor === 'function' ? constructor.name : undefined;
+}
+
 export function isGraphInterrupt(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') {
+    return false;
+  }
+
+  const errorRecord = error as Record<string, unknown>;
   return (
-    error !== null &&
-    typeof error === 'object' &&
-    'constructor' in error &&
-    error.constructor.name === 'GraphInterrupt'
+    getErrorName(errorRecord) === 'GraphInterrupt' ||
+    getConstructorName(errorRecord) === 'GraphInterrupt'
   );
 }
 

--- a/packages/patterns/src/shared/error-handling.ts
+++ b/packages/patterns/src/shared/error-handling.ts
@@ -14,21 +14,35 @@
  * @returns True if the error is a GraphInterrupt
  */
 function getErrorName(error: Record<string, unknown>): string | undefined {
-  return typeof error.name === 'string' ? error.name : undefined;
+  try {
+    return typeof error.name === 'string' ? error.name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function getConstructorName(error: Record<string, unknown>): string | undefined {
-  if (!('constructor' in error)) {
+  let constructorValue: unknown;
+  try {
+    constructorValue = error.constructor;
+  } catch {
     return undefined;
   }
 
-  const { constructor } = error;
-  if (constructor !== null && typeof constructor === 'object' && 'name' in constructor) {
-    const constructorName = (constructor as { name?: unknown }).name;
-    return typeof constructorName === 'string' ? constructorName : undefined;
+  if (constructorValue === undefined) {
+    return undefined;
   }
 
-  return typeof constructor === 'function' ? constructor.name : undefined;
+  if (constructorValue !== null && typeof constructorValue === 'object') {
+    try {
+      const constructorName = (constructorValue as { name?: unknown }).name;
+      return typeof constructorName === 'string' ? constructorName : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return typeof constructorValue === 'function' ? constructorValue.name : undefined;
 }
 
 export function isGraphInterrupt(error: unknown): boolean {
@@ -41,6 +55,18 @@ export function isGraphInterrupt(error: unknown): boolean {
     getErrorName(errorRecord) === 'GraphInterrupt' ||
     getConstructorName(errorRecord) === 'GraphInterrupt'
   );
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  try {
+    return String(error);
+  } catch {
+    return 'Unknown error';
+  }
 }
 
 /**
@@ -78,7 +104,7 @@ export function handleNodeError(
   }
 
   // Extract error message
-  const errorMessage = error instanceof Error ? error.message : String(error);
+  const errorMessage = toErrorMessage(error);
 
   // Log if verbose
   if (verbose) {

--- a/packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts
+++ b/packages/patterns/tests/multi-agent/utils/wrap-react-agent.suite.ts
@@ -191,6 +191,47 @@ describe('Multi-Agent Utils wrapReActAgent', () => {
     });
   });
 
+  it('forwards only runnable config keys while preserving supported options', async () => {
+    const mockReActAgent = createMockReActAgent(async () => createHumanMessageResponse('Done'));
+    const wrappedAgent = wrapReActAgent('worker1', mockReActAgent);
+
+    await wrappedAgent(createWorkerState(), {
+      tags: ['multi-agent'],
+      metadata: { source: 'test' },
+      recursionLimit: 12,
+      configurable: {
+        thread_id: 'parent-thread',
+      },
+      customRuntimeFlag: 'drop-me',
+    });
+
+    expect(mockReActAgent.invoke).toHaveBeenCalledWith(
+      { messages: [{ role: 'user', content: 'Analyze customer feedback data' }] },
+      {
+        tags: ['multi-agent'],
+        metadata: { source: 'test' },
+        recursionLimit: 12,
+        configurable: {
+          thread_id: 'parent-thread:worker:worker1',
+        },
+      }
+    );
+  });
+
+  it('drops malformed worker config values instead of forwarding arbitrary records', async () => {
+    const mockReActAgent = createMockReActAgent(async () => createHumanMessageResponse('Done'));
+    const wrappedAgent = wrapReActAgent('worker1', mockReActAgent);
+
+    await wrappedAgent(createWorkerState(), {
+      customRuntimeFlag: 'drop-me',
+    });
+
+    expect(mockReActAgent.invoke).toHaveBeenCalledWith(
+      { messages: [{ role: 'user', content: 'Analyze customer feedback data' }] },
+      undefined
+    );
+  });
+
   it('emits more error console output when verbose is enabled', async () => {
     const mockReActAgent = createMockReActAgent(async () => {
       throw new Error('forced failure');

--- a/packages/patterns/tests/shared/error-handling.test.ts
+++ b/packages/patterns/tests/shared/error-handling.test.ts
@@ -32,6 +32,34 @@ describe('withErrorHandling', () => {
     await expect(wrapped({ input: 'test' })).rejects.toBe(graphInterrupt);
   });
 
+  it('does not mask the original error when interrupt-like getters throw', async () => {
+    const originalError = new Error('boom');
+    const thrownValue = Object.create(null) as { name?: string; constructor?: unknown };
+    Object.defineProperty(thrownValue, 'name', {
+      get() {
+        throw originalError;
+      },
+    });
+    Object.defineProperty(thrownValue, 'constructor', {
+      get() {
+        throw originalError;
+      },
+    });
+
+    const wrapped = withErrorHandling(
+      async () => {
+        throw thrownValue;
+      },
+      'test-node'
+    );
+
+    const result = await wrapped({ input: 'test' });
+    expect(result).toEqual({
+      status: 'failed',
+      error: 'Unknown error',
+    });
+  });
+
   it('returns fallback status and error even when state omits optional channels', async () => {
     type MinimalState = { input: string; status?: string; error?: string };
     const wrapped = withErrorHandling<MinimalState>(

--- a/packages/patterns/tests/shared/error-handling.test.ts
+++ b/packages/patterns/tests/shared/error-handling.test.ts
@@ -16,6 +16,22 @@ describe('withErrorHandling', () => {
     await expect(wrapped({ input: 'test' })).rejects.toBe(graphInterrupt);
   });
 
+  it('rethrows GraphInterrupt-like errors when the constructor name is unstable', async () => {
+    class MinifiedInterrupt extends Error {
+      override name = 'GraphInterrupt';
+    }
+
+    const graphInterrupt = new MinifiedInterrupt('pause for human input');
+    const wrapped = withErrorHandling(
+      async () => {
+        throw graphInterrupt;
+      },
+      'test-node'
+    );
+
+    await expect(wrapped({ input: 'test' })).rejects.toBe(graphInterrupt);
+  });
+
   it('returns fallback status and error even when state omits optional channels', async () => {
     type MinimalState = { input: string; status?: string; error?: string };
     const wrapped = withErrorHandling<MinimalState>(

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3542,7 +3542,8 @@ Implementation notes:
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #153 marked ready for review on 2026-07-09 after focused validation, full-suite validation, lint, story-doc updates, and tracker sync were complete
 - [ ] Wait for merge; do not merge directly from local branch
 
 ### Notes

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3640,19 +3640,33 @@ Implementation notes:
 **Branch:** `fix/st-09088-multi-agent-runtime-boundary-hardening`
 
 ### Checklist
-- [ ] Create branch `fix/st-09088-multi-agent-runtime-boundary-hardening`
-- [ ] Create draft PR with story ID in title
-- [ ] Define test strategy before implementation: cover malformed runnable-config inputs, supported config forwarding, GraphInterrupt compatibility, and current wrapped-node error bubbling
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-- [ ] Replace the bare config cast in `packages/patterns/src/multi-agent/utils-shared.ts` with structural RunnableConfig validation or safe forwarding logic
-- [ ] Harden `packages/patterns/src/shared/error-handling.ts` so GraphInterrupt detection does not rely solely on constructor-name matching
-- [ ] Add/update focused tests until the runtime-boundary behavior passes, keeping evidence in checklist notes and PR body
-- [ ] Record explicit-`any` warning deltas and the runtime-boundary compatibility rationale in story docs
-- [ ] Add or update story documentation at `docs/st09088-multi-agent-runtime-boundary-hardening.md` (or document why not required)
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Create branch `fix/st-09088-multi-agent-runtime-boundary-hardening`
+  - Created as `codex/fix/st-09088-multi-agent-runtime-boundary-hardening` (workspace branch-prefix policy)
+- [x] Create draft PR with story ID in title
+  - PR #153: https://github.com/TVScoundrel/agentforge/pull/153
+- [x] Define test strategy before implementation: cover malformed runnable-config inputs, supported config forwarding, GraphInterrupt compatibility, and current wrapped-node error bubbling
+  - Selected a focused red-first regression path because both seams are small public runtime boundaries: extend the public `withErrorHandling(...)` interrupt coverage and assert wrapped ReAct invocation keeps supported runnable keys while dropping arbitrary config input.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Added a GraphInterrupt regression for an error whose constructor name is unstable and a wrap-agent config-forwarding regression; the initial red run failed because the unstable-constructor interrupt was converted into `{ status: 'failed', error: 'pause for human input' }` instead of being rethrown.
+- [x] Replace the bare config cast in `packages/patterns/src/multi-agent/utils-shared.ts` with structural RunnableConfig validation or safe forwarding logic
+  - `toRunnableConfig(...)` now uses LangChain's `pickRunnableConfigKeys(...)` helper and removes undefined-only shells so only supported runnable options survive forwarding.
+- [x] Harden `packages/patterns/src/shared/error-handling.ts` so GraphInterrupt detection does not rely solely on constructor-name matching
+  - `isGraphInterrupt(...)` now accepts either `error.name === 'GraphInterrupt'` or the legacy constructor-name compatibility signal.
+- [x] Add/update focused tests until the runtime-boundary behavior passes, keeping evidence in checklist notes and PR body
+  - `pnpm --filter @agentforge/patterns test --run packages/patterns/tests/multi-agent/utils.test.ts packages/patterns/tests/shared/error-handling.test.ts` -> initial red run failed in the unstable-constructor interrupt regression; post-fix rerun passed with `2` files and `15` tests
+  - `pnpm --filter @agentforge/patterns typecheck` -> passed
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 80/289`, `patterns 2/28`
+- [x] Record explicit-`any` warning deltas and the runtime-boundary compatibility rationale in story docs
+  - Recorded in `docs/st09088-multi-agent-runtime-boundary-hardening.md`; explicit-`any` baseline remains flat at `workspace 80/289`, `patterns 2/28`
+- [x] Add or update story documentation at `docs/st09088-multi-agent-runtime-boundary-hardening.md` (or document why not required)
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - The public wrap-agent and shared error-handling regressions cover the changed runtime boundaries directly; no further targeted automation was needed before workspace validation.
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> passed with `224` files passed, `9` skipped; `2516` tests passed, `110` skipped
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with existing warning-only baseline; touched `patterns` package remained warning-only and the explicit-`any` baseline still held at `workspace 80/289`, `patterns 2/28`
+- [x] Commit completed checklist items as logical commits and push updates
+  - Commit `2d612c3b` (`fix(st-09088): harden multi-agent runtime boundaries`) pushed to `origin/codex/fix/st-09088-multi-agent-runtime-boundary-hardening`
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2348,7 +2348,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/multi-agent/utils-shared.ts` stops relying on a bare `RunnableConfig` cast and only forwards a structurally validated config shape that remains compatible with the current worker execution flow.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2348,7 +2348,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] `packages/patterns/src/multi-agent/utils-shared.ts` stops relying on a bare `RunnableConfig` cast and only forwards a structurally validated config shape that remains compatible with the current worker execution flow.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-07-08
-**Active Story:** None currently - next recommended ready story is ST-09088
+**Last Updated:** 2026-07-09
+**Active Story:** ST-09088 - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -1,9 +1,9 @@
 # Feature Plan: SOLID Micro-Refactors and Type Boundary Hardening
 
 **Epic Range:** EP-09 through EP-09
-**Status:** In Progress
+**Status:** In Review
 **Last Updated:** 2026-07-09
-**Active Story:** ST-09088 - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
+**Active Story:** ST-09088 - Harden Multi-Agent Runnable Config and GraphInterrupt Detection (In Review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-08
+**Last Updated:** 2026-07-09
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-09088` - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
-  - Depends on: None
 - `ST-09084` - Deduplicate Tool Testing Helpers Across Core and Testing
   - Depends on: None
 - `ST-09085` - Modularize Relational Schema Type Mapper and Tests
@@ -25,7 +23,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-09088` - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
+  - Depends on: None
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 2 stories
 
@@ -23,14 +23,14 @@
 
 ## In Progress
 
-- `ST-09088` - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
-  - Depends on: None
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09088` - Harden Multi-Agent Runnable Config and GraphInterrupt Detection
+  - Depends on: None
 
 ## Blocked
 


### PR DESCRIPTION
## Story
- ST-09088

## What Changed
- hardened multi-agent worker config forwarding so wrapped ReAct agents only receive supported RunnableConfig keys
- normalized malformed or undefined-only worker config input away instead of passing inert arbitrary-record shells into agent invocation
- removed the constructor-name-only GraphInterrupt dependency by recognizing interrupt errors through stable error identity signals while preserving the legacy constructor-name compatibility path
- added focused public-surface regressions for malformed worker config input, supported config forwarding, unstable-constructor GraphInterrupt handling, and wrapped-node error bubbling

## Acceptance Criteria Coverage
- `packages/patterns/src/multi-agent/utils-shared.ts` no longer relies on a bare `RunnableConfig` cast and now forwards a sanitized RunnableConfig shape
- `packages/patterns/src/shared/error-handling.ts` no longer depends solely on `constructor.name === 'GraphInterrupt'`
- focused tests cover malformed config input, interrupt compatibility, and wrapped-node error bubbling through the public patterns test surface

## Test Strategy
- red-first focused regression coverage on the public `withErrorHandling(...)` and `wrapReActAgent(...)` paths
- package-scoped patterns validation before broader workspace validation

## Validation Performed
- `pnpm --filter @agentforge/patterns test --run packages/patterns/tests/multi-agent/utils.test.ts packages/patterns/tests/shared/error-handling.test.ts`
- `pnpm --filter @agentforge/patterns typecheck`
- `pnpm lint:explicit-any:baseline`
- `pnpm test --run`
- `pnpm lint`

## Status
- Ready for review
