### PR TITLE
docs(st-11001): publish repository security boundary policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ See [ROADMAP.md](./docs/ROADMAP.md) for complete development history.
 
 ---
 
+## Security
+
+Read the [security policy](./SECURITY.md) before exposing AgentForge tools, skills, examples, or multi-agent workflows to model-controlled input.
+
+The policy distinguishes privileged-by-design surfaces from framework guardrails that AgentForge is expected to enforce by default, and it explains how to classify example-only issues versus framework trust-boundary bugs.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please follow these steps:

--- a/docs-site/contributing.md
+++ b/docs-site/contributing.md
@@ -12,6 +12,8 @@ We are committed to providing a welcoming and inclusive environment. Please be r
 
 Before creating a bug report, please check existing issues to avoid duplicates.
 
+If you suspect a security vulnerability or trust-boundary bypass, follow the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) instead of opening a public issue.
+
 **When filing a bug report, include:**
 - Clear, descriptive title
 - Steps to reproduce the issue

--- a/docs-site/guide/agent-skills-authoring.md
+++ b/docs-site/guide/agent-skills-authoring.md
@@ -130,6 +130,8 @@ Static assets like images, data files, or templates. Always accessible.
 
 Trust levels control access to `scripts/` resources:
 
+The repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) defines the broader trust-boundary expectations for untrusted skill roots and model-visible skill content.
+
 | Trust Level | `references/` | `scripts/` | `assets/` |
 |-------------|---------------|------------|-----------|
 | `workspace` | Read | Read | Read |

