### PR TITLE
ST-11005: Enforce Trust-Aware Skill Prompt and Activation Boundaries

### DIFF
--- a/docs-site/guide/agent-skills-authoring.md
+++ b/docs-site/guide/agent-skills-authoring.md
@@ -138,6 +138,8 @@ The repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/
 | `trusted` | Activatable | Read | Read | Read |
 | `untrusted` | Discoverable only until root promotion | Read | **Denied** | Read |
 
+The root `SKILL.md` is protected like the full activation body: it is readable through activation tools only from `workspace` or `trusted` roots.
+
 ### Promoting a Skill Root
 
 To allow script access and full `activate-skill` access from a root:

--- a/docs-site/guide/agent-skills-authoring.md
+++ b/docs-site/guide/agent-skills-authoring.md
@@ -132,15 +132,15 @@ Trust levels control access to `scripts/` resources:
 
 The repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) defines the broader trust-boundary expectations for untrusted skill roots and model-visible skill content.
 
-| Trust Level | `references/` | `scripts/` | `assets/` |
-|-------------|---------------|------------|-----------|
-| `workspace` | Read | Read | Read |
-| `trusted` | Read | Read | Read |
-| `untrusted` | Read | **Denied** | Read |
+| Trust Level | SKILL.md Activation | `references/` | `scripts/` | `assets/` |
+|-------------|---------------------|---------------|------------|-----------|
+| `workspace` | Activatable | Read | Read | Read |
+| `trusted` | Activatable | Read | Read | Read |
+| `untrusted` | Discoverable only until root promotion | Read | **Denied** | Read |
 
 ### Promoting a Skill Root
 
-To allow script access from a root:
+To allow script access and full `activate-skill` access from a root:
 
 1. **Review** the skill scripts manually
 2. **Configure** the root with explicit trust:
@@ -153,6 +153,8 @@ const registry = new SkillRegistry({
   ],
 });
 ```
+
+Until that promotion happens, the skill can still appear in the prompt under `<untrusted_skills>`, but `activate-skill` will return a trust-policy message instead of the full SKILL.md body.
 
 ### `allowed-tools` Field
 

--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -143,7 +143,7 @@ Reads a resource file from within a skill directory.
 | `name` | `string` | Skill name |
 | `path` | `string` | Relative path within the skill directory |
 
-**Returns:** File content as string. Blocked for `scripts/` paths from untrusted roots.
+**Returns:** File content as string. `scripts/` paths and the root `SKILL.md` are blocked from untrusted roots.
 
 ## Events
 
@@ -185,7 +185,7 @@ All resource paths are validated:
 
 ### Trust Policy Enforcement
 
-Script resources (`scripts/` directory) are subject to trust policy checks. Non-script resources (references, assets) remain readable from any discovered root, but the full SKILL.md body is only activatable from `workspace` or `trusted` roots.
+Script resources (`scripts/` directory) are subject to trust policy checks. Non-script resources (references, assets) remain readable from any discovered root, while `SKILL.md` itself is protected as the full skill instruction body and is only readable from `workspace` or `trusted` roots.
 
 See [Trust Policies](/guide/agent-skills-authoring#trust-policies) for the full trust model.
 See the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) for the maintainer boundary on untrusted skill roots versus trusted project-owned skill content.

--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -294,11 +294,11 @@ If issues are detected after enabling Agent Skills:
 
 ::: warning
 Setting `enabled: false` only suppresses `generatePrompt()`. If activation tools are registered with the agent, they remain callable. Remove them from the tool array for a complete rollback.
+:::
 
 ## Migration Note
 
 If you previously passed plain string roots such as `skillRoots: ['.agentskills']`, those roots remain discoverable but are now treated as `untrusted` for prompt and activation purposes. Migrate reviewed roots to explicit objects such as `{ path: '.agentskills', trust: 'workspace' }` or `{ path: '/shared/skills', trust: 'trusted' }` before expecting `activate-skill` to expose the full SKILL.md body.
-:::
 
 ## See Also
 

--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -47,7 +47,8 @@ const skillRegistry = new SkillRegistry({
 
 ```typescript
 const skillsPrompt = skillRegistry.generatePrompt();
