### PR TITLE
feat(tools): harden default web tool egress policy [ST-11002]

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -78,6 +78,25 @@ const result = await httpPost.invoke({
 });
 ```
 
+HTTP and scraper factories apply a destination policy before every request. By default, localhost, metadata, link-local, and private-network destinations are blocked, including destinations reached through redirects or hostname resolution. Use the explicit opt-in flags only for trusted operator-controlled or internal-network workflows:
+
+```typescript
+import { createHttpTools, createScraperTools } from '@agentforge/tools';
+
+const [safeHttpClient] = createHttpTools({
+  destinationPolicy: { maxRedirects: 3 }
+});
+
+const [internalScraper] = createScraperTools({
+  destinationPolicy: {
+    allowPrivateNetwork: true,
+    allowLocalhost: true,
+  }
+});
+```
+
+Available policy flags are `allowLocalhost`, `allowPrivateNetwork`, `allowLinkLocal`, `allowMetadata`, `allowRedirects`, and `maxRedirects`. See [`ST-11002` web egress policy hardening](https://github.com/TVScoundrel/agentforge/blob/main/docs/st11002-web-egress-policy-hardening.md) for the security rationale and migration guidance.
+
 ### Web Scraping
 
 ```typescript
@@ -1400,4 +1419,3 @@ const tools = [askHuman, ...otherTools];
 ## Complete Tool List
 
 See the [Tools README](https://github.com/TVScoundrel/agentforge/tree/main/packages/tools) for the complete list of all 88 tools with detailed documentation.
-

--- a/docs/st11002-web-egress-policy-hardening.md
+++ b/docs/st11002-web-egress-policy-hardening.md
@@ -1,0 +1,45 @@
+# ST-11002: Web Tool Egress Policy Hardening
+
+## Outcome
+
+The default HTTP and scraper tools now validate every HTTP(S) destination before making a request. Localhost, metadata endpoints, link-local addresses, and private-network addresses are blocked by default, including when a hostname resolves to one of those address classes.
+
+Redirects are handled explicitly rather than delegated to Axios. Each `Location` target is resolved and revalidated before the next request, so a public URL cannot redirect through a chain into a blocked destination. Redirects are limited to five hops by default.
+
+## Configuration
+
+`createHttpTools()` and `createScraperTools()` accept a `destinationPolicy` configuration:
+
+```typescript
+import { createHttpTools, createScraperTools } from '@agentforge/tools';
+
+const [httpClient] = createHttpTools({
+  destinationPolicy: {
+    maxRedirects: 3,
+  },
+});
+
+const [scraper] = createScraperTools({
+  destinationPolicy: {
+    allowPrivateNetwork: true,
+  },
+});
+```
+
+The opt-in flags are intentionally separate:
+
+- `allowLocalhost` permits loopback destinations.
+- `allowPrivateNetwork` permits RFC1918, IPv6 ULA, and carrier-grade private ranges.
+- `allowLinkLocal` permits link-local destinations.
+- `allowMetadata` permits known cloud metadata destinations, including `169.254.169.254`.
+- `allowRedirects` can be set to `false`, and `maxRedirects` bounds allowed hops.
+
+Applications should grant only the narrowest policy required. The opt-in exists for trusted operator-controlled or internal-network workflows; it is not a safe default for model-exposed tools.
+
+## Compatibility
+
+Existing factory signatures remain compatible. Existing HTTP and scraper tools still follow normal HTTP redirects and return their normal response/data shapes, but unsafe destinations now fail with `DestinationPolicyError` before the network request. The generic HTTP client reports the final URL after a validated redirect chain.
+
+## Validation
+
+Focused coverage in `packages/tools/tests/web/egress-policy.test.ts` covers IP literals, DNS-resolved private addresses, chained redirect bypasses, privileged opt-in, and factory wiring. No CI change is required because the policy uses the existing package and workspace TypeScript/Vitest/lint validation paths.

--- a/packages/tools/src/web/egress-policy.ts
+++ b/packages/tools/src/web/egress-policy.ts
@@ -1,6 +1,6 @@
 import { lookup as dnsLookup } from 'node:dns/promises';
 import net from 'node:net';
-import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios';
+import axios, { type AddressFamily, type AxiosRequestConfig, type AxiosResponse, type LookupAddress } from 'axios';
 
 export type DestinationBlockReason =
   | 'unsupported-protocol'
@@ -24,6 +24,11 @@ const DEFAULT_MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const IPV4_MAPPED_NETWORK = '::ffff:0:0';
 const SENSITIVE_REDIRECT_HEADERS = new Set(['authorization', 'cookie', 'proxy-authorization']);
+
+interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
 
 export const DEFAULT_DESTINATION_POLICY = Object.freeze({
   allowLocalhost: false,
@@ -135,10 +140,10 @@ function policyAllows(reason: DestinationBlockReason, policy: DestinationPolicy)
   return false;
 }
 
-async function resolveDestinationAddresses(hostname: string): Promise<string[]> {
+async function resolveDestinationAddresses(hostname: string): Promise<ResolvedAddress[]> {
   try {
     const addresses = await dnsLookup(hostname, { all: true, verbatim: true });
-    return addresses.map(({ address }) => address);
+    return addresses.map(({ address, family }) => ({ address, family: family as 4 | 6 }));
   } catch (error) {
     throw new DestinationPolicyError(hostname, 'dns-resolution-failed', `Destination policy could not resolve hostname "${hostname}" before making a request: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -148,7 +153,7 @@ function blockDestination(url: string, reason: DestinationBlockReason): never {
   throw new DestinationPolicyError(url, reason, `Destination blocked by web egress policy (${reason}): ${url}`);
 }
 
-export async function assertDestinationAllowed(url: string, policy: DestinationPolicy = {}): Promise<void> {
+async function validateDestinationAllowed(url: string, policy: DestinationPolicy): Promise<ResolvedAddress[]> {
   const effectivePolicy = { ...DEFAULT_DESTINATION_POLICY, ...policy };
   let parsed: URL;
   try {
@@ -161,12 +166,19 @@ export async function assertDestinationAllowed(url: string, policy: DestinationP
   const hostname = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
   const directReason = classifyHostname(hostname);
   if (directReason && !policyAllows(directReason, effectivePolicy)) blockDestination(url, directReason);
-  if (directReason) return;
+  const version = net.isIP(hostname);
+  if (version !== 0) return [{ address: hostname, family: version as 4 | 6 }];
 
-  for (const address of await resolveDestinationAddresses(hostname)) {
+  const addresses = await resolveDestinationAddresses(hostname);
+  for (const { address } of addresses) {
     const reason = classifyIp(address);
     if (reason && !policyAllows(reason, effectivePolicy)) blockDestination(url, reason);
   }
+  return addresses;
+}
+
+export async function assertDestinationAllowed(url: string, policy: DestinationPolicy = {}): Promise<void> {
+  await validateDestinationAllowed(url, policy);
 }
 
 function isRedirectStatus(status: number): boolean {
@@ -187,6 +199,29 @@ function stripSensitiveRedirectHeaders(headers: AxiosRequestConfig['headers']): 
   return sanitizedHeaders as AxiosRequestConfig['headers'];
 }
 
+function createPinnedLookup(addresses: ResolvedAddress[]) {
+  return (
+    _hostname: string,
+    options: object,
+    callback: (error: Error | null, address: LookupAddress | LookupAddress[], family?: AddressFamily) => void
+  ): void => {
+    const requestedFamily = 'family' in options && (options.family === 4 || options.family === 6) ? options.family : undefined;
+    const candidates = requestedFamily ? addresses.filter(({ family }) => family === requestedFamily) : addresses;
+    if (candidates.length === 0) {
+      callback(new Error(`No validated destination address matches the requested address family: ${requestedFamily}`), '', undefined);
+      return;
+    }
+
+    if ('all' in options && options.all === true) {
+      callback(null, candidates, undefined);
+      return;
+    }
+
+    const [{ address, family }] = candidates;
+    callback(null, address, family);
+  };
+}
+
 export async function requestWithDestinationPolicy<T = unknown>(config: AxiosRequestConfig<T>, policy: DestinationPolicy = {}): Promise<AxiosResponse<T>> {
   if (!config.url) throw new Error('A request URL is required for destination policy enforcement');
   const effectivePolicy = { ...DEFAULT_DESTINATION_POLICY, ...policy };
@@ -202,7 +237,8 @@ export async function requestWithDestinationPolicy<T = unknown>(config: AxiosReq
   };
 
   for (let redirectCount = 0; ; redirectCount += 1) {
-    await assertDestinationAllowed(currentUrl, effectivePolicy);
+    const validatedAddresses = await validateDestinationAllowed(currentUrl, effectivePolicy);
+    currentConfig.lookup = createPinnedLookup(validatedAddresses);
     const response = await axios(currentConfig);
     if (!isRedirectStatus(response.status)) return response;
     if (effectivePolicy.allowRedirects === false) blockDestination(currentUrl, 'redirect');

--- a/packages/tools/src/web/egress-policy.ts
+++ b/packages/tools/src/web/egress-policy.ts
@@ -247,7 +247,11 @@ export async function requestWithDestinationPolicy<T = unknown>(config: AxiosReq
     const location = responseLocation(response);
     if (!location) throw new DestinationPolicyError(currentUrl, 'redirect', `Redirect response did not include a Location header: ${currentUrl}`);
     const previousUrl = currentUrl;
-    currentUrl = new URL(location, currentUrl).toString();
+    try {
+      currentUrl = new URL(location, currentUrl).toString();
+    } catch {
+      throw new DestinationPolicyError(currentUrl, 'redirect', `Redirect response included an invalid Location header: ${location}`);
+    }
     const method = String(currentConfig.method ?? 'GET').toUpperCase();
     const nextMethod = response.status === 303 || ((response.status === 301 || response.status === 302) && method === 'POST') ? 'GET' : method;
     currentConfig = { ...currentConfig, url: currentUrl, method: nextMethod };

--- a/packages/tools/src/web/egress-policy.ts
+++ b/packages/tools/src/web/egress-policy.ts
@@ -1,0 +1,209 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import net from 'node:net';
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios';
+
+export type DestinationBlockReason =
+  | 'unsupported-protocol'
+  | 'localhost'
+  | 'metadata'
+  | 'private-network'
+  | 'link-local'
+  | 'redirect'
+  | 'dns-resolution-failed';
+
+export interface DestinationPolicy {
+  allowLocalhost?: boolean;
+  allowPrivateNetwork?: boolean;
+  allowLinkLocal?: boolean;
+  allowMetadata?: boolean;
+  allowRedirects?: boolean;
+  maxRedirects?: number;
+}
+
+const DEFAULT_MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const IPV4_MAPPED_NETWORK = '::ffff:0:0';
+
+export const DEFAULT_DESTINATION_POLICY = Object.freeze({
+  allowLocalhost: false,
+  allowPrivateNetwork: false,
+  allowLinkLocal: false,
+  allowMetadata: false,
+  allowRedirects: true,
+  maxRedirects: DEFAULT_MAX_REDIRECTS,
+});
+
+export class DestinationPolicyError extends Error {
+  readonly code = 'WEB_DESTINATION_BLOCKED';
+
+  constructor(
+    readonly url: string,
+    readonly reason: DestinationBlockReason,
+    message: string
+  ) {
+    super(message);
+    this.name = 'DestinationPolicyError';
+  }
+}
+
+function ipv4ToNumber(address: string): number | undefined {
+  const octets = address.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return undefined;
+  return (((octets[0] * 256 + octets[1]) * 256 + octets[2]) * 256 + octets[3]) >>> 0;
+}
+
+function ipv4InCidr(address: string, network: string, prefix: number): boolean {
+  const value = ipv4ToNumber(address);
+  const networkValue = ipv4ToNumber(network);
+  if (value === undefined || networkValue === undefined) return false;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (value & mask) === (networkValue & mask);
+}
+
+function expandIpv6(address: string): bigint | undefined {
+  const normalized = address.toLowerCase().split('%')[0];
+  let input = normalized;
+  const ipv4Start = normalized.lastIndexOf(':') + 1;
+  const ipv4 = normalized.slice(ipv4Start);
+
+  if (net.isIP(ipv4) === 4) {
+    const value = ipv4ToNumber(ipv4);
+    if (value === undefined) return undefined;
+    input = `${normalized.slice(0, ipv4Start)}${(value >>> 16).toString(16)}:${(value & 0xffff).toString(16)}`;
+  }
+
+  const halves = input.split('::');
+  if (halves.length > 2) return undefined;
+  const left = halves[0] ? halves[0].split(':').filter(Boolean) : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(':').filter(Boolean) : [];
+  const missing = 8 - left.length - right.length;
+  if (missing < 0 || (halves.length === 1 && missing !== 0)) return undefined;
+
+  const groups = [...left, ...Array.from({ length: missing }, () => '0'), ...right];
+  if (groups.length !== 8 || groups.some((group) => !/^[0-9a-f]{1,4}$/.test(group))) return undefined;
+  return groups.reduce((value, group) => (value << 16n) | BigInt(parseInt(group, 16)), 0n);
+}
+
+function ipv6InCidr(address: bigint, network: bigint, prefix: number): boolean {
+  return prefix === 0 || (address >> BigInt(128 - prefix)) === (network >> BigInt(128 - prefix));
+}
+
+function ipv6ToIpv4(address: bigint): string | undefined {
+  const mappedNetwork = expandIpv6(IPV4_MAPPED_NETWORK);
+  if (mappedNetwork === undefined || !ipv6InCidr(address, mappedNetwork, 96)) return undefined;
+  const value = Number(address & 0xffffffffn) >>> 0;
+  return [value >>> 24, (value >>> 16) & 255, (value >>> 8) & 255, value & 255].join('.');
+}
+
+function classifyIp(address: string): DestinationBlockReason | undefined {
+  const normalized = address.replace(/^\[|\]$/g, '').toLowerCase();
+  const version = net.isIP(normalized);
+
+  if (version === 4) {
+    if (normalized === '169.254.169.254') return 'metadata';
+    if (ipv4InCidr(normalized, '127.0.0.0', 8)) return 'localhost';
+    if (ipv4InCidr(normalized, '169.254.0.0', 16)) return 'link-local';
+    if (ipv4InCidr(normalized, '10.0.0.0', 8) || ipv4InCidr(normalized, '172.16.0.0', 12) || ipv4InCidr(normalized, '192.168.0.0', 16) || ipv4InCidr(normalized, '100.64.0.0', 10)) return 'private-network';
+    return undefined;
+  }
+
+  if (version !== 6) return undefined;
+  const value = expandIpv6(normalized);
+  if (value === undefined) return undefined;
+  const mappedIpv4 = ipv6ToIpv4(value);
+  if (mappedIpv4) return classifyIp(mappedIpv4);
+  if (value === expandIpv6('fd00:ec2::254')) return 'metadata';
+  if (value === expandIpv6('::1')) return 'localhost';
+  if (ipv6InCidr(value, expandIpv6('fe80::')!, 10)) return 'link-local';
+  if (ipv6InCidr(value, expandIpv6('fc00::')!, 7)) return 'private-network';
+  return undefined;
+}
+
+function classifyHostname(hostname: string): DestinationBlockReason | undefined {
+  const normalized = hostname.toLowerCase().replace(/\.$/, '');
+  if (normalized === 'localhost' || normalized.endsWith('.localhost') || normalized === 'localhost.localdomain') return 'localhost';
+  if (normalized === 'metadata' || normalized === 'metadata.google.internal' || normalized === 'instance-data') return 'metadata';
+  return classifyIp(normalized);
+}
+
+function policyAllows(reason: DestinationBlockReason, policy: DestinationPolicy): boolean {
+  if (reason === 'localhost') return policy.allowLocalhost === true;
+  if (reason === 'metadata') return policy.allowMetadata === true;
+  if (reason === 'private-network') return policy.allowPrivateNetwork === true;
+  if (reason === 'link-local') return policy.allowLinkLocal === true;
+  return false;
+}
+
+async function resolveDestinationAddresses(hostname: string): Promise<string[]> {
+  try {
+    const addresses = await dnsLookup(hostname, { all: true, verbatim: true });
+    return addresses.map(({ address }) => address);
+  } catch (error) {
+    throw new DestinationPolicyError(hostname, 'dns-resolution-failed', `Destination policy could not resolve hostname "${hostname}" before making a request: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function blockDestination(url: string, reason: DestinationBlockReason): never {
+  throw new DestinationPolicyError(url, reason, `Destination blocked by web egress policy (${reason}): ${url}`);
+}
+
+export async function assertDestinationAllowed(url: string, policy: DestinationPolicy = {}): Promise<void> {
+  const effectivePolicy = { ...DEFAULT_DESTINATION_POLICY, ...policy };
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    blockDestination(url, 'unsupported-protocol');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') blockDestination(url, 'unsupported-protocol');
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  const directReason = classifyHostname(hostname);
+  if (directReason && !policyAllows(directReason, effectivePolicy)) blockDestination(url, directReason);
+  if (directReason) return;
+
+  for (const address of await resolveDestinationAddresses(hostname)) {
+    const reason = classifyIp(address);
+    if (reason && !policyAllows(reason, effectivePolicy)) blockDestination(url, reason);
+  }
+}
+
+function isRedirectStatus(status: number): boolean {
+  return REDIRECT_STATUSES.has(status);
+}
+
+function responseLocation(response: AxiosResponse): string | undefined {
+  const headers = response.headers as Record<string, string | undefined>;
+  return headers.location ?? headers.Location;
+}
+
+export async function requestWithDestinationPolicy<T = unknown>(config: AxiosRequestConfig<T>, policy: DestinationPolicy = {}): Promise<AxiosResponse<T>> {
+  if (!config.url) throw new Error('A request URL is required for destination policy enforcement');
+  const effectivePolicy = { ...DEFAULT_DESTINATION_POLICY, ...policy };
+  const maxRedirects = effectivePolicy.maxRedirects;
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0) throw new Error('maxRedirects must be a non-negative integer');
+
+  let currentUrl = config.url;
+  let currentConfig: AxiosRequestConfig<T> = {
+    ...config,
+    url: currentUrl,
+    maxRedirects: 0,
+    validateStatus: (status) => isRedirectStatus(status) || (config.validateStatus ? config.validateStatus(status) : status >= 200 && status < 300),
+  };
+
+  for (let redirectCount = 0; ; redirectCount += 1) {
+    await assertDestinationAllowed(currentUrl, effectivePolicy);
+    const response = await axios(currentConfig);
+    if (!isRedirectStatus(response.status)) return response;
+    if (effectivePolicy.allowRedirects === false) blockDestination(currentUrl, 'redirect');
+    if (redirectCount >= maxRedirects) throw new DestinationPolicyError(currentUrl, 'redirect', `Maximum redirect count (${maxRedirects}) exceeded for ${currentUrl}`);
+
+    const location = responseLocation(response);
+    if (!location) throw new DestinationPolicyError(currentUrl, 'redirect', `Redirect response did not include a Location header: ${currentUrl}`);
+    currentUrl = new URL(location, currentUrl).toString();
+    const method = String(currentConfig.method ?? 'GET').toUpperCase();
+    const nextMethod = response.status === 303 || ((response.status === 301 || response.status === 302) && method === 'POST') ? 'GET' : method;
+    currentConfig = { ...currentConfig, url: currentUrl, method: nextMethod };
+    if (nextMethod === 'GET' || nextMethod === 'HEAD') delete currentConfig.data;
+  }
+}

--- a/packages/tools/src/web/egress-policy.ts
+++ b/packages/tools/src/web/egress-policy.ts
@@ -23,6 +23,7 @@ export interface DestinationPolicy {
 const DEFAULT_MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const IPV4_MAPPED_NETWORK = '::ffff:0:0';
+const SENSITIVE_REDIRECT_HEADERS = new Set(['authorization', 'cookie', 'proxy-authorization']);
 
 export const DEFAULT_DESTINATION_POLICY = Object.freeze({
   allowLocalhost: false,
@@ -177,6 +178,15 @@ function responseLocation(response: AxiosResponse): string | undefined {
   return headers.location ?? headers.Location;
 }
 
+function stripSensitiveRedirectHeaders(headers: AxiosRequestConfig['headers']): AxiosRequestConfig['headers'] {
+  if (!headers) return headers;
+  const sanitizedHeaders = { ...headers } as Record<string, unknown>;
+  for (const headerName of Object.keys(sanitizedHeaders)) {
+    if (SENSITIVE_REDIRECT_HEADERS.has(headerName.toLowerCase())) delete sanitizedHeaders[headerName];
+  }
+  return sanitizedHeaders as AxiosRequestConfig['headers'];
+}
+
 export async function requestWithDestinationPolicy<T = unknown>(config: AxiosRequestConfig<T>, policy: DestinationPolicy = {}): Promise<AxiosResponse<T>> {
   if (!config.url) throw new Error('A request URL is required for destination policy enforcement');
   const effectivePolicy = { ...DEFAULT_DESTINATION_POLICY, ...policy };
@@ -200,10 +210,14 @@ export async function requestWithDestinationPolicy<T = unknown>(config: AxiosReq
 
     const location = responseLocation(response);
     if (!location) throw new DestinationPolicyError(currentUrl, 'redirect', `Redirect response did not include a Location header: ${currentUrl}`);
+    const previousUrl = currentUrl;
     currentUrl = new URL(location, currentUrl).toString();
     const method = String(currentConfig.method ?? 'GET').toUpperCase();
     const nextMethod = response.status === 303 || ((response.status === 301 || response.status === 302) && method === 'POST') ? 'GET' : method;
     currentConfig = { ...currentConfig, url: currentUrl, method: nextMethod };
+    if (new URL(previousUrl).origin !== new URL(currentUrl).origin) {
+      currentConfig.headers = stripSensitiveRedirectHeaders(currentConfig.headers);
+    }
     if (nextMethod === 'GET' || nextMethod === 'HEAD') delete currentConfig.data;
   }
 }

--- a/packages/tools/src/web/http/index.ts
+++ b/packages/tools/src/web/http/index.ts
@@ -11,6 +11,8 @@ import type { HttpToolsConfig } from './types.js';
 
 // Export types
 export * from './types.js';
+export { assertDestinationAllowed, DEFAULT_DESTINATION_POLICY, DestinationPolicyError, requestWithDestinationPolicy } from '../egress-policy.js';
+export type { DestinationBlockReason, DestinationPolicy } from '../egress-policy.js';
 
 // Default tool instances
 export const httpClient = createHttpClientTool();
@@ -35,12 +37,11 @@ export const httpTools = [httpClient, httpGet, httpPost];
  * ```
  */
 export function createHttpTools(config: HttpToolsConfig = {}) {
-  const { defaultTimeout = 30000, defaultHeaders = {} } = config;
+  const { defaultTimeout = 30000, defaultHeaders = {}, destinationPolicy = {} } = config;
 
   return [
-    createHttpClientTool(defaultTimeout, defaultHeaders),
-    createHttpGetTool(defaultTimeout, defaultHeaders),
-    createHttpPostTool(defaultTimeout, defaultHeaders),
+    createHttpClientTool(defaultTimeout, defaultHeaders, destinationPolicy),
+    createHttpGetTool(defaultTimeout, defaultHeaders, destinationPolicy),
+    createHttpPostTool(defaultTimeout, defaultHeaders, destinationPolicy),
   ];
 }
-

--- a/packages/tools/src/web/http/tools/http-client.ts
+++ b/packages/tools/src/web/http/tools/http-client.ts
@@ -5,7 +5,8 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import axios, { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig } from 'axios';
+import { requestWithDestinationPolicy } from '../../egress-policy.js';
 import { httpRequestSchema, HttpResponse } from '../types.js';
 
 /**
@@ -25,11 +26,12 @@ import { httpRequestSchema, HttpResponse } from '../types.js';
  */
 export function createHttpClientTool(
   defaultTimeout: number = 30000,
-  defaultHeaders: Record<string, string> = {}
+  defaultHeaders: Record<string, string> = {},
+  destinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-client')
-    .description('Make HTTP requests to web APIs and services. Supports GET, POST, PUT, DELETE, PATCH methods with custom headers and body.')
+    .description('Make policy-checked HTTP requests to web APIs and services. Supports GET, POST, PUT, DELETE, PATCH methods with custom headers and body. Local, metadata, link-local, and private-network destinations are blocked by default.')
     .category(ToolCategory.WEB)
     .tags(['http', 'api', 'request', 'web'])
     .schema(httpRequestSchema)
@@ -44,17 +46,16 @@ export function createHttpClientTool(
         validateStatus: () => true, // Don't throw on any status code
       };
 
-      const response = await axios(config);
+      const response = await requestWithDestinationPolicy(config, destinationPolicy);
 
       return {
         status: response.status,
         statusText: response.statusText,
         headers: response.headers as Record<string, string>,
         data: response.data,
-        url: input.url,
+        url: response.config.url ?? input.url,
         method: input.method ?? 'GET',
       };
     })
     .build();
 }
-

--- a/packages/tools/src/web/http/tools/http-client.ts
+++ b/packages/tools/src/web/http/tools/http-client.ts
@@ -5,8 +5,9 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 import { requestWithDestinationPolicy } from '../../egress-policy.js';
+import type { DestinationPolicy } from '../../egress-policy.js';
 import { httpRequestSchema, HttpResponse } from '../types.js';
 
 /**
@@ -27,7 +28,7 @@ import { httpRequestSchema, HttpResponse } from '../types.js';
 export function createHttpClientTool(
   defaultTimeout: number = 30000,
   defaultHeaders: Record<string, string> = {},
-  destinationPolicy = {}
+  destinationPolicy: DestinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-client')

--- a/packages/tools/src/web/http/tools/http-get.ts
+++ b/packages/tools/src/web/http/tools/http-get.ts
@@ -5,7 +5,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import axios from 'axios';
+import { requestWithDestinationPolicy } from '../../egress-policy.js';
 import { httpGetSchema } from '../types.js';
 
 /**
@@ -16,22 +16,24 @@ import { httpGetSchema } from '../types.js';
  */
 export function createHttpGetTool(
   defaultTimeout: number = 30000,
-  defaultHeaders: Record<string, string> = {}
+  defaultHeaders: Record<string, string> = {},
+  destinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-get')
-    .description('Make a simple HTTP GET request to a URL and return the response data.')
+    .description('Make a policy-checked HTTP GET request to a URL and return the response data. Local, metadata, link-local, and private-network destinations are blocked by default.')
     .category(ToolCategory.WEB)
     .tags(['http', 'get', 'fetch', 'web'])
     .schema(httpGetSchema)
     .implement(async (input) => {
-      const response = await axios.get(input.url, {
+      const response = await requestWithDestinationPolicy({
+        method: 'GET',
+        url: input.url,
         headers: { ...defaultHeaders, ...input.headers },
         params: input.params,
         timeout: defaultTimeout,
-      });
+      }, destinationPolicy);
       return response.data;
     })
     .build();
 }
-

--- a/packages/tools/src/web/http/tools/http-get.ts
+++ b/packages/tools/src/web/http/tools/http-get.ts
@@ -6,6 +6,7 @@
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { requestWithDestinationPolicy } from '../../egress-policy.js';
+import type { DestinationPolicy } from '../../egress-policy.js';
 import { httpGetSchema } from '../types.js';
 
 /**
@@ -17,7 +18,7 @@ import { httpGetSchema } from '../types.js';
 export function createHttpGetTool(
   defaultTimeout: number = 30000,
   defaultHeaders: Record<string, string> = {},
-  destinationPolicy = {}
+  destinationPolicy: DestinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-get')

--- a/packages/tools/src/web/http/tools/http-post.ts
+++ b/packages/tools/src/web/http/tools/http-post.ts
@@ -5,7 +5,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import axios from 'axios';
+import { requestWithDestinationPolicy } from '../../egress-policy.js';
 import { httpPostSchema } from '../types.js';
 
 /**
@@ -16,25 +16,28 @@ import { httpPostSchema } from '../types.js';
  */
 export function createHttpPostTool(
   defaultTimeout: number = 30000,
-  defaultHeaders: Record<string, string> = {}
+  defaultHeaders: Record<string, string> = {},
+  destinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-post')
-    .description('Make a simple HTTP POST request with JSON body and return the response data.')
+    .description('Make a policy-checked HTTP POST request with JSON body and return the response data. Local, metadata, link-local, and private-network destinations are blocked by default.')
     .category(ToolCategory.WEB)
     .tags(['http', 'post', 'api', 'web'])
     .schema(httpPostSchema)
     .implement(async (input) => {
-      const response = await axios.post(input.url, input.body, {
+      const response = await requestWithDestinationPolicy({
+        method: 'POST',
+        url: input.url,
+        data: input.body,
         headers: {
           'Content-Type': 'application/json',
           ...defaultHeaders,
           ...input.headers,
         },
         timeout: defaultTimeout,
-      });
+      }, destinationPolicy);
       return response.data;
     })
     .build();
 }
-

--- a/packages/tools/src/web/http/tools/http-post.ts
+++ b/packages/tools/src/web/http/tools/http-post.ts
@@ -6,6 +6,7 @@
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { requestWithDestinationPolicy } from '../../egress-policy.js';
+import type { DestinationPolicy } from '../../egress-policy.js';
 import { httpPostSchema } from '../types.js';
 
 /**
@@ -17,7 +18,7 @@ import { httpPostSchema } from '../types.js';
 export function createHttpPostTool(
   defaultTimeout: number = 30000,
   defaultHeaders: Record<string, string> = {},
-  destinationPolicy = {}
+  destinationPolicy: DestinationPolicy = {}
 ) {
   return toolBuilder()
     .name('http-post')

--- a/packages/tools/src/web/http/types.ts
+++ b/packages/tools/src/web/http/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import type { DestinationPolicy } from '../egress-policy.js';
 
 /**
  * HTTP method enum
@@ -59,4 +60,5 @@ export const httpPostSchema = z.object({
 export interface HttpToolsConfig {
   defaultTimeout?: number;
   defaultHeaders?: Record<string, string>;
+  destinationPolicy?: DestinationPolicy;
 }

--- a/packages/tools/src/web/index.ts
+++ b/packages/tools/src/web/index.ts
@@ -6,7 +6,13 @@
 
 export * from './http/index.js';
 export * from './scraper/index.js';
-export * from './egress-policy.js';
+export {
+  assertDestinationAllowed,
+  DEFAULT_DESTINATION_POLICY,
+  DestinationPolicyError,
+  requestWithDestinationPolicy,
+} from './egress-policy.js';
+export type { DestinationBlockReason, DestinationPolicy } from './egress-policy.js';
 export * from './html-parser/index.js';
 export * from './url-validator/index.js';
 export * from './web-search/index.js';

--- a/packages/tools/src/web/index.ts
+++ b/packages/tools/src/web/index.ts
@@ -6,9 +6,9 @@
 
 export * from './http/index.js';
 export * from './scraper/index.js';
+export * from './egress-policy.js';
 export * from './html-parser/index.js';
 export * from './url-validator/index.js';
 export * from './web-search/index.js';
 export * from './slack/index.js';
 export * from './confluence/index.js';
-

--- a/packages/tools/src/web/scraper/index.ts
+++ b/packages/tools/src/web/scraper/index.ts
@@ -7,6 +7,8 @@
 // Export types
 export type { ScraperResult, ScraperToolsConfig } from './types.js';
 export { webScraperSchema } from './types.js';
+export type { DestinationBlockReason, DestinationPolicy } from '../egress-policy.js';
+export { DEFAULT_DESTINATION_POLICY } from '../egress-policy.js';
 
 // Export tool factory
 export { createWebScraperTool } from './tools/web-scraper.js';
@@ -33,7 +35,6 @@ export const scraperTools = [webScraper];
  * ```
  */
 export function createScraperTools(config: import('./types.js').ScraperToolsConfig = {}) {
-  const { defaultTimeout = 30000, userAgent = 'Mozilla/5.0 (compatible; AgentForge/1.0; +https://agentforge.dev)' } = config;
-  return [createWebScraperTool(defaultTimeout, userAgent)];
+  const { defaultTimeout = 30000, userAgent = 'Mozilla/5.0 (compatible; AgentForge/1.0; +https://agentforge.dev)', destinationPolicy = {} } = config;
+  return [createWebScraperTool(defaultTimeout, userAgent, destinationPolicy)];
 }
-

--- a/packages/tools/src/web/scraper/tools/web-scraper.ts
+++ b/packages/tools/src/web/scraper/tools/web-scraper.ts
@@ -7,6 +7,7 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import * as cheerio from 'cheerio';
 import { requestWithDestinationPolicy } from '../../egress-policy.js';
+import type { DestinationPolicy } from '../../egress-policy.js';
 import { webScraperSchema, type ScraperResult } from '../types.js';
 
 /**
@@ -29,7 +30,7 @@ import { webScraperSchema, type ScraperResult } from '../types.js';
 export function createWebScraperTool(
   defaultTimeout: number = 30000,
   userAgent: string = 'Mozilla/5.0 (compatible; AgentForge/1.0; +https://agentforge.dev)',
-  destinationPolicy = {}
+  destinationPolicy: DestinationPolicy = {}
 ) {
   return toolBuilder()
     .name('web-scraper')

--- a/packages/tools/src/web/scraper/tools/web-scraper.ts
+++ b/packages/tools/src/web/scraper/tools/web-scraper.ts
@@ -5,8 +5,8 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import axios from 'axios';
 import * as cheerio from 'cheerio';
+import { requestWithDestinationPolicy } from '../../egress-policy.js';
 import { webScraperSchema, type ScraperResult } from '../types.js';
 
 /**
@@ -28,28 +28,31 @@ import { webScraperSchema, type ScraperResult } from '../types.js';
  */
 export function createWebScraperTool(
   defaultTimeout: number = 30000,
-  userAgent: string = 'Mozilla/5.0 (compatible; AgentForge/1.0; +https://agentforge.dev)'
+  userAgent: string = 'Mozilla/5.0 (compatible; AgentForge/1.0; +https://agentforge.dev)',
+  destinationPolicy = {}
 ) {
   return toolBuilder()
     .name('web-scraper')
-    .description('Scrape and extract data from web pages. Can extract text, HTML, links, images, and use CSS selectors to target specific elements.')
+    .description('Scrape and extract data from policy-checked web pages. Local, metadata, link-local, and private-network destinations are blocked by default. Supports text, HTML, links, images, and CSS selectors.')
     .category(ToolCategory.WEB)
     .tags(['scraper', 'web', 'html', 'extract', 'parse'])
     .schema(webScraperSchema)
     .implement(async (input): Promise<ScraperResult> => {
       // Fetch the page
-      const response = await axios.get(input.url, {
+      const response = await requestWithDestinationPolicy<string>({
+        method: 'GET',
+        url: input.url,
         timeout: input.timeout || defaultTimeout,
         headers: {
           'User-Agent': userAgent,
         },
-      });
+      }, destinationPolicy);
 
       const html = response.data;
       const $ = cheerio.load(html);
 
       const result: ScraperResult = {
-        url: input.url,
+        url: response.config.url ?? input.url,
       };
 
       // Apply selector if provided
@@ -134,4 +137,3 @@ export function createWebScraperTool(
     })
     .build();
 }
-

--- a/packages/tools/src/web/scraper/types.ts
+++ b/packages/tools/src/web/scraper/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import type { DestinationPolicy } from '../egress-policy.js';
 
 /**
  * Scraper result type
@@ -26,6 +27,7 @@ export interface ScraperResult {
 export interface ScraperToolsConfig {
   defaultTimeout?: number;
   userAgent?: string;
+  destinationPolicy?: DestinationPolicy;
 }
 
 /**
@@ -41,4 +43,3 @@ export const webScraperSchema = z.object({
   extractMetadata: z.boolean().default(false).describe('Extract meta tags (title, description, etc.)'),
   timeout: z.number().default(30000).describe('Request timeout in milliseconds'),
 });
-

--- a/packages/tools/tests/web/egress-policy.test.ts
+++ b/packages/tools/tests/web/egress-policy.test.ts
@@ -44,7 +44,7 @@ describe('web egress destination policy', () => {
   it('revalidates redirect destinations before following them', async () => {
     mockedAxios.mockResolvedValueOnce({
       status: 302,
-      headers: { location: 'https://93.184.216.34/next' },
+      headers: { location: ['https://93.184.216.34/next'] },
       config: {},
       data: undefined,
       statusText: 'Found',

--- a/packages/tools/tests/web/egress-policy.test.ts
+++ b/packages/tools/tests/web/egress-policy.test.ts
@@ -134,6 +134,21 @@ describe('web egress destination policy', () => {
     expect(redirectedHeaders).toEqual({ 'X-Request-Id': 'kept' });
   });
 
+  it('wraps invalid redirect locations in a destination policy error', async () => {
+    mockedAxios.mockResolvedValueOnce({
+      status: 302,
+      headers: { location: 'https://[invalid' },
+      config: {},
+      data: undefined,
+      statusText: 'Found',
+    });
+
+    await expect(requestWithDestinationPolicy({ url: 'https://source.example.test/start' })).rejects.toMatchObject({
+      code: 'WEB_DESTINATION_BLOCKED',
+      reason: 'redirect',
+    });
+  });
+
   it('allows explicit localhost opt-in for privileged operators', async () => {
     await expect(assertDestinationAllowed('http://127.0.0.1:8080/health', { allowLocalhost: true })).resolves.toBeUndefined();
   });

--- a/packages/tools/tests/web/egress-policy.test.ts
+++ b/packages/tools/tests/web/egress-policy.test.ts
@@ -1,0 +1,101 @@
+import { lookup } from 'node:dns/promises';
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  assertDestinationAllowed,
+  requestWithDestinationPolicy,
+  type DestinationPolicy,
+} from '../../src/web/egress-policy.js';
+
+vi.mock('axios');
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+
+const mockedAxios = vi.mocked(axios);
+const mockedLookup = vi.mocked(lookup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+});
+
+describe('web egress destination policy', () => {
+  it.each([
+    ['http://127.0.0.1/admin', 'localhost'],
+    ['http://169.254.169.254/latest/meta-data', 'metadata'],
+    ['http://10.0.0.8/internal', 'private-network'],
+    ['http://172.16.0.4/internal', 'private-network'],
+    ['http://192.168.1.20/internal', 'private-network'],
+    ['http://169.254.10.20/internal', 'link-local'],
+  ])('blocks %s as %s by default', async (url, reason) => {
+    await expect(assertDestinationAllowed(url)).rejects.toMatchObject({ reason });
+  });
+
+  it('blocks hostnames that resolve to private addresses', async () => {
+    mockedLookup.mockResolvedValue([{ address: '10.0.0.8', family: 4 }]);
+    await expect(assertDestinationAllowed('https://public.example.test/resource')).rejects.toMatchObject({ reason: 'private-network' });
+  });
+
+  it('revalidates redirect destinations before following them', async () => {
+    mockedAxios.mockResolvedValueOnce({
+      status: 302,
+      headers: { location: 'https://93.184.216.34/next' },
+      config: {},
+      data: undefined,
+      statusText: 'Found',
+    }).mockResolvedValueOnce({
+      status: 302,
+      headers: { location: 'http://192.168.1.20/internal' },
+      config: {},
+      data: undefined,
+      statusText: 'Found',
+    });
+
+    await expect(
+      requestWithDestinationPolicy({
+        method: 'GET',
+        url: 'https://93.184.216.34/start',
+        validateStatus: () => true,
+      })
+    ).rejects.toMatchObject({ reason: 'private-network' });
+    expect(mockedAxios).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows privileged internal-network opt-in across redirects', async () => {
+    const policy: DestinationPolicy = {
+      allowPrivateNetwork: true,
+      allowLinkLocal: true,
+      allowMetadata: true,
+    };
+    mockedAxios
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: { location: 'http://192.168.1.20/internal' },
+        config: {},
+        data: undefined,
+        statusText: 'Found',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        config: {},
+        data: { ok: true },
+        statusText: 'OK',
+      });
+
+    const response = await requestWithDestinationPolicy(
+      {
+        method: 'GET',
+        url: 'https://93.184.216.34/start',
+        validateStatus: () => true,
+      },
+      policy
+    );
+
+    expect(response.data).toEqual({ ok: true });
+    expect(mockedAxios).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows explicit localhost opt-in for privileged operators', async () => {
+    await expect(assertDestinationAllowed('http://127.0.0.1:8080/health', { allowLocalhost: true })).resolves.toBeUndefined();
+  });
+});

--- a/packages/tools/tests/web/egress-policy.test.ts
+++ b/packages/tools/tests/web/egress-policy.test.ts
@@ -6,6 +6,8 @@ import {
   requestWithDestinationPolicy,
   type DestinationPolicy,
 } from '../../src/web/egress-policy.js';
+import { createHttpTools } from '../../src/web/http/index.js';
+import { createScraperTools } from '../../src/web/scraper/index.js';
 
 vi.mock('axios');
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
@@ -26,6 +28,10 @@ describe('web egress destination policy', () => {
     ['http://172.16.0.4/internal', 'private-network'],
     ['http://192.168.1.20/internal', 'private-network'],
     ['http://169.254.10.20/internal', 'link-local'],
+    ['http://[::1]/admin', 'localhost'],
+    ['http://[::ffff:127.0.0.1]/admin', 'localhost'],
+    ['http://[fd00::1]/internal', 'private-network'],
+    ['http://[fe80::1]/internal', 'link-local'],
   ])('blocks %s as %s by default', async (url, reason) => {
     await expect(assertDestinationAllowed(url)).rejects.toMatchObject({ reason });
   });
@@ -97,5 +103,14 @@ describe('web egress destination policy', () => {
 
   it('allows explicit localhost opt-in for privileged operators', async () => {
     await expect(assertDestinationAllowed('http://127.0.0.1:8080/health', { allowLocalhost: true })).resolves.toBeUndefined();
+  });
+
+  it('wires the default policy through HTTP and scraper tool factories', async () => {
+    const [, httpGet] = createHttpTools();
+    const [scraper] = createScraperTools();
+
+    await expect(httpGet.invoke({ url: 'http://10.0.0.8/internal' })).rejects.toMatchObject({ reason: 'private-network' });
+    await expect(scraper.invoke({ url: 'http://127.0.0.1:8080/health' })).rejects.toMatchObject({ reason: 'localhost' });
+    expect(mockedAxios).not.toHaveBeenCalled();
   });
 });

--- a/packages/tools/tests/web/egress-policy.test.ts
+++ b/packages/tools/tests/web/egress-policy.test.ts
@@ -101,6 +101,39 @@ describe('web egress destination policy', () => {
     expect(mockedAxios).toHaveBeenCalledTimes(2);
   });
 
+  it('strips sensitive headers before following a cross-origin redirect', async () => {
+    mockedAxios
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: { location: 'https://redirected.example.test/next' },
+        config: {},
+        data: undefined,
+        statusText: 'Found',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        config: {},
+        data: { ok: true },
+        statusText: 'OK',
+      });
+
+    await requestWithDestinationPolicy({
+      method: 'GET',
+      url: 'https://source.example.test/start',
+      headers: {
+        Authorization: 'Bearer secret',
+        Cookie: 'session=secret',
+        'Proxy-Authorization': 'Basic secret',
+        'X-Request-Id': 'kept',
+      },
+      validateStatus: () => true,
+    });
+
+    const redirectedHeaders = mockedAxios.mock.calls[1][0].headers;
+    expect(redirectedHeaders).toEqual({ 'X-Request-Id': 'kept' });
+  });
+
   it('allows explicit localhost opt-in for privileged operators', async () => {
     await expect(assertDestinationAllowed('http://127.0.0.1:8080/health', { allowLocalhost: true })).resolves.toBeUndefined();
   });

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -119,3 +119,29 @@
   - PR #160 marked ready for review on 2026-07-17 after the conformance expectation fix, repo-wide `pnpm test --run`, `pnpm lint`, checklist sync, and PR body update were complete.
 - [x] Wait for merge; do not merge directly from local branch
   - PR #160 merged into `main` on 2026-07-18 as commit `e34389a9`; post-merge tracker sync and ready-lane grooming completed from local `main`.
+
+## ST-11002: Harden Default Web Tool Egress Policy
+
+**Branch:** `feat/st-11002-web-egress-policy`
+
+### Checklist
+- [x] Create branch `feat/st-11002-web-egress-policy`
+  - Created on 2026-07-20 from `main` after moving `ST-11002` to `In Progress` in `planning/kanban-queue.md`.
+- [ ] Create draft PR with story ID in title
+- [x] Define test strategy before implementation: identify the practical failing automated test seam for destination policy enforcement and redirect revalidation
+  - Strategy: add red-first unit coverage for the shared destination classifier and request helper in `packages/tools/tests/web/egress-policy.test.ts`, using mocked Axios responses to prove initial private-target denial and redirect-bypass denial without making network requests.
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Added `packages/tools/tests/web/egress-policy.test.ts` before the production module; the red run failed because `src/web/egress-policy.ts` did not exist, then the focused green run passed after implementation.
+- [ ] Add a shared destination policy for HTTP and scraper tools that blocks localhost, link-local, metadata, and RFC1918/private-network targets by default
+- [ ] Ensure destination policy validation covers hostname resolution and IP-literal forms for supported HTTP(S) destinations
+- [ ] Ensure redirect handling revalidates every hop and cannot bypass blocked-destination policy through chained redirects
+- [ ] Preserve an explicit privileged/internal-network opt-in path with documented policy configuration
+- [ ] Add focused tests covering localhost, metadata, RFC1918/private-network, redirect-bypass, and privileged opt-in behavior
+- [ ] Add or update story documentation at `docs/st11002-web-egress-policy-hardening.md`
+- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [ ] Assess CI impact; update CI or document why no CI change is required
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Commit completed checklist items as logical commits and push updates
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -127,7 +127,8 @@
 ### Checklist
 - [x] Create branch `feat/st-11002-web-egress-policy`
   - Created on 2026-07-20 from `main` after moving `ST-11002` to `In Progress` in `planning/kanban-queue.md`.
-- [ ] Create draft PR with story ID in title
+- [x] Create draft PR with story ID in title
+  - Created draft PR #161: https://github.com/TVScoundrel/agentforge/pull/161
 - [x] Define test strategy before implementation: identify the practical failing automated test seam for destination policy enforcement and redirect revalidation
   - Strategy: add red-first unit coverage for the shared destination classifier and request helper in `packages/tools/tests/web/egress-policy.test.ts`, using mocked Axios responses to prove initial private-target denial and redirect-bypass denial without making network requests.
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
@@ -148,8 +149,11 @@
   - Added the shared helper, factory wiring, IPv4/IPv6 boundary, DNS, redirect, and opt-in regressions; no further focused automation is required beyond the full validation gates.
 - [x] Assess CI impact; update CI or document why no CI change is required
   - No CI change is required because the new policy uses the existing package/workspace TypeScript, Vitest, and lint paths.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `225` passed, `9` skipped files; `2524` passed, `110` skipped tests.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with `0` errors and the existing warning baseline.
+- [x] Commit completed checklist items as logical commits and push updates
+  - `e4f31706` established the red-first test checkpoint and `9960dc41` contains the implementation, documentation, and focused tests; both are pushed to `origin/feat/st-11002-web-egress-policy`.
 - [ ] Mark PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -132,14 +132,22 @@
   - Strategy: add red-first unit coverage for the shared destination classifier and request helper in `packages/tools/tests/web/egress-policy.test.ts`, using mocked Axios responses to prove initial private-target denial and redirect-bypass denial without making network requests.
 - [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
   - Added `packages/tools/tests/web/egress-policy.test.ts` before the production module; the red run failed because `src/web/egress-policy.ts` did not exist, then the focused green run passed after implementation.
-- [ ] Add a shared destination policy for HTTP and scraper tools that blocks localhost, link-local, metadata, and RFC1918/private-network targets by default
-- [ ] Ensure destination policy validation covers hostname resolution and IP-literal forms for supported HTTP(S) destinations
-- [ ] Ensure redirect handling revalidates every hop and cannot bypass blocked-destination policy through chained redirects
-- [ ] Preserve an explicit privileged/internal-network opt-in path with documented policy configuration
-- [ ] Add focused tests covering localhost, metadata, RFC1918/private-network, redirect-bypass, and privileged opt-in behavior
-- [ ] Add or update story documentation at `docs/st11002-web-egress-policy-hardening.md`
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Assess CI impact; update CI or document why no CI change is required
+- [x] Add a shared destination policy for HTTP and scraper tools that blocks localhost, link-local, metadata, and RFC1918/private-network targets by default
+  - Added `packages/tools/src/web/egress-policy.ts` and wired the HTTP client, GET/POST helpers, and scraper factories through its default-deny policy.
+- [x] Ensure destination policy validation covers hostname resolution and IP-literal forms for supported HTTP(S) destinations
+  - Validates HTTP(S) schemes, IPv4/IPv6 literals, IPv4-mapped IPv6 literals, and every DNS-resolved address before request execution.
+- [x] Ensure redirect handling revalidates every hop and cannot bypass blocked-destination policy through chained redirects
+  - Disabled Axios automatic redirects in the shared helper, follows supported redirect responses manually, and validates each `Location` target before the next request with a five-hop default cap.
+- [x] Preserve an explicit privileged/internal-network opt-in path with documented policy configuration
+  - Exported `DestinationPolicy` and `DEFAULT_DESTINATION_POLICY`; documented the separate `allowLocalhost`, `allowPrivateNetwork`, `allowLinkLocal`, `allowMetadata`, `allowRedirects`, and `maxRedirects` controls.
+- [x] Add focused tests covering localhost, metadata, RFC1918/private-network, redirect-bypass, and privileged opt-in behavior
+  - `packages/tools/tests/web/egress-policy.test.ts` now covers 15 focused cases, including IPv4/IPv6, DNS resolution, chained redirects, factory wiring, and privileged opt-in.
+- [x] Add or update story documentation at `docs/st11002-web-egress-policy-hardening.md`
+  - Added the story rationale, configuration examples, compatibility notes, and validation evidence; linked it from `docs-site/api/tools.md`.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - Added the shared helper, factory wiring, IPv4/IPv6 boundary, DNS, redirect, and opt-in regressions; no further focused automation is required beyond the full validation gates.
+- [x] Assess CI impact; update CI or document why no CI change is required
+  - No CI change is required because the new policy uses the existing package/workspace TypeScript, Vitest, and lint paths.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items as logical commits and push updates

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -155,5 +155,6 @@
   - `pnpm lint` -> passed with `0` errors and the existing warning baseline.
 - [x] Commit completed checklist items as logical commits and push updates
   - `e4f31706` established the red-first test checkpoint and `9960dc41` contains the implementation, documentation, and focused tests; both are pushed to `origin/feat/st-11002-web-egress-policy`.
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #161 marked ready for review on 2026-07-20 after implementation, documentation, tracker synchronization, `pnpm test --run`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, and self-review.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2515,14 +2515,14 @@
 **Priority:** P1 (High)
 **Estimate:** 5 hours
 **Dependencies:** ST-11001
-**Status:** In Progress (2026-07-20)
+**Status:** In Review (PR #161, 2026-07-20)
 
 **Acceptance criteria:**
-- [ ] Default HTTP and scraping tool surfaces support an explicit destination policy that can block localhost, link-local, metadata, and RFC1918/private-network targets by default or via a clearly documented safe preset
-- [ ] Redirect handling cannot bypass blocked-destination policy through chained hops
-- [ ] Existing privileged/internal-network use cases keep a documented opt-in path rather than being silently removed
-- [ ] Focused tests cover localhost, metadata, RFC1918, and redirect-bypass attempts
-- [ ] Add or update story documentation at `docs/st11002-web-tool-egress-policy-hardening.md`
+- [x] Default HTTP and scraping tool surfaces support an explicit destination policy that blocks localhost, link-local, metadata, and RFC1918/private-network targets by default
+- [x] Redirect handling cannot bypass blocked-destination policy through chained hops
+- [x] Existing privileged/internal-network use cases keep a documented opt-in path rather than being silently removed
+- [x] Focused tests cover localhost, metadata, RFC1918, IPv4/IPv6, DNS resolution, and redirect-bypass attempts
+- [x] Add or update story documentation at `docs/st11002-web-egress-policy-hardening.md`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2515,6 +2515,7 @@
 **Priority:** P1 (High)
 **Estimate:** 5 hours
 **Dependencies:** ST-11001
+**Status:** In Progress (2026-07-20)
 
 **Acceptance criteria:**
 - [ ] Default HTTP and scraping tool surfaces support an explicit destination policy that can block localhost, link-local, metadata, and RFC1918/private-network targets by default or via a clearly documented safe preset

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-07-20
-**Active Story:** ST-11002 - In Progress on 2026-07-20; ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
+**Active Story:** ST-11002 - In Review on 2026-07-20 (PR #161); ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
-**Last Updated:** 2026-07-18
-**Active Story:** ST-11002 - Ready on 2026-07-18; ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
+**Last Updated:** 2026-07-20
+**Active Story:** ST-11002 - In Progress on 2026-07-20; ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-18
+**Last Updated:** 2026-07-20
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-11002` - Harden Default Web Tool Egress Policy
-  - Depends on: `ST-11001` (merged)
 - `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
   - Depends on: `ST-11001` (merged)
 - `ST-11006` - Harden Express Chat Example Ownership Semantics
@@ -25,7 +23,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-11002` - Harden Default Web Tool Egress Policy
+  - Depends on: `ST-11001` (merged)
 
 ---
 
@@ -52,6 +51,7 @@ _No stories currently in backlog_
 - ST-11001 complete - repository security policy routing is now documented through the root README, contributing guide, tools guide, and agent-skills guides; Epic 11 queue grooming promoted `ST-11005`, `ST-11002`, `ST-11003`, and `ST-11006` into `Ready` behind the existing top-priority `ST-11004` after the policy baseline merged (merged 2026-07-15, PR #158)
 - ST-11004 complete - multi-agent supervisor routing now preserves trusted `supervisorTask` intent separately from worker `task_result` output, reuses worker results only as labeled untrusted context, and bounds that context for prompt growth safety; the ready lane advanced to `ST-11005`, which moved to `In Progress` on 2026-07-17, with `ST-11002`, `ST-11003`, and `ST-11006` still dependency-ready behind it (merged 2026-07-16, PR #159)
 - ST-11005 complete - skill prompts and activation now distinguish trusted/workspace skills from discoverable untrusted skills, block untrusted `SKILL.md` exposure through activation and resource aliases, preserve script-resource policy, and document the root-promotion migration path; the ready lane remains `ST-11002`, `ST-11003`, and `ST-11006` (merged 2026-07-18, PR #160)
+- ST-11002 moved to `In Progress` on 2026-07-20 as the next dependency-ready EP-11 story; `ST-11003` and `ST-11006` remain in `Ready` behind the merged `ST-11001` policy baseline
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -31,7 +31,7 @@ None currently.
 
 - `ST-11002` - Harden Default Web Tool Egress Policy
   - Depends on: `ST-11001` (merged)
-  - PR: #161 (draft, validation complete; ready-state transition pending)
+  - PR: #161 (ready for review)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -23,14 +23,15 @@
 
 ## In Progress
 
-- `ST-11002` - Harden Default Web Tool Egress Policy
-  - Depends on: `ST-11001` (merged)
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11002` - Harden Default Web Tool Egress Policy
+  - Depends on: `ST-11001` (merged)
+  - PR: #161 (draft, validation complete; ready-state transition pending)
 
 ---
 
@@ -52,6 +53,7 @@ _No stories currently in backlog_
 - ST-11004 complete - multi-agent supervisor routing now preserves trusted `supervisorTask` intent separately from worker `task_result` output, reuses worker results only as labeled untrusted context, and bounds that context for prompt growth safety; the ready lane advanced to `ST-11005`, which moved to `In Progress` on 2026-07-17, with `ST-11002`, `ST-11003`, and `ST-11006` still dependency-ready behind it (merged 2026-07-16, PR #159)
 - ST-11005 complete - skill prompts and activation now distinguish trusted/workspace skills from discoverable untrusted skills, block untrusted `SKILL.md` exposure through activation and resource aliases, preserve script-resource policy, and document the root-promotion migration path; the ready lane remains `ST-11002`, `ST-11003`, and `ST-11006` (merged 2026-07-18, PR #160)
 - ST-11002 moved to `In Progress` on 2026-07-20 as the next dependency-ready EP-11 story; `ST-11003` and `ST-11006` remain in `Ready` behind the merged `ST-11001` policy baseline
+- ST-11002 moved to `In Review` on 2026-07-20 with PR #161 after implementation, focused and full validation, lint, typecheck, build, documentation, and tracker synchronization; `ST-11003` and `ST-11006` remain in `Ready`
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story

`ST-11002` - Harden Default Web Tool Egress Policy

## What Changed

- Added a shared destination-policy and redirect-validation seam for the HTTP client, GET/POST helpers, and web scraper.
- Added red-first regressions for IPv4/IPv6 private destinations, DNS-resolved private addresses, chained redirect bypasses, privileged opt-in behavior, and factory wiring.
- Added operator-facing hardening documentation and linked it from the tools API docs.
- Follow-up commit `d4c1cc21` types `destinationPolicy` explicitly on all direct HTTP/scraper factory APIs and uses a type-only Axios import.
- Follow-up commit `eeed0dc6` makes the root policy exports explicit and strips sensitive credentials before cross-origin redirect hops.
- Follow-up commit `6130280e` pins validated DNS addresses into each Axios request and normalizes multi-valued `Location` headers.
- Follow-up commit `81c2a21a` converts malformed redirect locations into typed `DestinationPolicyError` failures.
- Updated the Epic 11 Kanban, feature metadata, story tracker, and execution checklist through In Review.

## Acceptance Criteria Coverage

- [x] Default HTTP and scraping tool surfaces enforce safe destination policy.
- [x] Redirect hops are revalidated before follow-up requests.
- [x] Privileged/internal-network opt-in is documented and preserved.
- [x] Focused test seam established with 17 passing regression cases after the initial red run.
- [x] Story documentation added.

## Test Strategy

The practical seam is a shared request helper and destination classifier. Tests mock Axios and DNS resolution so policy behavior is verified without network access, including initial destinations and every redirect hop.

## Validation Performed

- `pnpm --filter @agentforge/tools test --run tests/web/egress-policy.test.ts` initially failed because the production module did not exist.
- `pnpm --filter @agentforge/tools test --run tests/web/egress-policy.test.ts` -> 1 file, 17 tests passed.
- `pnpm test --run` -> 225 files passed, 9 skipped; 2526 tests passed, 110 skipped.
- `pnpm lint` -> all workspace lint tasks passed with 0 errors and the existing warning baseline.
- `pnpm typecheck` -> passed.
- `pnpm build` -> all package and VitePress builds passed; VitePress emitted the existing large-chunk warning.
- `git diff --check` -> passed.

## Status

Ready for review. Implementation commit `9960dc41` and review follow-ups `d4c1cc21`, `eeed0dc6`, `6130280e`, and `81c2a21a` are pushed; all nine Copilot threads are resolved and no merge was performed.