--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -10,6 +10,10 @@ AgentForge supports the [Agent Skills specification](https://agentskills.io/spec
 
 Agent Skills are markdown-based instruction packs that agents load on demand via tool calls. Each skill is a directory containing a `SKILL.md` file with frontmatter metadata and instructional content.
 
+::: warning Trust Boundary
+Skills can carry untrusted instructions even when script execution is blocked. Read the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) before treating third-party skills as equivalent to trusted system guidance.
+:::
+
 ```
 .agentskills/
 ├── code-review/
@@ -183,6 +187,7 @@ All resource paths are validated:
 Script resources (`scripts/` directory) are subject to trust policy checks. Non-script resources (references, assets, SKILL.md) are always accessible.
 
 See [Trust Policies](/guide/agent-skills-authoring#trust-policies) for the full trust model.
+See the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) for the maintainer boundary on untrusted skill roots versus trusted project-owned skill content.
 
 ## Feature Flag
 
@@ -294,4 +299,3 @@ Setting `enabled: false` only suppresses `generatePrompt()`. If activation tools
 - **[Skill-Powered Agent Tutorial](/tutorials/skill-powered-agent)** — Step-by-step walkthrough building a skill-powered agent from scratch
 - **[Agent Skills Examples](/examples/agent-skills)** — Common patterns and runnable code snippets
 - **[SkillRegistry API Reference](/api/skills#skillregistry)** — Full API documentation for the SkillRegistry class
-

--- a/docs-site/guide/concepts/tools.md
+++ b/docs-site/guide/concepts/tools.md
@@ -19,6 +19,10 @@ A **tool** is a function that an AI agent can call to perform actions or retriev
 - **Search the web**
 - And much more...
 
+::: warning Security Boundary
+Many tools are intentionally powerful. Read the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) before exposing filesystem, network, shell, or data-mutation tools to model-controlled input.
+:::
+
 ## Why AgentForge Tools?
 
 AgentForge's tool system goes beyond simple function calling:
@@ -378,4 +382,3 @@ const readJsonTool = toolBuilder()
 - [Standard Tools](/api/tools) - 70 pre-built tools
 - [Custom Tools Tutorial](/tutorials/custom-tools) - Build your own tools
 - [Agent Patterns](/guide/concepts/patterns) - Use tools with agents
-

--- a/docs/st11001-repository-security-boundary-policy.md
+++ b/docs/st11001-repository-security-boundary-policy.md
@@ -13,7 +13,7 @@ This story formalizes AgentForge's repository-level security posture around inte
   - `docs-site/guide/concepts/tools.md`
   - `docs-site/guide/agent-skills.md`
   - `docs-site/guide/agent-skills-authoring.md`
-- Added the missing Epic 11 checklist file and updated the planning artifacts to track `ST-11001` through in-progress and in-review status.
+- Added the missing Epic 11 checklist file and updated the planning artifacts to track `ST-11001` as the active Epic 11 story and then as in review.
 
 ## Test Strategy
 

--- a/docs/st11001-repository-security-boundary-policy.md
+++ b/docs/st11001-repository-security-boundary-policy.md
@@ -1,0 +1,25 @@
+# ST-11001: Repository Security Boundary Policy
+
+## Summary
+
+This story formalizes AgentForge's repository-level security posture around intentionally powerful framework surfaces versus guardrails the framework itself is expected to enforce. The core `SECURITY.md` policy already captured the supported-version policy, private reporting guidance, trust-boundary model, and scope classification, so the delivery work focused on linking that policy from the maintainer and adopter docs that most directly influence safe usage.
+
+## What Changed
+
+- Reused the existing top-level `SECURITY.md` as the canonical repository security policy.
+- Added a root README security section that points maintainers and adopters at the policy before exposing tools, skills, examples, or multi-agent workflows to model-controlled input.
+- Updated `docs-site/contributing.md` so security findings are routed to the repository security policy instead of public bug reports.
+- Added policy cross-links in:
+  - `docs-site/guide/concepts/tools.md`
+  - `docs-site/guide/agent-skills.md`
+  - `docs-site/guide/agent-skills-authoring.md`
+- Added the missing Epic 11 checklist file and marked `ST-11001` as the active in-progress story in the planning artifacts.
+
+## Test Strategy
+
+- No practical failing automated test seam exists for this story because it changes repository policy and documentation routing rather than runtime behavior.
+- Validation therefore relies on targeted diff review plus the repository's standard test and lint gates.
+
+## CI Impact
+
+- No CI workflow change is required because the story does not alter runtime code paths or the documented validation contract; the existing repo-wide test and lint commands remain the authoritative quality gates.

--- a/docs/st11001-repository-security-boundary-policy.md
+++ b/docs/st11001-repository-security-boundary-policy.md
@@ -13,7 +13,7 @@ This story formalizes AgentForge's repository-level security posture around inte
   - `docs-site/guide/concepts/tools.md`
   - `docs-site/guide/agent-skills.md`
   - `docs-site/guide/agent-skills-authoring.md`
-- Added the missing Epic 11 checklist file and marked `ST-11001` as the active in-progress story in the planning artifacts.
+- Added the missing Epic 11 checklist file and updated the planning artifacts to track `ST-11001` through in-progress and in-review status.
 
 ## Test Strategy
 

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -1,0 +1,37 @@
+# Epic 11: Security Boundary Hardening - Story Tasks
+
+## ST-11001: Publish Repository Security Boundary Policy
+
+**Branch:** `docs/st-11001-repository-security-boundary-policy`
+
+### Checklist
+- [x] Create branch `docs/st-11001-repository-security-boundary-policy`
+  - Created on 2026-07-14 from `main`.
+- [ ] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: identify whether this policy/docs hardening story has a practical failing automated test seam or should rely on documented rationale plus validation commands
+  - Strategy: this is a repository-policy and docs-routing story with no practical red-test seam, so record the rationale up front and rely on targeted diff review plus the repo's standard full-suite and lint gates.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - No practical failing automated test exists because the story changes policy text and security-routing guidance rather than runtime behavior or a tested docs-build transform.
+- [x] Add a top-level `SECURITY.md` that documents supported versions, reporting guidance, and the repository trust boundaries for tools, skills, examples, and downstream host applications
+  - Existing tracked `SECURITY.md` already satisfied this baseline on `main` from commit `b7f53f02` (`docs(ep-11): add security policy and hardening backlog`); this story keeps that file as the canonical policy baseline.
+- [x] Explicitly distinguish privileged-by-design surfaces from framework guarantees intended to be safe for model-controlled input
+  - Confirmed in `SECURITY.md` under `Privileged-by-Design Surfaces` and `Framework Guardrails Expected by Default`.
+- [x] Cross-link security-relevant docs to the new policy where that guidance materially affects safe adoption
+  - Added links from `README.md`, `docs-site/contributing.md`, `docs-site/guide/concepts/tools.md`, `docs-site/guide/agent-skills.md`, and `docs-site/guide/agent-skills-authoring.md`.
+- [x] Include maintainer guidance for classifying example-only issues, untrusted skill roots, and model-exposed tool execution
+  - Confirmed in `SECURITY.md` under `Framework Packages vs Example Applications`, `Out of Scope`, and `Disclosure Expectations`.
+- [x] Add/update production docs until focused validation passes, keeping evidence in checklist notes and PR body
+  - Updated the maintainer/adopter docs above to route security-sensitive usage to the repository policy before exposing privileged surfaces to model-controlled input.
+- [x] Add or update story documentation at `docs/st11001-repository-security-boundary-policy.md` (or document why not required)
+  - Added `docs/st11001-repository-security-boundary-policy.md`.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - No additional automated tests are required because the story does not alter runtime behavior; the residual validation need is covered by full-suite and lint verification.
+- [x] Assess CI impact; update CI or document why no CI change is required
+  - No CI change is required because the story changes policy/docs only and does not introduce a new validation contract beyond the existing repo-wide test and lint commands.
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `224` passed, `9` skipped files; `2498` passed, `110` skipped tests.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with the existing warning baseline only (`0` errors).
+- [ ] Commit completed checklist items as logical commits and push updates
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -35,5 +35,6 @@
   - `pnpm lint` -> passed with the existing warning baseline only (`0` errors).
 - [x] Commit completed checklist items as logical commits and push updates
   - `91933602` `docs(st-11001): publish security policy guidance` pushed to `origin/docs/st-11001-repository-security-boundary-policy`; tracker and ready-state sync are captured in the current review-prep follow-up commit.
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #158 marked ready for review on 2026-07-14 after docs updates, story documentation, validation, PR body verification, and tracker sync were complete.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -7,7 +7,8 @@
 ### Checklist
 - [x] Create branch `docs/st-11001-repository-security-boundary-policy`
   - Created on 2026-07-14 from `main`.
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - Draft PR #158 created on 2026-07-14: <https://github.com/TVScoundrel/agentforge/pull/158>
 - [x] Define test strategy before implementation: identify whether this policy/docs hardening story has a practical failing automated test seam or should rely on documented rationale plus validation commands
   - Strategy: this is a repository-policy and docs-routing story with no practical red-test seam, so record the rationale up front and rely on targeted diff review plus the repo's standard full-suite and lint gates.
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
@@ -32,6 +33,7 @@
   - `pnpm test --run` -> `224` passed, `9` skipped files; `2498` passed, `110` skipped tests.
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> passed with the existing warning baseline only (`0` errors).
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Commit completed checklist items as logical commits and push updates
+  - `91933602` `docs(st-11001): publish security policy guidance` pushed to `origin/docs/st-11001-repository-security-boundary-policy`; tracker and ready-state sync are captured in the current review-prep follow-up commit.
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2501,11 +2501,11 @@
 **Status:** In Review (PR #158, 2026-07-14)
 
 **Acceptance criteria:**
-- [ ] Add a repository-level `SECURITY.md` that documents supported versions, reporting guidance, and the project’s intended trust boundaries for tools, skills, examples, and downstream host applications
-- [ ] The policy explicitly distinguishes privileged-by-design surfaces from framework guarantees that are expected to be safe for model-controlled input
-- [ ] Security-relevant docs cross-link to the new policy where that guidance materially affects safe adoption
-- [ ] The policy includes concrete maintainer guidance for classifying example-only issues, untrusted skill roots, and model-exposed tool execution
-- [ ] Add or update story documentation at `docs/st11001-repository-security-boundary-policy.md`
+- [x] Add a repository-level `SECURITY.md` that documents supported versions, reporting guidance, and the project’s intended trust boundaries for tools, skills, examples, and downstream host applications
+- [x] The policy explicitly distinguishes privileged-by-design surfaces from framework guarantees that are expected to be safe for model-controlled input
+- [x] Security-relevant docs cross-link to the new policy where that guidance materially affects safe adoption
+- [x] The policy includes concrete maintainer guidance for classifying example-only issues, untrusted skill roots, and model-exposed tool execution
+- [x] Add or update story documentation at `docs/st11001-repository-security-boundary-policy.md`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2498,6 +2498,7 @@
 **Priority:** P1 (High)
 **Estimate:** 3 hours
 **Dependencies:** None
+**Status:** In Review (PR #158, 2026-07-14)
 
 **Acceptance criteria:**
 - [ ] Add a repository-level `SECURITY.md` that documents supported versions, reporting guidance, and the project’s intended trust boundaries for tools, skills, examples, and downstream host applications

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-07-14
-**Active Story:** ST-11001 - In Progress
+**Active Story:** ST-11001 - In Review (PR #158); next recommended ready story is ST-11004
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -1,5 +1,12 @@
 # Feature Plan: EP-11 Security Boundary Hardening
 
+**Epic Range:** EP-11 through EP-11
+**Status:** In Progress
+**Last Updated:** 2026-07-14
+**Active Story:** ST-11001 - In Progress
+
+---
+
 ## Goal
 
 Turn the 2026-07-09 repository security scan into a concrete, reviewable hardening backlog that improves security-sensitive defaults and documents the intended trust model more clearly.

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -30,6 +30,8 @@ None currently.
 - `ST-11001` - Publish Repository Security Boundary Policy
   - PR #158
 
+---
+
 ## Blocked
 
 _No stories currently blocked_

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-13
+**Last Updated:** 2026-07-14
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-11001` - Publish Repository Security Boundary Policy
-  - Depends on: None
 - `ST-11004` - Separate Worker Output from Supervisor Routing Input
   - Depends on: None
 