-// Returns <available_skills> XML block with skill names + descriptions
+// Returns trusted <available_skills> XML and, when present,
+// a separate <untrusted_skills> section for discoverable-but-blocked roots
 ```
 
 ### 3. Register Activation Tools
@@ -81,7 +82,7 @@ const agent = createReActAgent({
 
 ### Skill Root Trust Levels
 
-Each skill root can be assigned a trust level that controls access to `scripts/` resources:
+Each skill root can be assigned a trust level that controls script access and whether `activate-skill` can expose the full SKILL.md body to the model:
 
 ```typescript
 const registry = new SkillRegistry({
@@ -94,11 +95,11 @@ const registry = new SkillRegistry({
 });
 ```
 
-| Trust Level | Script Access | Use Case |
-|-------------|--------------|----------|
-| `workspace` | Allowed | Project-local skills |
-| `trusted` | Allowed | Verified shared skill repositories |
-| `untrusted` | **Denied** | Community or unknown skill sources |
+| Trust Level | Full Skill Activation | Script Access | Use Case |
+|-------------|-----------------------|---------------|----------|
+| `workspace` | Allowed | Allowed | Project-local skills |
+| `trusted` | Allowed | Allowed | Verified shared skill repositories |
+| `untrusted` | **Blocked until root promotion** | **Denied** | Community or unknown skill sources |
 
 ::: tip
 Plain string roots default to `'untrusted'` for security. Promote roots to `'trusted'` or `'workspace'` only after reviewing their contents.
@@ -109,13 +110,13 @@ Plain string roots default to `'untrusted'` for security. Promote roots to `'tru
 ```
 Startup:
   1. new SkillRegistry({ skillRoots }) → scans folders → parses SKILL.md frontmatter
-  2. skillRegistry.generatePrompt() → <available_skills> XML
+  2. skillRegistry.generatePrompt() → trusted <available_skills> XML plus optional <untrusted_skills> notice block
   3. XML injected into agent system prompt (~50-100 tokens per skill)
 
 Runtime (agent decides):
   4. Agent reads task → sees relevant skill in prompt
   5. Agent calls activate-skill({ name: "skill-name" })
-     → Returns full SKILL.md body content
+     → Returns full SKILL.md body content only for workspace/trusted roots
   6. Agent optionally calls read-skill-resource({ name: "skill-name", path: "references/guide.md" })
      → Returns referenced file content
   7. Agent follows skill instructions using its existing tools
@@ -125,13 +126,13 @@ Runtime (agent decides):
 
 ### `activate-skill`
 
-Loads the full body content of a skill's SKILL.md file.
+Loads the full body content of a skill's SKILL.md file for `workspace` and `trusted` roots.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `string` | Skill name (must match a discovered skill) |
 
-**Returns:** SKILL.md body content as markdown string.
+**Returns:** SKILL.md body content as markdown string for trusted roots. Untrusted roots return a trust-policy message explaining that the operator must promote the root to `trusted` or `workspace` after review.
 
 ### `read-skill-resource`
 
@@ -152,9 +153,9 @@ The `SkillRegistry` emits structured events for observability:
 |-------|------|
 | `skill:discovered` | Skill found and parsed during discovery |
 | `skill:warning` | Skill parse or validation issue |
-| `skill:activated` | `activate-skill` tool successfully loaded a skill |
+| `skill:activated` | `activate-skill` tool successfully loaded a trusted/workspace skill |
 | `skill:resource-loaded` | `read-skill-resource` tool successfully loaded a resource |
-| `trust:policy-denied` | Script access blocked by trust policy |
+| `trust:policy-denied` | Skill activation or script access blocked by trust policy |
 | `trust:policy-allowed` | Script access permitted by trust policy |
 
 ```typescript
@@ -184,7 +185,7 @@ All resource paths are validated:
 
 ### Trust Policy Enforcement
 
-Script resources (`scripts/` directory) are subject to trust policy checks. Non-script resources (references, assets, SKILL.md) are always accessible.
+Script resources (`scripts/` directory) are subject to trust policy checks. Non-script resources (references, assets) remain readable from any discovered root, but the full SKILL.md body is only activatable from `workspace` or `trusted` roots.
 
 See [Trust Policies](/guide/agent-skills-authoring#trust-policies) for the full trust model.
 See the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) for the maintainer boundary on untrusted skill roots versus trusted project-owned skill content.
@@ -199,10 +200,11 @@ const registry = new SkillRegistry({
   skillRoots: ['.agentskills'],
 });
 
-// Enabled — generatePrompt() returns <available_skills> XML
+// Enabled — generatePrompt() returns trusted <available_skills>
+// and optional discoverable <untrusted_skills> entries
 const registryEnabled = new SkillRegistry({
   enabled: true,
-  skillRoots: ['.agentskills'],
+  skillRoots: [{ path: '.agentskills', trust: 'workspace' }],
 });
 ```
 
@@ -216,8 +218,9 @@ Use this checklist when enabling Agent Skills in a production or team environmen
 
 1. Start with `enabled: false` (default) — skills are discovered but not surfaced to the LLM
 2. Verify discovery with `registry.size()` and `registry.getScanErrors()` before enabling
-3. Set `enabled: true` to activate prompt injection
+3. Set `enabled: true` to activate prompt injection for trusted/workspace roots
 4. Set `allowUntrustedScripts: false` (default) — block untrusted script access
+5. Promote only reviewed roots to `trusted` or `workspace` if you want the model to activate their full SKILL.md bodies
 
 ```typescript
 const registry = new SkillRegistry({
@@ -291,6 +294,10 @@ If issues are detected after enabling Agent Skills:
 
 ::: warning
 Setting `enabled: false` only suppresses `generatePrompt()`. If activation tools are registered with the agent, they remain callable. Remove them from the tool array for a complete rollback.
+
+## Migration Note
+
+If you previously passed plain string roots such as `skillRoots: ['.agentskills']`, those roots remain discoverable but are now treated as `untrusted` for prompt and activation purposes. Migrate reviewed roots to explicit objects such as `{ path: '.agentskills', trust: 'workspace' }` or `{ path: '/shared/skills', trust: 'trusted' }` before expecting `activate-skill` to expose the full SKILL.md body.
 :::
 
 ## See Also

--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -198,7 +198,7 @@ Discovered 2 skills:
 
 ## Step 5: Generate the System Prompt
 
-The `generatePrompt()` method produces an `<available_skills>` XML block that tells the LLM which skills are available:
+The `generatePrompt()` method produces a trusted `<available_skills>` XML block and, when needed, a separate `<untrusted_skills>` block that keeps community roots discoverable without treating them as implicitly safe:
 
 ```typescript
 // 2. Generate skill-aware system prompt
@@ -214,13 +214,30 @@ Output:
     <name>code-review</name>
     <description>Performs thorough code reviews with focus on best practices, security, and maintainability.</description>
     <location>/path/to/.agentskills/code-review</location>
+    <trust>workspace</trust>
   </skill>
   <skill>
     <name>test-generator</name>
     <description>Generates comprehensive test suites following project conventions and testing best practices.</description>
     <location>/path/to/.agentskills/test-generator</location>
+    <trust>workspace</trust>
   </skill>
 </available_skills>
+```
+
+If you also scan unreviewed community roots, they appear in a separate section:
+
+```xml
+<untrusted_skills>
+  <trust_notice>Untrusted skills are discoverable, but their full SKILL.md bodies stay blocked until the root is promoted to trusted or workspace status.</trust_notice>
+  <skill>
+    <name>community-pack</name>
+    <description>Third-party community skill</description>
+    <location>/path/to/community-pack</location>
+    <trust>untrusted</trust>
+    <activation_policy>requires-trusted-root</activation_policy>
+  </skill>
+</untrusted_skills>
 ```
 
 ::: tip Subset Filtering
@@ -235,7 +252,7 @@ This is useful when building focused agents that only need a subset of available
 
 The `toActivationTools()` method returns two tools pre-wired to the registry:
 
-- **`activate-skill`** — loads the full SKILL.md instructions for a skill by name
+- **`activate-skill`** — loads the full SKILL.md instructions for a trusted/workspace skill by name
 - **`read-skill-resource`** — reads a resource file from a skill's directory
 
 ```typescript
@@ -261,7 +278,7 @@ const agent = createReActAgent({
 ${skillPrompt}
 
 When a user asks for help, check if an available skill matches the task.
-If so, use the activate-skill tool to load the skill's full instructions,
+If so, use the activate-skill tool to load the skill's full instructions from trusted or workspace roots,
 then follow those instructions to complete the task.
 Use read-skill-resource to load any referenced templates or files.`,
 });
@@ -292,7 +309,7 @@ for (const msg of result.messages) {
 
 The agent will:
 1. See `code-review` in `<available_skills>` and recognize it matches the task
-2. Call `activate-skill` with `{ name: "code-review" }` to load the full instructions
+2. Call `activate-skill` with `{ name: "code-review" }` to load the full instructions from the trusted workspace root
 3. Follow the skill's review process (read files, analyze, structured output)
 
 ```bash
@@ -355,14 +372,18 @@ const skillRegistry = new SkillRegistry({
 });
 ```
 
-| Trust Level | Reference Files | Script Files | Use Case |
-|-------------|----------------|--------------|----------|
-| `workspace` | Allowed | Allowed | First-party skills in your project |
-| `trusted` | Allowed | Allowed | Vetted community/team skills |
-| `untrusted` | Allowed | Blocked | Unknown or unreviewed skill sources |
+| Trust Level | Full Skill Activation | Reference Files | Script Files | Use Case |
+|-------------|-----------------------|----------------|--------------|----------|
+| `workspace` | Allowed | Allowed | Allowed | First-party skills in your project |
+| `trusted` | Allowed | Allowed | Allowed | Vetted community/team skills |
+| `untrusted` | Blocked until root promotion | Allowed | Blocked | Unknown or unreviewed skill sources |
 
 ::: warning Script Access
 Resources under `scripts/` directories are subject to trust policy enforcement. Only `workspace` and `trusted` roots allow script access. Use `allowUntrustedScripts: true` in config to override (not recommended for production).
+:::
+
+::: warning Full Skill Activation
+Untrusted roots are still listed in the prompt so the model can surface them for operator review, but `activate-skill` will refuse to return their full SKILL.md bodies until you explicitly promote that root to `trusted` or `workspace`.
 :::
 
 ## Complete Working Example
@@ -419,7 +440,7 @@ const agent = createReActAgent({
 ${skillPrompt}
 
 When a user asks for help, check if an available skill matches the task.
-If so, use the activate-skill tool to load the skill's full instructions,
+If so, use the activate-skill tool to load the skill's full instructions from trusted or workspace roots,
 then follow those instructions to complete the task.
 Use read-skill-resource to load any referenced templates or files.`,
 });

--- a/docs/st11005-skill-trust-boundary-hardening.md
+++ b/docs/st11005-skill-trust-boundary-hardening.md
@@ -18,6 +18,7 @@ That split-brain behavior made it too easy for a model-exposed agent to treat th
 
 - Prompt generation now annotates trusted skill entries with their trust level and separates untrusted discoveries into a dedicated `<untrusted_skills>` block with an explicit activation-policy notice.
 - Full-body activation now uses a trust-policy check parallel to the existing script-resource trust policy.
+- `read-skill-resource` applies the same activation policy to direct `SKILL.md` requests, closing the resource-tool bypass for untrusted roots.
 - `workspace` and `trusted` roots can still activate normally.
 - `untrusted` roots stay discoverable for operator review and migration planning, but their SKILL.md bodies stay blocked until the root is explicitly promoted.
 

--- a/docs/st11005-skill-trust-boundary-hardening.md
+++ b/docs/st11005-skill-trust-boundary-hardening.md
@@ -1,0 +1,50 @@
+# ST-11005: Skill Trust Boundary Hardening
+
+## Summary
+
+`ST-11005` hardens Agent Skills so untrusted skill packs remain discoverable without being treated as implicitly safe privileged instructions. Trusted and workspace roots continue to surface through `<available_skills>` and can be activated normally. Untrusted roots now surface through a separate `<untrusted_skills>` section and `activate-skill` blocks their full SKILL.md bodies until the operator explicitly promotes the root to `trusted` or `workspace`.
+
+## Why This Change Exists
+
+Before this story, skill discovery already tracked root trust levels for script-resource access, but prompt generation and full-skill activation treated every discovered skill the same. That created a trust-boundary mismatch:
+
+- `read-skill-resource` correctly blocked untrusted `scripts/` content by default.
+- `generatePrompt()` still surfaced untrusted skill packs alongside trusted ones without a visible distinction.
+- `activate-skill` still returned the full SKILL.md body from untrusted roots, even though those instructions could be model-visible and effectively privileged.
+
+That split-brain behavior made it too easy for a model-exposed agent to treat third-party skill instructions as first-party orchestration guidance.
+
+## Implementation Notes
+
+- Prompt generation now annotates trusted skill entries with their trust level and separates untrusted discoveries into a dedicated `<untrusted_skills>` block with an explicit activation-policy notice.
+- Full-body activation now uses a trust-policy check parallel to the existing script-resource trust policy.
+- `workspace` and `trusted` roots can still activate normally.
+- `untrusted` roots stay discoverable for operator review and migration planning, but their SKILL.md bodies stay blocked until the root is explicitly promoted.
+
+## Compatibility Impact
+
+This is a behavior change for adopters who previously relied on plain string roots such as `skillRoots: ['.agentskills']` and expected `activate-skill` to return full SKILL.md bodies immediately.
+
+String roots still normalize to `untrusted` for safe defaults. To preserve pre-hardening activation behavior for reviewed skill packs, migrate those roots to explicit trust objects:
+
+```ts
+const registry = new SkillRegistry({
+  enabled: true,
+  skillRoots: [
+    { path: '.agentskills', trust: 'workspace' },
+    { path: '/shared/reviewed-skills', trust: 'trusted' },
+  ],
+});
+```
+
+If a root should remain discoverable but not activatable, keep it untrusted.
+
+## Validation
+
+Focused regressions cover:
+
+- prompt generation separating trusted and untrusted skills,
+- untrusted-only discovery remaining visible through `<untrusted_skills>`,
+- blocked full-body activation for untrusted roots,
+- successful activation for explicit `workspace` and `trusted` roots, and
+- preserved resource-policy behavior for trusted and untrusted script/resource paths.

--- a/packages/skills/src/activation-activate-tool.ts
+++ b/packages/skills/src/activation-activate-tool.ts
@@ -53,6 +53,7 @@ export function createActivateSkillTool(
 
         registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
           name: skill.metadata.name,
+          resourcePath: 'SKILL.md',
           trustLevel: skill.trustLevel,
           reason: policyDecision.reason,
           message: policyDecision.message,

--- a/packages/skills/src/activation-activate-tool.ts
+++ b/packages/skills/src/activation-activate-tool.ts
@@ -27,7 +27,8 @@ export function createActivateSkillTool(
     .description(
       'Activate an Agent Skill by name, loading its full instructions for trusted roots. ' +
       'Returns the complete SKILL.md body content for workspace or explicitly trusted skills. ' +
-      'Use this when you see a relevant skill in <available_skills> and want to follow its instructions.',
+      'Use this when you see a relevant skill in <available_skills> or <untrusted_skills>; ' +
+      'activation is blocked for untrusted roots until they are promoted.',
     )
     .category(ToolCategory.SKILLS)
     .tags(['skill', 'activation', 'agent-skills'])

--- a/packages/skills/src/activation-activate-tool.ts
+++ b/packages/skills/src/activation-activate-tool.ts
@@ -8,6 +8,7 @@ import { SkillRegistryEvent } from './types.js';
 import { extractBody } from './activation-content.js';
 import { activateSkillSchema } from './activation-schemas.js';
 import { activationLogger, buildMissingSkillMessage } from './activation-shared.js';
+import { evaluateSkillActivationPolicy } from './trust.js';
 
 /**
  * Create the `activate-skill` tool bound to a registry instance.
@@ -24,8 +25,8 @@ export function createActivateSkillTool(
   return new ToolBuilder<z.infer<typeof activateSkillSchema>, string>()
     .name('activate-skill')
     .description(
-      'Activate an Agent Skill by name, loading its full instructions. ' +
-      'Returns the complete SKILL.md body content for the named skill. ' +
+      'Activate an Agent Skill by name, loading its full instructions for trusted roots. ' +
+      'Returns the complete SKILL.md body content for workspace or explicitly trusted skills. ' +
       'Use this when you see a relevant skill in <available_skills> and want to follow its instructions.',
     )
     .category(ToolCategory.SKILLS)
@@ -40,6 +41,25 @@ export function createActivateSkillTool(
         return errorMessage;
       }
 
+      const policyDecision = evaluateSkillActivationPolicy(skill.trustLevel);
+      if (!policyDecision.allowed) {
+        activationLogger.warn('Skill activation blocked — trust policy', {
+          name,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+          message: policyDecision.message,
+        });
+
+        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+          name: skill.metadata.name,
+          trustLevel: skill.trustLevel,
+          reason: policyDecision.reason,
+          message: policyDecision.message,
+        });
+
+        return policyDecision.message;
+      }
+
       const skillMdPath = resolve(skill.skillPath, 'SKILL.md');
       try {
         const content = readFileSync(skillMdPath, 'utf-8');
@@ -49,12 +69,15 @@ export function createActivateSkillTool(
           name: skill.metadata.name,
           skillPath: skill.skillPath,
           bodyLength: body.length,
+          trustLevel: skill.trustLevel,
+          activationReason: policyDecision.reason,
         });
 
         registry.emitEvent(SkillRegistryEvent.SKILL_ACTIVATED, {
           name: skill.metadata.name,
           skillPath: skill.skillPath,
           bodyLength: body.length,
+          trustLevel: skill.trustLevel,
         });
 
         return body;

--- a/packages/skills/src/activation-resource-tool.ts
+++ b/packages/skills/src/activation-resource-tool.ts
@@ -74,7 +74,7 @@ export function createReadSkillResourceTool(
 
           registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
             name: skill.metadata.name,
-            resourcePath,
+            resourcePath: 'SKILL.md',
             trustLevel: skill.trustLevel,
             reason: activationDecision.reason,
             message: activationDecision.message,

--- a/packages/skills/src/activation-resource-tool.ts
+++ b/packages/skills/src/activation-resource-tool.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { ToolBuilder, ToolCategory } from '@agentforge/core';
 import type { Tool } from '@agentforge/core';
 import type { z } from 'zod';
 import type { SkillRegistry } from './registry.js';
-import { evaluateTrustPolicy } from './trust.js';
+import { evaluateSkillActivationPolicy, evaluateTrustPolicy } from './trust.js';
 import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
 import { resolveResourcePath } from './activation-path.js';
 import { readSkillResourceSchema } from './activation-schemas.js';
@@ -26,7 +27,8 @@ export function createReadSkillResourceTool(
     .description(
       'Read a resource file from an activated Agent Skill. ' +
       'Returns the content of a file within the skill directory (e.g., references/, scripts/, assets/). ' +
-      'The path must be relative to the skill root and cannot traverse outside it.',
+      'The path must be relative to the skill root and cannot traverse outside it. ' +
+      'SKILL.md is only readable from workspace or trusted roots.',
     )
     .category(ToolCategory.SKILLS)
     .tags(['skill', 'resource', 'agent-skills'])
@@ -48,6 +50,30 @@ export function createReadSkillResourceTool(
           error: pathResult.error,
         });
         return pathResult.error;
+      }
+
+      const isSkillInstructions = pathResult.resolvedPath === resolve(skill.skillPath, 'SKILL.md');
+      if (isSkillInstructions) {
+        const activationDecision = evaluateSkillActivationPolicy(skill.trustLevel);
+        if (!activationDecision.allowed) {
+          activationLogger.warn('Skill resource load blocked — skill instructions trust policy', {
+            name,
+            resourcePath,
+            trustLevel: skill.trustLevel,
+            reason: activationDecision.reason,
+            message: activationDecision.message,
+          });
+
+          registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+            name: skill.metadata.name,
+            resourcePath,
+            trustLevel: skill.trustLevel,
+            reason: activationDecision.reason,
+            message: activationDecision.message,
+          });
+
+          return activationDecision.message;
+        }
       }
 
       const policyDecision = evaluateTrustPolicy(

--- a/packages/skills/src/activation-resource-tool.ts
+++ b/packages/skills/src/activation-resource-tool.ts
@@ -52,7 +52,8 @@ export function createReadSkillResourceTool(
         return pathResult.error;
       }
 
-      const isSkillInstructions = pathResult.resolvedPath === resolve(skill.skillPath, 'SKILL.md');
+      const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
+      const isSkillInstructions = pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
       if (isSkillInstructions) {
         const activationDecision = evaluateSkillActivationPolicy(skill.trustLevel);
         if (!activationDecision.allowed) {

--- a/packages/skills/src/activation-resource-tool.ts
+++ b/packages/skills/src/activation-resource-tool.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ToolBuilder, ToolCategory } from '@agentforge/core';
 import type { Tool } from '@agentforge/core';
@@ -53,7 +53,14 @@ export function createReadSkillResourceTool(
       }
 
       const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
-      const isSkillInstructions = pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
+      let isSkillInstructions = pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
+      if (!isSkillInstructions) {
+        try {
+          isSkillInstructions = realpathSync(pathResult.resolvedPath).toLowerCase() === realpathSync(skillInstructionsPath).toLowerCase();
+        } catch {
+          // The resource read below reports missing or unreadable paths.
+        }
+      }
       if (isSkillInstructions) {
         const activationDecision = evaluateSkillActivationPolicy(skill.trustLevel);
         if (!activationDecision.allowed) {

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -53,6 +53,7 @@ export {
 // Trust Policy
 export {
   evaluateTrustPolicy,
+  evaluateSkillActivationPolicy,
   isScriptResource,
   normalizeRootConfig,
 } from './trust.js';

--- a/packages/skills/src/registry-prompt.ts
+++ b/packages/skills/src/registry-prompt.ts
@@ -27,7 +27,10 @@ export function generateSkillPrompt(
     skills = skills.slice(0, config.maxDiscoveredSkills);
   }
 
-  if (skills.length === 0) {
+  const trustedSkills = skills.filter((skill) => skill.trustLevel !== 'untrusted');
+  const untrustedSkills = skills.filter((skill) => skill.trustLevel === 'untrusted');
+
+  if (trustedSkills.length === 0 && untrustedSkills.length === 0) {
     logger.debug('Skill prompt generation produced empty result', {
       totalDiscovered,
       filterApplied: !!(options?.skills && options.skills.length > 0),
@@ -38,11 +41,23 @@ export function generateSkillPrompt(
     return '';
   }
 
-  const xml = `<available_skills>\n${skills.map(renderSkillEntry).join('\n')}\n</available_skills>`;
+  const sections: string[] = [];
+
+  if (trustedSkills.length > 0) {
+    sections.push(`<available_skills>\n${trustedSkills.map(renderTrustedSkillEntry).join('\n')}\n</available_skills>`);
+  }
+
+  if (untrustedSkills.length > 0) {
+    sections.push(renderUntrustedSkillsSection(untrustedSkills));
+  }
+
+  const xml = sections.join('\n');
   const estimatedTokens = Math.ceil(xml.length / 4);
 
   logger.info('Skill prompt generated', {
     skillCount: skills.length,
+    trustedSkillCount: trustedSkills.length,
+    untrustedSkillCount: untrustedSkills.length,
     totalDiscovered,
     filterApplied: !!(options?.skills && options.skills.length > 0),
     ...(config.maxDiscoveredSkills !== undefined ? { maxCap: config.maxDiscoveredSkills } : {}),
@@ -53,12 +68,34 @@ export function generateSkillPrompt(
   return xml;
 }
 
-function renderSkillEntry(skill: Skill): string {
+function renderTrustedSkillEntry(skill: Skill): string {
   return [
     '  <skill>',
     `    <name>${escapeXml(skill.metadata.name)}</name>`,
     `    <description>${escapeXml(skill.metadata.description)}</description>`,
     `    <location>${escapeXml(skill.skillPath)}</location>`,
+    `    <trust>${escapeXml(skill.trustLevel)}</trust>`,
+    '  </skill>',
+  ].join('\n');
+}
+
+function renderUntrustedSkillsSection(skills: Skill[]): string {
+  return [
+    '<untrusted_skills>',
+    '  <trust_notice>Untrusted skills are discoverable, but their full SKILL.md bodies stay blocked until the root is promoted to trusted or workspace status.</trust_notice>',
+    ...skills.map(renderUntrustedSkillEntry),
+    '</untrusted_skills>',
+  ].join('\n');
+}
+
+function renderUntrustedSkillEntry(skill: Skill): string {
+  return [
+    '  <skill>',
+    `    <name>${escapeXml(skill.metadata.name)}</name>`,
+    `    <description>${escapeXml(skill.metadata.description)}</description>`,
+    `    <location>${escapeXml(skill.skillPath)}</location>`,
+    `    <trust>${escapeXml(skill.trustLevel)}</trust>`,
+    '    <activation_policy>requires-trusted-root</activation_policy>',
     '  </skill>',
   ].join('\n');
 }

--- a/packages/skills/src/registry-prompt.ts
+++ b/packages/skills/src/registry-prompt.ts
@@ -27,8 +27,12 @@ export function generateSkillPrompt(
     skills = skills.slice(0, config.maxDiscoveredSkills);
   }
 
-  const trustedSkills = skills.filter((skill) => skill.trustLevel !== 'untrusted');
-  const untrustedSkills = skills.filter((skill) => skill.trustLevel === 'untrusted');
+  const trustedSkills = skills.filter(
+    (skill) => skill.trustLevel === 'workspace' || skill.trustLevel === 'trusted',
+  );
+  const untrustedSkills = skills.filter(
+    (skill) => skill.trustLevel !== 'workspace' && skill.trustLevel !== 'trusted',
+  );
 
   if (trustedSkills.length === 0 && untrustedSkills.length === 0) {
     logger.debug('Skill prompt generation produced empty result', {

--- a/packages/skills/src/registry-prompt.ts
+++ b/packages/skills/src/registry-prompt.ts
@@ -23,16 +23,19 @@ export function generateSkillPrompt(
     skills = skills.filter((skill) => requested.has(skill.metadata.name));
   }
 
-  if (config.maxDiscoveredSkills !== undefined && config.maxDiscoveredSkills >= 0) {
-    skills = skills.slice(0, config.maxDiscoveredSkills);
-  }
-
-  const trustedSkills = skills.filter(
+  let trustedSkills = skills.filter(
     (skill) => skill.trustLevel === 'workspace' || skill.trustLevel === 'trusted',
   );
-  const untrustedSkills = skills.filter(
+  let untrustedSkills = skills.filter(
     (skill) => skill.trustLevel !== 'workspace' && skill.trustLevel !== 'trusted',
   );
+
+  if (config.maxDiscoveredSkills !== undefined && config.maxDiscoveredSkills >= 0) {
+    const trustedLimit = Math.min(config.maxDiscoveredSkills, trustedSkills.length);
+    trustedSkills = trustedSkills.slice(0, trustedLimit);
+    untrustedSkills = untrustedSkills.slice(0, config.maxDiscoveredSkills - trustedLimit);
+    skills = [...trustedSkills, ...untrustedSkills];
+  }
 
   if (trustedSkills.length === 0 && untrustedSkills.length === 0) {
     logger.debug('Skill prompt generation produced empty result', {

--- a/packages/skills/src/trust.ts
+++ b/packages/skills/src/trust.ts
@@ -77,7 +77,8 @@ export function isScriptResource(resourcePath: string): boolean {
 /**
  * Evaluate the trust policy for a resource access request.
  *
- * Non-script resources are always allowed regardless of trust level.
+ * Non-script resources are allowed regardless of trust level, except for
+ * SKILL.md, which is protected by the activation policy.
  * Script resources require `workspace` or `trusted` trust, or the
  * `allowUntrustedScripts` override to be enabled.
  *
@@ -91,7 +92,7 @@ export function evaluateTrustPolicy(
   trustLevel: TrustLevel,
   allowUntrustedScripts: boolean = false,
 ): TrustPolicyDecision {
-  // Non-script resources — no policy enforcement needed
+  // Non-script resources — SKILL.md is checked separately by the resource tool.
   if (!isScriptResource(resourcePath)) {
     return {
       allowed: true,

--- a/packages/skills/src/trust.ts
+++ b/packages/skills/src/trust.ts
@@ -141,3 +141,44 @@ export function evaluateTrustPolicy(
       };
   }
 }
+
+/**
+ * Evaluate whether the full SKILL.md body can be exposed through activation.
+ *
+ * Untrusted roots stay discoverable, but their full instruction bodies are
+ * blocked until the operator explicitly promotes that root to `trusted` or
+ * `workspace`.
+ */
+export function evaluateSkillActivationPolicy(trustLevel: TrustLevel): TrustPolicyDecision {
+  switch (trustLevel) {
+    case 'workspace':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.WORKSPACE_SKILL_ACTIVATION,
+        message: 'Skill activation allowed — skill root has workspace trust',
+      };
+
+    case 'trusted':
+      return {
+        allowed: true,
+        reason: TrustPolicyReason.TRUSTED_SKILL_ACTIVATION,
+        message: 'Skill activation allowed — skill root is explicitly trusted',
+      };
+
+    case 'untrusted':
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+        message: `Skill activation blocked — skill root is untrusted. ` +
+          `Untrusted skills remain discoverable, but their full SKILL.md bodies are blocked by default. ` +
+          `Promote the skill root to 'trusted' or 'workspace' trust level after review to allow activation.`,
+      };
+
+    default:
+      return {
+        allowed: false,
+        reason: TrustPolicyReason.UNKNOWN_TRUST_LEVEL,
+        message: `Skill activation blocked — trust level "${trustLevel}" is unknown and is treated as untrusted for security.`,
+      };
+  }
+}

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -59,6 +59,12 @@ export enum TrustPolicyReason {
   WORKSPACE_TRUST = 'workspace-trust',
   /** Skill root has explicit trusted status — scripts allowed */
   TRUSTED_ROOT = 'trusted-root',
+  /** Skill body activation allowed because the root is workspace-owned */
+  WORKSPACE_SKILL_ACTIVATION = 'workspace-skill-activation',
+  /** Skill body activation allowed because the root is explicitly trusted */
+  TRUSTED_SKILL_ACTIVATION = 'trusted-skill-activation',
+  /** Full skill-body activation denied for an untrusted root */
+  UNTRUSTED_SKILL_ACTIVATION_DENIED = 'untrusted-skill-activation-denied',
   /** Skill root is untrusted — scripts denied by default */
   UNTRUSTED_SCRIPT_DENIED = 'untrusted-script-denied',
   /** Untrusted script access was explicitly allowed via config override */

--- a/packages/skills/tests/activation/activate-skill.suite.ts
+++ b/packages/skills/tests/activation/activate-skill.suite.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolCategory } from '@agentforge/core';
 import { SkillRegistry } from '../../src/registry.js';
 import { createActivateSkillTool } from '../../src/activation.js';
-import { SkillRegistryEvent } from '../../src/types.js';
+import { SkillRegistryEvent, TrustPolicyReason } from '../../src/types.js';
 import { cleanupTempDirs, createSkillFixture, createTempDir } from './shared.js';
 
 describe('activate-skill tool', () => {
@@ -72,6 +72,8 @@ describe('activate-skill tool', () => {
       ],
     });
     const tool = createActivateSkillTool(registry);
+    const deniedEvents: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => deniedEvents.push(data));
 
     expect(await tool.invoke({ name: 'trusted-skill' })).toBe('Trusted body');
 
@@ -80,6 +82,13 @@ describe('activate-skill tool', () => {
     expect(blocked).toContain('untrusted');
     expect(blocked).toContain('trusted');
     expect(blocked).not.toContain('Untrusted body');
+    expect(deniedEvents).toHaveLength(1);
+    expect(deniedEvents[0]).toEqual(expect.objectContaining({
+      name: 'community-skill',
+      resourcePath: 'SKILL.md',
+      trustLevel: 'untrusted',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+    }));
   });
 
   it('returns helpful not-found messages', async () => {

--- a/packages/skills/tests/activation/activate-skill.suite.ts
+++ b/packages/skills/tests/activation/activate-skill.suite.ts
@@ -21,7 +21,7 @@ describe('activate-skill tool', () => {
   });
 
   it('has the expected metadata', () => {
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const tool = createActivateSkillTool(registry);
 
     expect(tool.metadata.name).toBe('activate-skill');
@@ -40,17 +40,52 @@ describe('activate-skill tool', () => {
     );
     createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill', '\nBody content only');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const tool = createActivateSkillTool(registry);
 
     expect(await tool.invoke({ name: 'code-review' })).toContain('# Code Review');
     expect(await tool.invoke({ name: 'my-skill' })).toBe('Body content only');
   });
 
+  it('blocks activation for untrusted skills until the root is promoted', async () => {
+    const trustedRoot = createTempDir();
+    const untrustedRoot = createTempDir();
+    tempDirs.push(trustedRoot, untrustedRoot);
+
+    createSkillFixture(
+      trustedRoot,
+      'trusted-skill',
+      'name: trusted-skill\ndescription: Trusted skill',
+      '\nTrusted body',
+    );
+    createSkillFixture(
+      untrustedRoot,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nUntrusted body',
+    );
+
+    const registry = new SkillRegistry({
+      skillRoots: [
+        { path: trustedRoot, trust: 'trusted' },
+        { path: untrustedRoot, trust: 'untrusted' },
+      ],
+    });
+    const tool = createActivateSkillTool(registry);
+
+    expect(await tool.invoke({ name: 'trusted-skill' })).toBe('Trusted body');
+
+    const blocked = await tool.invoke({ name: 'community-skill' });
+    expect(blocked).toContain('blocked');
+    expect(blocked).toContain('untrusted');
+    expect(blocked).toContain('trusted');
+    expect(blocked).not.toContain('Untrusted body');
+  });
+
   it('returns helpful not-found messages', async () => {
     createSkillFixture(tempDir, 'code-review', 'name: code-review\ndescription: CR', '\nbody');
 
-    const populatedRegistry = new SkillRegistry({ skillRoots: [tempDir] });
+    const populatedRegistry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const populatedTool = createActivateSkillTool(populatedRegistry);
     const populatedResult = await populatedTool.invoke({ name: 'non-existent' });
     expect(populatedResult).toContain('Skill "non-existent" not found');
@@ -67,7 +102,7 @@ describe('activate-skill tool', () => {
   it('emits activation events and read errors correctly', async () => {
     const brokenDir = createSkillFixture(tempDir, 'broken-skill', 'name: broken-skill\ndescription: Broken', '\nbody');
     createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const tool = createActivateSkillTool(registry);
 
     const handler = vi.fn();
@@ -96,7 +131,7 @@ describe('activate-skill tool', () => {
     mkdirSync(noFrontmatterDir, { recursive: true });
     writeFileSync(join(noFrontmatterDir, 'SKILL.md'), '# Just content\n\nNo frontmatter here.', 'utf-8');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const tool = createActivateSkillTool(registry);
 
     expect(await tool.invoke({ name: 'empty-body' })).toBe('');

--- a/packages/skills/tests/activation/activation-tools.suite.ts
+++ b/packages/skills/tests/activation/activation-tools.suite.ts
@@ -24,7 +24,7 @@ describe('createSkillActivationTools', () => {
   });
 
   it('returns the two skill tools in the SKILLS category', () => {
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const tools = createSkillActivationTools(registry);
 
     expect(tools).toHaveLength(2);
@@ -51,7 +51,7 @@ describe('SkillRegistry.toActivationTools()', () => {
   it('returns activation tools bound to the registry', async () => {
     createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: A test skill', '\n# Test Skill\n\nInstructions here.');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const [activateTool, readResourceTool] = registry.toActivationTools();
 
     expect(activateTool.metadata.name).toBe('activate-skill');
@@ -82,7 +82,7 @@ describe('Skill activation integration', () => {
     );
     createResourceFile(skillDir, 'references/checklist.md', '# Checklist\n\n- [ ] Check naming\n- [ ] Check tests');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const [activateTool, readResourceTool] = registry.toActivationTools();
 
     const skillBody = await activateTool.invoke({ name: 'code-review' });
@@ -119,7 +119,7 @@ describe('Skill activation integration', () => {
     const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
     createResourceFile(skillDir, 'references/ref.md', 'reference content');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const [activateTool, readResourceTool] = registry.toActivationTools();
 
     const activatedHandler = vi.fn();
@@ -137,7 +137,7 @@ describe('Skill activation integration', () => {
   it('works alongside generatePrompt and tool spreading', async () => {
     createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test skill for compose', '\n# Skill Body');
 
-    const registry = new SkillRegistry({ skillRoots: [tempDir], enabled: true });
+    const registry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }], enabled: true });
     const [activateTool] = registry.toActivationTools();
 
     const prompt = registry.generatePrompt();

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -97,11 +97,13 @@ describe('read-skill-resource tool', () => {
     expect(caseVariantResult).not.toContain('secret instructions');
     expect(symlinkResult).not.toContain('secret instructions');
     expect(deniedEvents).toHaveLength(4);
-    expect(deniedEvents[0]).toEqual(expect.objectContaining({
-      name: 'my-skill',
-      resourcePath: 'SKILL.md',
-      trustLevel: 'untrusted',
-    }));
+    for (const event of deniedEvents) {
+      expect(event).toEqual(expect.objectContaining({
+        name: 'my-skill',
+        resourcePath: 'SKILL.md',
+        trustLevel: 'untrusted',
+      }));
+    }
   });
 
   it('emits resource events on success and not on failure', async () => {

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -1,3 +1,5 @@
+import { symlinkSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolCategory } from '@agentforge/core';
 import { SkillRegistry } from '../../src/registry.js';
@@ -83,14 +85,18 @@ describe('read-skill-resource tool', () => {
     const directResult = await tool.invoke({ name: 'my-skill', path: 'SKILL.md' });
     const normalizedResult = await tool.invoke({ name: 'my-skill', path: './SKILL.md' });
     const caseVariantResult = await tool.invoke({ name: 'my-skill', path: 'skill.md' });
+    symlinkSync(join(tempDir, 'my-skill', 'SKILL.md'), join(tempDir, 'my-skill', 'instructions.md'));
+    const symlinkResult = await tool.invoke({ name: 'my-skill', path: 'instructions.md' });
 
     expect(directResult).toContain('Skill activation blocked');
     expect(normalizedResult).toContain('Skill activation blocked');
     expect(caseVariantResult).toContain('Skill activation blocked');
+    expect(symlinkResult).toContain('Skill activation blocked');
     expect(directResult).not.toContain('secret instructions');
     expect(normalizedResult).not.toContain('secret instructions');
     expect(caseVariantResult).not.toContain('secret instructions');
-    expect(deniedEvents).toHaveLength(3);
+    expect(symlinkResult).not.toContain('secret instructions');
+    expect(deniedEvents).toHaveLength(4);
     expect(deniedEvents[0]).toEqual(expect.objectContaining({
       name: 'my-skill',
       resourcePath: 'SKILL.md',

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -72,6 +72,29 @@ describe('read-skill-resource tool', () => {
     expect(missingResource).toContain('nonexistent.md');
   });
 
+  it('blocks SKILL.md reads from untrusted roots, including normalized paths', async () => {
+    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nsecret instructions');
+
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const tool = createReadSkillResourceTool(registry);
+    const deniedEvents: unknown[] = [];
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, (data) => deniedEvents.push(data));
+
+    const directResult = await tool.invoke({ name: 'my-skill', path: 'SKILL.md' });
+    const normalizedResult = await tool.invoke({ name: 'my-skill', path: './SKILL.md' });
+
+    expect(directResult).toContain('Skill activation blocked');
+    expect(normalizedResult).toContain('Skill activation blocked');
+    expect(directResult).not.toContain('secret instructions');
+    expect(normalizedResult).not.toContain('secret instructions');
+    expect(deniedEvents).toHaveLength(2);
+    expect(deniedEvents[0]).toEqual(expect.objectContaining({
+      name: 'my-skill',
+      resourcePath: 'SKILL.md',
+      trustLevel: 'untrusted',
+    }));
+  });
+
   it('emits resource events on success and not on failure', async () => {
     const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
     createResourceFile(skillDir, 'references/guide.md', 'Guide content');

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -82,12 +82,15 @@ describe('read-skill-resource tool', () => {
 
     const directResult = await tool.invoke({ name: 'my-skill', path: 'SKILL.md' });
     const normalizedResult = await tool.invoke({ name: 'my-skill', path: './SKILL.md' });
+    const caseVariantResult = await tool.invoke({ name: 'my-skill', path: 'skill.md' });
 
     expect(directResult).toContain('Skill activation blocked');
     expect(normalizedResult).toContain('Skill activation blocked');
+    expect(caseVariantResult).toContain('Skill activation blocked');
     expect(directResult).not.toContain('secret instructions');
     expect(normalizedResult).not.toContain('secret instructions');
-    expect(deniedEvents).toHaveLength(2);
+    expect(caseVariantResult).not.toContain('secret instructions');
+    expect(deniedEvents).toHaveLength(3);
     expect(deniedEvents[0]).toEqual(expect.objectContaining({
       name: 'my-skill',
       resourcePath: 'SKILL.md',

--- a/packages/skills/tests/conformance.test.ts
+++ b/packages/skills/tests/conformance.test.ts
@@ -242,12 +242,13 @@ describe('Conformance: Tool Activation', () => {
     expect(body).toContain('Test Quality Rules');
   });
 
-  it('should activate community-tool from untrusted root', async () => {
+  it('should keep community-tool discoverable but block full-body activation from an untrusted root', async () => {
     const [activateSkill] = registry.toActivationTools();
     const body = await activateSkill.invoke({ name: 'community-tool' });
-    expect(body).toContain('Community Tool');
-    // Activation always works regardless of trust — trust is enforced on resources
-    expect(body).toContain('trust policy');
+    expect(body).toContain('blocked');
+    expect(body).toContain('untrusted');
+    expect(body).toContain('trusted');
+    expect(body).not.toContain('Community Tool');
   });
 
   it('should emit SKILL_ACTIVATED event on activation', async () => {
@@ -499,9 +500,11 @@ describe('Conformance: Full Pipeline', () => {
     expect(codeReviewBody).toContain('Code Review Skill');
 
     const communityBody = await activateSkill.invoke({ name: 'community-tool' });
-    expect(communityBody).toContain('Community Tool');
+    expect(communityBody).toContain('blocked');
+    expect(communityBody).toContain('untrusted');
+    expect(communityBody).not.toContain('Community Tool');
 
-    expect(activated).toHaveLength(2);
+    expect(activated).toHaveLength(1);
 
     // 4. Read resource — workspace reference (allowed)
     const styleGuide = await readResource.invoke({
@@ -531,7 +534,7 @@ describe('Conformance: Full Pipeline', () => {
       path: 'scripts/install.sh',
     });
     expect(blockedScript).toContain('blocked');
-    expect(denied).toHaveLength(1);
+    expect(denied).toHaveLength(2);
 
     // 8. Path traversal — blocked regardless of trust
     const traversal = await readResource.invoke({

--- a/packages/skills/tests/prompt.test.ts
+++ b/packages/skills/tests/prompt.test.ts
@@ -81,6 +81,21 @@ describe('SkillRegistry.generatePrompt()', () => {
       expect(xml).toContain('<name>my-skill</name>');
     });
 
+    it('should classify plain string roots as untrusted', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'community-skill', {
+        name: 'community-skill',
+        description: 'Community skill',
+      });
+
+      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<untrusted_skills>');
+      expect(xml).toContain('<trust>untrusted</trust>');
+      expect(xml).not.toContain('<available_skills>');
+    });
+
     it('should return empty string when enabled but no skills discovered', () => {
       const root = makeTempDir();
       // Empty root — no skills

--- a/packages/skills/tests/prompt.test.ts
+++ b/packages/skills/tests/prompt.test.ts
@@ -294,6 +294,34 @@ describe('SkillRegistry.generatePrompt()', () => {
       expect(skillBlocks).toHaveLength(2);
     });
 
+    it('should prioritize trusted skills before restricted skills when capped', () => {
+      const untrustedRoot = makeTempDir();
+      const trustedRoot = makeTempDir();
+      createSkillFixture(untrustedRoot, 'community-skill', {
+        name: 'community-skill',
+        description: 'Community skill',
+      });
+      createSkillFixture(trustedRoot, 'workspace-skill', {
+        name: 'workspace-skill',
+        description: 'Workspace skill',
+      });
+
+      const registry = new SkillRegistry({
+        skillRoots: [
+          { path: untrustedRoot, trust: 'untrusted' },
+          { path: trustedRoot, trust: 'workspace' },
+        ],
+        enabled: true,
+        maxDiscoveredSkills: 1,
+      });
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<name>workspace-skill</name>');
+      expect(xml).not.toContain('<name>community-skill</name>');
+      expect(xml).toContain('<available_skills>');
+      expect(xml).not.toContain('<untrusted_skills>');
+    });
+
     it('should return empty string when maxDiscoveredSkills is 0', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });

--- a/packages/skills/tests/prompt.test.ts
+++ b/packages/skills/tests/prompt.test.ts
@@ -72,7 +72,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt();
       expect(xml).toContain('<available_skills>');
       expect(xml).toContain('</available_skills>');
@@ -82,7 +82,7 @@ describe('SkillRegistry.generatePrompt()', () => {
     it('should return empty string when enabled but no skills discovered', () => {
       const root = makeTempDir();
       // Empty root — no skills
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       expect(registry.generatePrompt()).toBe('');
     });
   });
@@ -97,7 +97,7 @@ describe('SkillRegistry.generatePrompt()', () => {
         description: 'Review code for quality and correctness',
       });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt();
 
       expect(xml).toMatch(/^<available_skills>\n/);
@@ -114,7 +114,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
       createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt();
 
       expect(xml).toContain('<name>code-review</name>');
@@ -123,6 +123,40 @@ describe('SkillRegistry.generatePrompt()', () => {
       // Count skill blocks
       const skillBlocks = xml.match(/<skill>/g);
       expect(skillBlocks).toHaveLength(2);
+    });
+
+    it('should separate untrusted skills from the trusted available-skills list', () => {
+      const workspaceRoot = makeTempDir();
+      const communityRoot = makeTempDir();
+      createSkillFixture(workspaceRoot, 'workspace-skill', {
+        name: 'workspace-skill',
+        description: 'First-party workspace skill',
+      });
+      createSkillFixture(communityRoot, 'community-skill', {
+        name: 'community-skill',
+        description: 'Third-party community skill',
+      });
+
+      const registry = new SkillRegistry({
+        skillRoots: [
+          { path: workspaceRoot, trust: 'workspace' },
+          { path: communityRoot, trust: 'untrusted' },
+        ],
+        enabled: true,
+      });
+
+      const xml = registry.generatePrompt();
+
+      expect(xml).toContain('<available_skills>');
+      expect(xml).toContain('<name>workspace-skill</name>');
+      expect(xml).toContain('<trust>workspace</trust>');
+      expect(xml).toContain('<untrusted_skills>');
+      expect(xml).toContain('<name>community-skill</name>');
+      expect(xml).toContain('<trust>untrusted</trust>');
+      expect(xml).toContain('<activation_policy>requires-trusted-root</activation_policy>');
+
+      const trustedSection = xml.split('<untrusted_skills>')[0] ?? '';
+      expect(trustedSection).not.toContain('<name>community-skill</name>');
     });
 
     it('should escape XML special characters in skill fields', () => {
@@ -139,7 +173,7 @@ describe('SkillRegistry.generatePrompt()', () => {
         '# HTML Tools',
       ].join('\n'), 'utf-8');
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt();
 
       expect(xml).toContain('<name>html-tools</name>');
@@ -158,7 +192,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
       createSkillFixture(root, 'deployment', { name: 'deployment', description: 'Deploy apps' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt({ skills: ['code-review', 'testing'] });
 
       expect(xml).toContain('<name>code-review</name>');
@@ -173,7 +207,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt({ skills: ['nonexistent'] });
 
       expect(xml).toBe('');
@@ -184,7 +218,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
       createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt({ skills: [] });
 
       expect(xml).toContain('<name>code-review</name>');
@@ -196,7 +230,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
       createSkillFixture(root, 'testing', { name: 'testing', description: 'Write tests' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt();
 
       expect(xml).toContain('<name>code-review</name>');
@@ -207,7 +241,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt({ skills: ['code-review', 'nonexistent'] });
 
       expect(xml).toContain('<name>code-review</name>');
@@ -228,7 +262,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
 
       const registry = new SkillRegistry({
-        skillRoots: [root],
+        skillRoots: [{ path: root, trust: 'workspace' }],
         enabled: true,
         maxDiscoveredSkills: 2,
       });
@@ -243,7 +277,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
 
       const registry = new SkillRegistry({
-        skillRoots: [root],
+        skillRoots: [{ path: root, trust: 'workspace' }],
         enabled: true,
         maxDiscoveredSkills: 0,
       });
@@ -258,7 +292,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'skill-b', { name: 'skill-b', description: 'Skill B' });
 
       const registry = new SkillRegistry({
-        skillRoots: [root],
+        skillRoots: [{ path: root, trust: 'workspace' }],
         enabled: true,
         maxDiscoveredSkills: 100,
       });
@@ -275,7 +309,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
 
       const registry = new SkillRegistry({
-        skillRoots: [root],
+        skillRoots: [{ path: root, trust: 'workspace' }],
         enabled: true,
         maxDiscoveredSkills: 1,
       });
@@ -294,7 +328,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       createSkillFixture(root, 'skill-c', { name: 'skill-c', description: 'Skill C' });
 
       const registry = new SkillRegistry({
-        skillRoots: [root],
+        skillRoots: [{ path: root, trust: 'workspace' }],
         enabled: true,
         // maxDiscoveredSkills not set
       });
@@ -312,7 +346,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'code-review', { name: 'code-review', description: 'Review code' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
 
       // Simulate composing with tool prompt
       const toolPrompt = 'Available Tools:\n\n- my-tool: Does things';
@@ -349,7 +383,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml = registry.generatePrompt(undefined);
 
       expect(xml).toContain('<name>my-skill</name>');
@@ -357,7 +391,7 @@ describe('SkillRegistry.generatePrompt()', () => {
 
     it('should handle empty registry with enabled flag', () => {
       const root = makeTempDir();
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
 
       expect(registry.generatePrompt()).toBe('');
       expect(registry.generatePrompt({ skills: ['anything'] })).toBe('');
@@ -367,7 +401,7 @@ describe('SkillRegistry.generatePrompt()', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'skill-a', { name: 'skill-a', description: 'Skill A' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       expect(registry.generatePrompt()).toContain('<name>skill-a</name>');
 
       // Add another skill and re-scan
@@ -379,11 +413,31 @@ describe('SkillRegistry.generatePrompt()', () => {
       expect(xml).toContain('<name>skill-b</name>');
     });
 
+    it('should still expose untrusted skills when no trusted skills are available', () => {
+      const root = makeTempDir();
+      createSkillFixture(root, 'community-skill', {
+        name: 'community-skill',
+        description: 'Third-party community skill',
+      });
+
+      const registry = new SkillRegistry({
+        skillRoots: [{ path: root, trust: 'untrusted' }],
+        enabled: true,
+      });
+
+      const xml = registry.generatePrompt();
+
+      expect(xml).not.toContain('<available_skills>');
+      expect(xml).toContain('<untrusted_skills>');
+      expect(xml).toContain('<name>community-skill</name>');
+      expect(xml).toContain('<activation_policy>requires-trusted-root</activation_policy>');
+    });
+
     it('should produce consistent XML across multiple calls', () => {
       const root = makeTempDir();
       createSkillFixture(root, 'my-skill', { name: 'my-skill', description: 'A skill' });
 
-      const registry = new SkillRegistry({ skillRoots: [root], enabled: true });
+      const registry = new SkillRegistry({ skillRoots: [{ path: root, trust: 'workspace' }], enabled: true });
       const xml1 = registry.generatePrompt();
       const xml2 = registry.generatePrompt();
 

--- a/packages/skills/tests/prompt.test.ts
+++ b/packages/skills/tests/prompt.test.ts
@@ -11,6 +11,8 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SkillRegistry } from '../src/registry.js';
+import { generateSkillPrompt } from '../src/registry-prompt.js';
+import type { Skill } from '../src/types.js';
 
 /**
  * Create a temp directory for test fixtures.
@@ -157,6 +159,26 @@ describe('SkillRegistry.generatePrompt()', () => {
 
       const trustedSection = xml.split('<untrusted_skills>')[0] ?? '';
       expect(trustedSection).not.toContain('<name>community-skill</name>');
+    });
+
+    it('should restrict unknown runtime trust values to the untrusted section', () => {
+      const skill = {
+        metadata: { name: 'unknown-trust', description: 'Unknown trust' },
+        skillPath: '/skills/unknown-trust',
+        rootPath: '/skills',
+        trustLevel: 'unknown',
+      } as unknown as Skill;
+
+      const xml = generateSkillPrompt(
+        { enabled: true, skillRoots: [] },
+        [skill],
+        1,
+      );
+
+      expect(xml).not.toContain('<available_skills>');
+      expect(xml).toContain('<untrusted_skills>');
+      expect(xml).toContain('<trust>unknown</trust>');
+      expect(xml).toContain('<activation_policy>requires-trusted-root</activation_policy>');
     });
 
     it('should escape XML special characters in skill fields', () => {

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -87,7 +87,8 @@
 ### Checklist
 - [x] Create branch `feat/st-11005-skill-trust-boundaries`
   - Created on 2026-07-17 from `main` after moving `ST-11005` to `In Progress` in `planning/kanban-queue.md`.
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - Draft PR #160 created on 2026-07-17: <https://github.com/TVScoundrel/agentforge/pull/160>
 - [x] Define test strategy before implementation: identify the practical failing automated test seam for untrusted-skill discovery, prompt generation, and activation trust handling
   - Strategy: use focused red/green regressions in `packages/skills/tests/prompt.test.ts` and `packages/skills/tests/activation/activate-skill.suite.ts`, then re-run the activation entrypoint in `packages/skills/tests/activation.test.ts` to confirm the trust-aware activation flow composes with existing resource-policy coverage.
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
@@ -108,8 +109,11 @@
   - Added the prompt and activation regressions plus updated activation integration coverage; no additional focused automated tests are currently required beyond the pending repo-wide full-suite and lint gates.
 - [x] Assess CI impact; update CI or document why no CI change is required
   - No CI change is required because the hardening fits the existing skills-package and repo-wide validation paths; this story adds coverage inside the current Vitest suites rather than introducing a new automation contract.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `224` passed, `9` skipped files; `2505` passed, `110` skipped tests.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with the existing warning baseline only (`0` errors); workspace lint still reports longstanding warnings and ESLint flat-config env warnings in legacy example files outside this story.
 - [ ] Commit completed checklist items as logical commits and push updates
+  - `4a107088` `fix(st-11005): enforce skill trust boundaries` already pushed to `origin/feat/st-11005-skill-trust-boundaries`; this checklist sync plus the conformance expectation update are being recorded in the final review-prep follow-up commit.
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -79,3 +79,37 @@
   - PR #159 marked ready for review on 2026-07-16 after the focused regressions, repo-wide `pnpm test --run`, `pnpm lint`, checklist sync, and PR body verification all completed successfully.
 - [x] Wait for merge; do not merge directly from local branch
   - PR #159 merged into `main` on 2026-07-16 as commit `7aaeb92e`; post-merge tracker sync, done-story archival, and ready-lane grooming were completed from local `main`.
+
+## ST-11005: Enforce Trust-Aware Skill Prompt and Activation Boundaries
+
+**Branch:** `feat/st-11005-skill-trust-boundaries`
+
+### Checklist
+- [x] Create branch `feat/st-11005-skill-trust-boundaries`
+  - Created on 2026-07-17 from `main` after moving `ST-11005` to `In Progress` in `planning/kanban-queue.md`.
+- [ ] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: identify the practical failing automated test seam for untrusted-skill discovery, prompt generation, and activation trust handling
+  - Strategy: use focused red/green regressions in `packages/skills/tests/prompt.test.ts` and `packages/skills/tests/activation/activate-skill.suite.ts`, then re-run the activation entrypoint in `packages/skills/tests/activation.test.ts` to confirm the trust-aware activation flow composes with existing resource-policy coverage.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Added prompt and activation regressions first, then captured the expected red failures with `pnpm exec vitest --run packages/skills/tests/prompt.test.ts packages/skills/tests/activation/activate-skill.suite.ts`; initial failures confirmed untrusted skills were still emitted as ordinary `<available_skills>` entries and activation still returned full SKILL.md bodies.
+- [x] Identify the current prompt-generation and activation paths that treat untrusted skill content on the same footing as trusted/workspace skills, and document the intended trust boundary
+  - Confirmed the vulnerable path in `packages/skills/src/registry-prompt.ts` and `packages/skills/src/activation-activate-tool.ts`, where trust level existed for resource enforcement but not for prompt rendering or SKILL.md activation; the new boundary keeps untrusted roots discoverable while blocking full-body activation until root promotion.
+- [x] Update skill prompt generation and activation flows so trust level is explicit and untrusted skill bodies are not presented to the model on the same footing as trusted/workspace skills without an explicit policy choice
+  - `generatePrompt()` now separates trusted/workspace entries from discoverable `<untrusted_skills>` output, and `activate-skill` now enforces trust-aware SKILL.md activation via `evaluateSkillActivationPolicy()`.
+- [x] Preserve the existing script-resource trust policy and ensure the new prompt/activation trust handling composes with it without split-brain behavior
+  - Preserved `read-skill-resource` script gating and added the activation trust check alongside it so trusted/workspace roots still activate normally while untrusted roots remain blocked for both full-body activation and `scripts/` reads.
+- [x] Add focused regression or conformance coverage for untrusted-skill discovery, activation behavior, and the trusted-root opt-in path
+  - Added/updated focused regressions in `packages/skills/tests/prompt.test.ts`, `packages/skills/tests/activation/activate-skill.suite.ts`, and `packages/skills/tests/activation/activation-tools.suite.ts`; green validation passed with `pnpm exec vitest --run packages/skills/tests/prompt.test.ts packages/skills/tests/activation.test.ts`.
+- [x] Update public docs to explain trust tradeoffs for community skill packs and the migration path for existing adopters
+  - Updated `docs-site/guide/agent-skills.md`, `docs-site/guide/agent-skills-authoring.md`, and `docs-site/tutorials/skill-powered-agent.md` with the new prompt structure, activation boundary, and root-promotion migration guidance.
+- [x] Add or update story documentation at `docs/st11005-skill-trust-boundary-hardening.md` (or document why not required)
+  - Added `docs/st11005-skill-trust-boundary-hardening.md`.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - Added the prompt and activation regressions plus updated activation integration coverage; no additional focused automated tests are currently required beyond the pending repo-wide full-suite and lint gates.
+- [x] Assess CI impact; update CI or document why no CI change is required
+  - No CI change is required because the hardening fits the existing skills-package and repo-wide validation paths; this story adds coverage inside the current Vitest suites rather than introducing a new automation contract.
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Commit completed checklist items as logical commits and push updates
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -113,7 +113,8 @@
   - `pnpm test --run` -> `224` passed, `9` skipped files; `2505` passed, `110` skipped tests.
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> passed with the existing warning baseline only (`0` errors); workspace lint still reports longstanding warnings and ESLint flat-config env warnings in legacy example files outside this story.
-- [ ] Commit completed checklist items as logical commits and push updates
-  - `4a107088` `fix(st-11005): enforce skill trust boundaries` already pushed to `origin/feat/st-11005-skill-trust-boundaries`; this checklist sync plus the conformance expectation update are being recorded in the final review-prep follow-up commit.
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items as logical commits and push updates
+  - `4a107088` `fix(st-11005): enforce skill trust boundaries` and `2877bbe0` `test(st-11005): align conformance expectations` were pushed to `origin/feat/st-11005-skill-trust-boundaries`; the final ready-state tracker sync is captured in the current follow-up commit.
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #160 marked ready for review on 2026-07-17 after the conformance expectation fix, repo-wide `pnpm test --run`, `pnpm lint`, checklist sync, and PR body update were complete.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
-**Last Updated:** 2026-07-16
-**Active Story:** ST-11004 - Merged on 2026-07-16 (PR #159); next recommended ready story is ST-11005
+**Last Updated:** 2026-07-17
+**Active Story:** ST-11005 - In Progress on 2026-07-17; ST-11004 merged on 2026-07-16 (PR #159)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-16
+**Last Updated:** 2026-07-17
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories
-- **In Progress:** 0 stories
+- **Ready:** 3 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-11005` - Enforce Trust-Aware Skill Prompt and Activation Boundaries
-  - Depends on: `ST-11001` (merged)
 - `ST-11002` - Harden Default Web Tool Egress Policy
   - Depends on: `ST-11001` (merged)
 - `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
@@ -27,7 +25,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-11005` - Enforce Trust-Aware Skill Prompt and Activation Boundaries
+  - Depends on: `ST-11001` (merged)
 
 ---
 
@@ -52,7 +51,7 @@ _No stories currently in backlog_
 ## Notes
 
 - ST-11001 complete - repository security policy routing is now documented through the root README, contributing guide, tools guide, and agent-skills guides; Epic 11 queue grooming promoted `ST-11005`, `ST-11002`, `ST-11003`, and `ST-11006` into `Ready` behind the existing top-priority `ST-11004` after the policy baseline merged (merged 2026-07-15, PR #158)
-- ST-11004 complete - multi-agent supervisor routing now preserves trusted `supervisorTask` intent separately from worker `task_result` output, reuses worker results only as labeled untrusted context, and bounds that context for prompt growth safety; the ready lane now advances to `ST-11005` with `ST-11002`, `ST-11003`, and `ST-11006` still dependency-ready behind it (merged 2026-07-16, PR #159)
+- ST-11004 complete - multi-agent supervisor routing now preserves trusted `supervisorTask` intent separately from worker `task_result` output, reuses worker results only as labeled untrusted context, and bounds that context for prompt growth safety; the ready lane advanced to `ST-11005`, which moved to `In Progress` on 2026-07-17, with `ST-11002`, `ST-11003`, and `ST-11006` still dependency-ready behind it (merged 2026-07-16, PR #159)
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story
- ST-11005: Enforce Trust-Aware Skill Prompt and Activation Boundaries

## What Changed
- separated trusted and untrusted skill discovery in `SkillRegistry.generatePrompt()` so untrusted roots surface through a dedicated `<untrusted_skills>` section instead of the trusted `<available_skills>` list
- blocked `activate-skill` from returning full SKILL.md bodies for untrusted roots until the operator explicitly promotes the root to `trusted` or `workspace`
- preserved the existing script-resource trust policy and aligned activation behavior with it through a shared trust-policy seam
- added focused prompt and activation regressions, conformance coverage, and public docs for the migration path from plain string roots to explicit trust configuration

## Acceptance Criteria Coverage
- trust level is now explicit in generated skill prompt output, and untrusted skills are no longer presented on the same footing as trusted/workspace skills by default
- the existing script-resource trust policy remains intact and now composes with full-body activation trust enforcement
- focused regressions and conformance coverage cover untrusted-skill discovery, blocked untrusted activation, and the trusted-root opt-in path
- public docs explain the community-skill trust tradeoffs and root-promotion migration path
- story documentation added at `docs/st11005-skill-trust-boundary-hardening.md`

## Test Strategy
- test-first: added red regressions in `packages/skills/tests/prompt.test.ts` and `packages/skills/tests/activation/activate-skill.suite.ts` before changing runtime behavior
- validation included focused green runs, a conformance expectation update after the repo-wide run exposed outdated trust assumptions, then repo-wide test and lint verification

## Validation Performed
- `pnpm exec vitest --run packages/skills/tests/prompt.test.ts packages/skills/tests/activation.test.ts`
- `pnpm exec vitest --run packages/skills/tests/conformance.test.ts`
- `pnpm test --run`
- `pnpm lint`

## Validation Results
- `pnpm test --run` -> `224` passed, `9` skipped files; `2505` passed, `110` skipped tests
- `pnpm lint` -> passed with existing repo warning baseline only (`0` errors)

## Status
- Ready for review after final checklist-sync push