@@ -23,7 +21,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-11001` - Publish Repository Security Boundary Policy
+  - Depends on: None
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -21,14 +21,14 @@
 
 ## In Progress
 
-- `ST-11001` - Publish Repository Security Boundary Policy
-  - Depends on: None
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11001` - Publish Repository Security Boundary Policy
+  - PR #158
 
 ## Blocked
 


### PR DESCRIPTION
## Story

- `ST-11001` - Publish Repository Security Boundary Policy

## What Changed

- routed maintainer and adopter docs to the repository security policy from the root README, docs contributing guide, tools guide, and agent-skills guides
- added `docs/st11001-repository-security-boundary-policy.md` to capture the boundary model, delivery rationale, and validation evidence
- added the missing Epic 11 checklist tracker and marked `ST-11001` as in progress in the planning artifacts
- retained the existing tracked `SECURITY.md` baseline from `b7f53f02` as the canonical repository policy rather than duplicating it in a second file

## Acceptance Criteria Coverage

- repository-level `SECURITY.md` baseline confirmed in place with supported versions, reporting guidance, and trust boundaries for tools, skills, examples, and downstream hosts
- privileged-by-design surfaces versus framework guardrails are explicitly distinguished in `SECURITY.md`
- security-relevant docs now link to the policy where safe-adoption guidance materially affects usage
- maintainer guidance for example-only issues, untrusted skill roots, and model-exposed tool execution is documented in `SECURITY.md`
- story documentation added at `docs/st11001-repository-security-boundary-policy.md`

## Test Strategy

- no practical failing automated test seam exists because this story changes policy text and documentation routing rather than runtime behavior
- relied on targeted diff review plus the repository's standard full-suite and lint gates

## Validation Performed

- `git diff --check`
- `pnpm test --run`
- `pnpm lint`

## Status

- ready for review
