### PR TITLE
feat(tools): add file tool confinement controls [ST-11003]

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -1344,6 +1344,27 @@ if (searchResult.success) {
 }
 ```
 
+### Filesystem Confinement
+
+The standalone file and directory tool exports are privileged filesystem operations. For model-exposed agents, configure both factory groups with one shared policy:
+
+```typescript
+import {
+  createDirectoryOperationTools,
+  createFileOperationTools,
+  createFileSystemPolicy,
+} from '@agentforge/tools';
+
+const policy = createFileSystemPolicy({
+  workspaceRoot: process.cwd(),
+});
+
+const safeFileTools = createFileOperationTools({ policy });
+const safeDirectoryTools = createDirectoryOperationTools({ policy });
+```
+
+`workspaceRoot` resolves relative paths from the workspace and confines all configured operations to that root. Use `allowedRoots` for multiple permitted roots. The policy rejects lexical traversal, resolved symlink escapes, paths outside the allowed roots, and recursive deletion of an allowed root. Set `allowOutsideRoots: true` only for trusted local automation that explicitly needs unrestricted host access.
+
 ## Utility Tools (22)
 
 ### Date/Time

--- a/docs-site/guide/concepts/tools.md
+++ b/docs-site/guide/concepts/tools.md
@@ -20,7 +20,7 @@ A **tool** is a function that an AI agent can call to perform actions or retriev
 - And much more...
 
 ::: warning Security Boundary
-Many tools are intentionally powerful. Read the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) before exposing filesystem, network, shell, or data-mutation tools to model-controlled input.
+Many tools are intentionally powerful. Read the repository [Security Policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) before exposing filesystem, network, shell, or data-mutation tools to model-controlled input. For filesystem tools, configure `createFileSystemPolicy({ workspaceRoot, allowedRoots })` on both file and directory factories; reserve unrestricted exports and `allowOutsideRoots: true` for trusted local automation.
 :::
 
 ## Why AgentForge Tools?

--- a/docs/st11003-file-tool-confinement-controls.md
+++ b/docs/st11003-file-tool-confinement-controls.md
@@ -1,0 +1,41 @@
+# ST-11003: Filesystem Confinement Controls for Default File Tools
+
+## Rationale
+
+The standard file and directory tools perform host filesystem I/O and are privileged when exposed to model-controlled input. Before this story, every factory accepted raw paths without a shared allowed-root or workspace-relative policy, so path traversal and symlink escapes were left to the downstream application.
+
+## Confinement API
+
+Configure one policy instance on both factory groups:
+
+```typescript
+import {
+  createDirectoryOperationTools,
+  createFileOperationTools,
+  createFileSystemPolicy,
+} from '@agentforge/tools';
+
+const policy = createFileSystemPolicy({
+  workspaceRoot: process.cwd(),
+});
+
+const fileTools = createFileOperationTools({ policy });
+const directoryTools = createDirectoryOperationTools({ policy });
+```
+
+`workspaceRoot` is the base for relative paths and an allowed root. Use `allowedRoots` when an agent needs access to more than one explicitly approved directory. The shared policy validates lexical paths, resolves existing targets and missing creation parents through real paths, and applies the same checks to file reads, writes, appends, existence checks, directory listing/search/creation, and deletion.
+
+Confined operations reject `..` traversal, symlink escapes, paths outside the configured roots, and recursive deletion of an allowed root. The policy returns typed `FileSystemPolicyError` failures; safe tool implementations expose those through their normal `{ success: false, error }` result shape.
+
+## Trusted Automation
+
+The standalone tool exports preserve their existing unrestricted behavior for trusted local automation. A configured factory can also opt out explicitly with `allowOutsideRoots: true`, but this should not be used for model-exposed tools. Pure path utility tools do not perform filesystem I/O and are not part of the confinement policy.
+
+## Compatibility
+
+Existing positional factory arguments remain valid. The new `policy` option is additive on `FileOperationsConfig` and `DirectoryOperationsConfig`, and the public policy types and factory are exported from `@agentforge/tools`.
+
+## Validation
+
+- `packages/tools/tests/file/confinement.test.ts` covers workspace-relative paths, traversal, symlink escape, configured-root deletion, missing creation parents, non-following directory-list symlinks, directory operations, and the privileged opt-out.
+- The focused confinement suite passes with 8 tests; the full tools package suite passes with 1153 tests.

--- a/docs/st11003-file-tool-confinement-controls.md
+++ b/docs/st11003-file-tool-confinement-controls.md
@@ -35,6 +35,8 @@ The standalone tool exports preserve their existing unrestricted behavior for tr
 
 Existing positional factory arguments remain valid. The new `policy` option is additive on `FileOperationsConfig` and `DirectoryOperationsConfig`, and the public policy types and factory are exported from `@agentforge/tools`.
 
+`file-exists` retains its legacy result shape for successful and missing-path checks. Confinement violations from that tool are returned as explicit `{ success: false, error }` results instead of being reported as a missing path or rejected promise. Detailed `directory-list` results use non-following `lstat` metadata for symlink entries; this applies to both default and confined policies, so symlinks report link metadata rather than target metadata.
+
 ## Validation
 
 - `packages/tools/tests/file/confinement.test.ts` covers workspace-relative paths, traversal, symlink escape, configured-root deletion, missing creation parents, non-following directory-list symlinks, directory operations, and the privileged opt-out.

--- a/docs/st11003-file-tool-confinement-controls.md
+++ b/docs/st11003-file-tool-confinement-controls.md
@@ -39,3 +39,5 @@ Existing positional factory arguments remain valid. The new `policy` option is a
 
 - `packages/tools/tests/file/confinement.test.ts` covers workspace-relative paths, traversal, symlink escape, configured-root deletion, missing creation parents, non-following directory-list symlinks, directory operations, and the privileged opt-out.
 - The focused confinement suite passes with 8 tests; the full tools package suite passes with 1153 tests.
+- The repository-wide `pnpm test --run` passes with 226 test files passed, 9 skipped; 2534 tests passed, 110 skipped.
+- Repository-wide `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass. Lint reports the existing 161-warning baseline with 0 errors; build retains the existing VitePress chunk-size warning.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -223,7 +223,7 @@ const safeFileTools = createFileOperationTools({ policy });
 const safeDirectoryTools = createDirectoryOperationTools({ policy });
 ```
 
-The policy rejects `..` traversal, resolved symlink escapes, paths outside configured roots, and recursive deletion of a configured root. Use `allowedRoots` for multiple roots. Keep the default unrestricted exports for trusted local automation only; `allowOutsideRoots: true` is an explicit privileged opt-out when a configured factory must access the wider host filesystem.
+The policy rejects `..` traversal, resolved symlink escapes, paths outside configured roots, and recursive deletion of a configured root. Use `allowedRoots` for multiple roots. Keep the default unrestricted exports for trusted local automation only; `allowOutsideRoots: true` is an explicit privileged opt-out when a configured factory must access the wider host filesystem. The `file-exists` tool preserves its legacy result shape for successful and missing-path checks, while policy violations return `{ success: false, error }`. Detailed `directory-list` results use non-following `lstat` metadata for symlink entries under both default and confined policies.
 
 ### Utility Tools (22 tools)
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -204,6 +204,27 @@ Tools for file system operations.
 - **`pathRelative`** - Get relative path
 - **`pathNormalize`** - Normalize paths
 
+#### Filesystem Confinement
+
+The standalone filesystem tool exports are intentionally powerful for trusted local automation. For model-exposed tools, configure a shared policy on the factory functions so every file and directory operation uses the same allowed roots and symlink checks:
+
+```typescript
+import {
+  createDirectoryOperationTools,
+  createFileOperationTools,
+  createFileSystemPolicy,
+} from '@agentforge/tools';
+
+const policy = createFileSystemPolicy({
+  workspaceRoot: process.cwd(),
+});
+
+const safeFileTools = createFileOperationTools({ policy });
+const safeDirectoryTools = createDirectoryOperationTools({ policy });
+```
+
+The policy rejects `..` traversal, resolved symlink escapes, paths outside configured roots, and recursive deletion of a configured root. Use `allowedRoots` for multiple roots. Keep the default unrestricted exports for trusted local automation only; `allowOutsideRoots: true` is an explicit privileged opt-out when a configured factory must access the wider host filesystem.
+
 ### Utility Tools (22 tools)
 
 General utility tools for common operations.

--- a/packages/tools/src/file/confinement.ts
+++ b/packages/tools/src/file/confinement.ts
@@ -1,0 +1,160 @@
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+export type FileSystemPolicyErrorCode = 'FILE_SYSTEM_POLICY_VIOLATION';
+
+export class FileSystemPolicyError extends Error {
+  readonly code: FileSystemPolicyErrorCode = 'FILE_SYSTEM_POLICY_VIOLATION';
+
+  constructor(
+    message: string,
+    readonly operation: string,
+    readonly inputPath: string,
+  ) {
+    super(message);
+    this.name = 'FileSystemPolicyError';
+  }
+}
+
+export interface FileSystemPolicyOptions {
+  allowedRoots?: readonly string[];
+  workspaceRoot?: string;
+  allowOutsideRoots?: boolean;
+  allowRootDeletion?: boolean;
+}
+
+export type FileSystemPolicyInput = FileSystemPolicy | FileSystemPolicyOptions;
+
+function containsTraversal(inputPath: string): boolean {
+  return inputPath.split(/[\\/]+/).includes('..');
+}
+
+function isWithinRoot(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+async function resolveWithMissingTail(inputPath: string): Promise<string> {
+  let currentPath = inputPath;
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const resolvedPath = await fs.realpath(currentPath);
+      return path.join(resolvedPath, ...missingSegments);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error;
+      }
+
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        throw error;
+      }
+
+      missingSegments.unshift(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+export class FileSystemPolicy {
+  readonly allowedRoots: readonly string[];
+  readonly allowOutsideRoots: boolean;
+  readonly allowRootDeletion: boolean;
+  private readonly baseDirectory: string;
+
+  constructor(options: FileSystemPolicyOptions = {}) {
+    const configuredRoots = [
+      ...(options.allowedRoots ?? []),
+      ...(options.workspaceRoot ? [options.workspaceRoot] : []),
+    ];
+
+    this.allowedRoots = [...new Set(configuredRoots.map((root) => path.resolve(root)))];
+    this.baseDirectory = path.resolve(options.workspaceRoot ?? process.cwd());
+    this.allowOutsideRoots = options.allowOutsideRoots ?? this.allowedRoots.length === 0;
+    this.allowRootDeletion = options.allowRootDeletion ?? this.allowOutsideRoots;
+  }
+
+  async resolvePath(inputPath: string, operation: string): Promise<string> {
+    const absolutePath = path.resolve(this.baseDirectory, inputPath);
+
+    if (this.allowOutsideRoots) {
+      return absolutePath;
+    }
+
+    if (containsTraversal(inputPath)) {
+      throw new FileSystemPolicyError(
+        `Filesystem policy blocked ${operation}: path traversal is not allowed`,
+        operation,
+        inputPath,
+      );
+    }
+
+    let resolvedPath: string;
+    try {
+      resolvedPath = await resolveWithMissingTail(absolutePath);
+    } catch {
+      throw new FileSystemPolicyError(
+        `Filesystem policy could not resolve ${operation} path`,
+        operation,
+        inputPath,
+      );
+    }
+
+    const resolvedRoots = await this.resolveRoots(operation, inputPath);
+    if (!resolvedRoots.some((root) => isWithinRoot(root, resolvedPath))) {
+      throw new FileSystemPolicyError(
+        `Filesystem policy blocked ${operation}: path is outside the allowed roots`,
+        operation,
+        inputPath,
+      );
+    }
+
+    return resolvedPath;
+  }
+
+  async resolveDeletePath(inputPath: string, recursive: boolean): Promise<string> {
+    const resolvedPath = await this.resolvePath(inputPath, 'directory deletion');
+
+    if (recursive && !this.allowRootDeletion) {
+      const resolvedRoots = await this.resolveRoots('directory deletion', inputPath);
+      if (resolvedRoots.some((root) => root === resolvedPath)) {
+        throw new FileSystemPolicyError(
+          'Filesystem policy blocked directory deletion: recursive deletion of an allowed root is not permitted',
+          'directory deletion',
+          inputPath,
+        );
+      }
+    }
+
+    return resolvedPath;
+  }
+
+  private async resolveRoots(operation: string, inputPath: string): Promise<string[]> {
+    try {
+      return await Promise.all(this.allowedRoots.map((root) => fs.realpath(root)));
+    } catch {
+      throw new FileSystemPolicyError(
+        `Filesystem policy could not resolve an allowed root for ${operation}`,
+        operation,
+        inputPath,
+      );
+    }
+  }
+}
+
+export const DEFAULT_FILE_SYSTEM_POLICY = new FileSystemPolicy();
+
+export function createFileSystemPolicy(options: FileSystemPolicyOptions = {}): FileSystemPolicy {
+  return new FileSystemPolicy(options);
+}
+
+export function resolveFileSystemPolicy(policy?: FileSystemPolicyInput): FileSystemPolicy {
+  if (!policy) {
+    return DEFAULT_FILE_SYSTEM_POLICY;
+  }
+
+  return policy instanceof FileSystemPolicy ? policy : createFileSystemPolicy(policy);
+}

--- a/packages/tools/src/file/confinement.ts
+++ b/packages/tools/src/file/confinement.ts
@@ -78,10 +78,32 @@ export class FileSystemPolicy {
   }
 
   async resolvePath(inputPath: string, operation: string): Promise<string> {
+    const { resolvedPath } = await this.resolvePathWithRoots(inputPath, operation);
+    return resolvedPath;
+  }
+
+  async resolveDeletePath(inputPath: string, recursive: boolean): Promise<string> {
+    const { resolvedPath, resolvedRoots } = await this.resolvePathWithRoots(inputPath, 'directory deletion');
+
+    if (recursive && !this.allowRootDeletion && resolvedRoots.some((root) => root === resolvedPath)) {
+      throw new FileSystemPolicyError(
+        'Filesystem policy blocked directory deletion: recursive deletion of an allowed root is not permitted',
+        'directory deletion',
+        inputPath,
+      );
+    }
+
+    return resolvedPath;
+  }
+
+  private async resolvePathWithRoots(
+    inputPath: string,
+    operation: string,
+  ): Promise<{ resolvedPath: string; resolvedRoots: string[] }> {
     const absolutePath = path.resolve(this.baseDirectory, inputPath);
 
     if (this.allowOutsideRoots) {
-      return absolutePath;
+      return { resolvedPath: absolutePath, resolvedRoots: [] };
     }
 
     if (containsTraversal(inputPath)) {
@@ -112,24 +134,7 @@ export class FileSystemPolicy {
       );
     }
 
-    return resolvedPath;
-  }
-
-  async resolveDeletePath(inputPath: string, recursive: boolean): Promise<string> {
-    const resolvedPath = await this.resolvePath(inputPath, 'directory deletion');
-
-    if (recursive && !this.allowRootDeletion) {
-      const resolvedRoots = await this.resolveRoots('directory deletion', inputPath);
-      if (resolvedRoots.some((root) => root === resolvedPath)) {
-        throw new FileSystemPolicyError(
-          'Filesystem policy blocked directory deletion: recursive deletion of an allowed root is not permitted',
-          'directory deletion',
-          inputPath,
-        );
-      }
-    }
-
-    return resolvedPath;
+    return { resolvedPath, resolvedRoots };
   }
 
   private async resolveRoots(operation: string, inputPath: string): Promise<string[]> {

--- a/packages/tools/src/file/directory/index.ts
+++ b/packages/tools/src/file/directory/index.ts
@@ -15,6 +15,7 @@ import { createDirectoryCreateTool } from './tools/directory-create.js';
 import { createDirectoryDeleteTool } from './tools/directory-delete.js';
 import { createFileSearchTool } from './tools/file-search.js';
 import type { DirectoryOperationsConfig } from './types.js';
+import { resolveFileSystemPolicy } from '../confinement.js';
 
 /**
  * Default directory operation tool instances
@@ -42,13 +43,14 @@ export function createDirectoryOperationTools(config: DirectoryOperationsConfig 
     defaultRecursive = false,
     defaultIncludeDetails = false,
     defaultCaseSensitive = false,
+    policy: policyInput,
   } = config;
+  const policy = resolveFileSystemPolicy(policyInput);
 
   return [
-    createDirectoryListTool(defaultRecursive, defaultIncludeDetails),
-    createDirectoryCreateTool(true), // Always default to true for create
-    createDirectoryDeleteTool(false), // Always default to false for delete (safety)
-    createFileSearchTool(defaultRecursive, defaultCaseSensitive),
+    createDirectoryListTool(defaultRecursive, defaultIncludeDetails, policy),
+    createDirectoryCreateTool(true, policy), // Always default to true for create
+    createDirectoryDeleteTool(false, policy), // Always default to false for delete (safety)
+    createFileSearchTool(defaultRecursive, defaultCaseSensitive, policy),
   ];
 }
-

--- a/packages/tools/src/file/directory/tools/directory-create.ts
+++ b/packages/tools/src/file/directory/tools/directory-create.ts
@@ -5,11 +5,15 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { directoryCreateSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create directory create tool
  */
-export function createDirectoryCreateTool(defaultRecursive: boolean = true) {
+export function createDirectoryCreateTool(
+  defaultRecursive: boolean = true,
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('directory-create')
     .description('Create a new directory. Can optionally create parent directories if they don\'t exist.')
@@ -18,7 +22,8 @@ export function createDirectoryCreateTool(defaultRecursive: boolean = true) {
     .schema(directoryCreateSchema)
     .implementSafe(async (input) => {
       const recursive = input.recursive ?? defaultRecursive;
-      await fs.mkdir(input.path, { recursive });
+      const safePath = await policy.resolvePath(input.path, 'directory creation');
+      await fs.mkdir(safePath, { recursive });
 
       return {
         path: input.path,
@@ -27,4 +32,3 @@ export function createDirectoryCreateTool(defaultRecursive: boolean = true) {
     })
     .build();
 }
-

--- a/packages/tools/src/file/directory/tools/directory-delete.ts
+++ b/packages/tools/src/file/directory/tools/directory-delete.ts
@@ -5,11 +5,15 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { directoryDeleteSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create directory delete tool
  */
-export function createDirectoryDeleteTool(defaultRecursive: boolean = false) {
+export function createDirectoryDeleteTool(
+  defaultRecursive: boolean = false,
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('directory-delete')
     .description('Delete a directory. Can optionally delete non-empty directories recursively.')
@@ -18,7 +22,8 @@ export function createDirectoryDeleteTool(defaultRecursive: boolean = false) {
     .schema(directoryDeleteSchema)
     .implementSafe(async (input) => {
       const recursive = input.recursive ?? defaultRecursive;
-      await fs.rm(input.path, { recursive, force: false });
+      const safePath = await policy.resolveDeletePath(input.path, recursive);
+      await fs.rm(safePath, { recursive, force: false });
 
       return {
         path: input.path,
@@ -27,4 +32,3 @@ export function createDirectoryDeleteTool(defaultRecursive: boolean = false) {
     })
     .build();
 }
-

--- a/packages/tools/src/file/directory/tools/directory-list.ts
+++ b/packages/tools/src/file/directory/tools/directory-list.ts
@@ -6,11 +6,16 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { directoryListSchema } from '../types.js';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create directory list tool
  */
-export function createDirectoryListTool(defaultRecursive: boolean = false, defaultIncludeDetails: boolean = false) {
+export function createDirectoryListTool(
+  defaultRecursive: boolean = false,
+  defaultIncludeDetails: boolean = false,
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('directory-list')
     .description('List all files and directories in a directory. Can optionally include file details and filter by extension.')
@@ -18,13 +23,15 @@ export function createDirectoryListTool(defaultRecursive: boolean = false, defau
     .tags(['directory', 'list', 'files', 'filesystem'])
     .schema(directoryListSchema)
     .implementSafe(async (input) => {
+      const safePath = await policy.resolvePath(input.path, 'directory listing');
+      const includeDetails = input.includeDetails ?? defaultIncludeDetails;
       const listFiles = async (dir: string, recursive: boolean): Promise<any[]> => {
         const entries = await fs.readdir(dir, { withFileTypes: true });
         const files: any[] = [];
 
         for (const entry of entries) {
           const fullPath = path.join(dir, entry.name);
-          const relativePath = path.relative(input.path, fullPath);
+          const relativePath = path.relative(safePath, fullPath);
 
           // Apply extension filter if specified
           if (input.extension && !entry.name.endsWith(input.extension)) {
@@ -33,8 +40,8 @@ export function createDirectoryListTool(defaultRecursive: boolean = false, defau
             }
           }
 
-          if (input.includeDetails) {
-            const stats = await fs.stat(fullPath);
+          if (includeDetails) {
+            const stats = await fs.lstat(fullPath);
             files.push({
               name: entry.name,
               path: relativePath,
@@ -64,7 +71,7 @@ export function createDirectoryListTool(defaultRecursive: boolean = false, defau
       };
 
       const recursive = input.recursive ?? defaultRecursive;
-      const files = await listFiles(input.path, recursive);
+      const files = await listFiles(safePath, recursive);
 
       return {
         path: input.path,
@@ -74,4 +81,3 @@ export function createDirectoryListTool(defaultRecursive: boolean = false, defau
     })
     .build();
 }
-

--- a/packages/tools/src/file/directory/tools/file-search.ts
+++ b/packages/tools/src/file/directory/tools/file-search.ts
@@ -6,11 +6,16 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileSearchSchema } from '../types.js';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file search tool
  */
-export function createFileSearchTool(defaultRecursive: boolean = true, defaultCaseSensitive: boolean = false) {
+export function createFileSearchTool(
+  defaultRecursive: boolean = true,
+  defaultCaseSensitive: boolean = false,
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('file-search')
     .description('Search for files by name pattern in a directory. Supports wildcards and recursive search.')
@@ -20,6 +25,7 @@ export function createFileSearchTool(defaultRecursive: boolean = true, defaultCa
     .implementSafe(async (input) => {
       const recursive = input.recursive ?? defaultRecursive;
       const caseSensitive = input.caseSensitive ?? defaultCaseSensitive;
+      const safeDirectory = await policy.resolvePath(input.directory, 'file search');
 
       const searchFiles = async (dir: string): Promise<string[]> => {
         const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -47,7 +53,7 @@ export function createFileSearchTool(defaultRecursive: boolean = true, defaultCa
         return matches;
       };
 
-      const matches = await searchFiles(input.directory);
+      const matches = await searchFiles(safeDirectory);
 
       return {
         directory: input.directory,
@@ -58,4 +64,3 @@ export function createFileSearchTool(defaultRecursive: boolean = true, defaultCa
     })
     .build();
 }
-

--- a/packages/tools/src/file/directory/types.ts
+++ b/packages/tools/src/file/directory/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import type { FileSystemPolicyInput } from '../confinement.js';
 
 /**
  * Directory list schema
@@ -49,5 +50,5 @@ export interface DirectoryOperationsConfig {
   defaultRecursive?: boolean;
   defaultIncludeDetails?: boolean;
   defaultCaseSensitive?: boolean;
+  policy?: FileSystemPolicyInput;
 }
-

--- a/packages/tools/src/file/index.ts
+++ b/packages/tools/src/file/index.ts
@@ -7,4 +7,4 @@
 export * from './operations/index.js';
 export * from './directory/index.js';
 export * from './path/index.js';
-
+export * from './confinement.js';

--- a/packages/tools/src/file/operations/index.ts
+++ b/packages/tools/src/file/operations/index.ts
@@ -16,6 +16,7 @@ import { createFileWriterTool } from './tools/file-writer.js';
 import { createFileAppendTool } from './tools/file-append.js';
 import { createFileDeleteTool } from './tools/file-delete.js';
 import { createFileExistsTool } from './tools/file-exists.js';
+import { resolveFileSystemPolicy } from '../confinement.js';
 import type { FileOperationsConfig } from './types.js';
 
 /**
@@ -45,14 +46,15 @@ export function createFileOperationTools(config: FileOperationsConfig = {}) {
   const {
     defaultEncoding = 'utf8',
     createDirsDefault = false,
+    policy: policyInput,
   } = config;
+  const policy = resolveFileSystemPolicy(policyInput);
 
   return [
-    createFileReaderTool(defaultEncoding),
-    createFileWriterTool(defaultEncoding, createDirsDefault),
-    createFileAppendTool(defaultEncoding),
-    createFileDeleteTool(),
-    createFileExistsTool(),
+    createFileReaderTool(defaultEncoding, policy),
+    createFileWriterTool(defaultEncoding, createDirsDefault, policy),
+    createFileAppendTool(defaultEncoding, policy),
+    createFileDeleteTool(policy),
+    createFileExistsTool(policy),
   ];
 }
-

--- a/packages/tools/src/file/operations/tools/file-append.ts
+++ b/packages/tools/src/file/operations/tools/file-append.ts
@@ -5,11 +5,15 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileAppendSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file append tool
  */
-export function createFileAppendTool(defaultEncoding: string = 'utf8') {
+export function createFileAppendTool(
+  defaultEncoding: string = 'utf8',
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('file-append')
     .description('Append content to the end of a file. Creates the file if it doesn\'t exist.')
@@ -18,8 +22,9 @@ export function createFileAppendTool(defaultEncoding: string = 'utf8') {
     .schema(fileAppendSchema)
     .implementSafe(async (input) => {
       const encoding = input.encoding || defaultEncoding;
-      await fs.appendFile(input.path, input.content, encoding as BufferEncoding);
-      const stats = await fs.stat(input.path);
+      const safePath = await policy.resolvePath(input.path, 'file append');
+      await fs.appendFile(safePath, input.content, encoding as BufferEncoding);
+      const stats = await fs.stat(safePath);
 
       return {
         path: input.path,
@@ -28,4 +33,3 @@ export function createFileAppendTool(defaultEncoding: string = 'utf8') {
     })
     .build();
 }
-

--- a/packages/tools/src/file/operations/tools/file-delete.ts
+++ b/packages/tools/src/file/operations/tools/file-delete.ts
@@ -5,11 +5,12 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileDeleteSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file delete tool
  */
-export function createFileDeleteTool() {
+export function createFileDeleteTool(policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY) {
   return toolBuilder()
     .name('file-delete')
     .description('Delete a file from the file system. Returns an error if the file doesn\'t exist.')
@@ -17,7 +18,8 @@ export function createFileDeleteTool() {
     .tags(['file', 'delete', 'remove', 'filesystem'])
     .schema(fileDeleteSchema)
     .implementSafe(async (input) => {
-      await fs.unlink(input.path);
+      const safePath = await policy.resolvePath(input.path, 'file deletion');
+      await fs.unlink(safePath);
 
       return {
         path: input.path,
@@ -26,4 +28,3 @@ export function createFileDeleteTool() {
     })
     .build();
 }
-

--- a/packages/tools/src/file/operations/tools/file-exists.ts
+++ b/packages/tools/src/file/operations/tools/file-exists.ts
@@ -5,7 +5,11 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileExistsSchema } from '../types.js';
 import { promises as fs } from 'fs';
-import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
+import {
+  DEFAULT_FILE_SYSTEM_POLICY,
+  FileSystemPolicyError,
+  type FileSystemPolicy,
+} from '../../confinement.js';
 
 /**
  * Create file exists tool
@@ -18,8 +22,8 @@ export function createFileExistsTool(policy: FileSystemPolicy = DEFAULT_FILE_SYS
     .tags(['file', 'exists', 'check', 'filesystem'])
     .schema(fileExistsSchema)
     .implement(async (input) => {
-      const safePath = await policy.resolvePath(input.path, 'file existence check');
       try {
+        const safePath = await policy.resolvePath(input.path, 'file existence check');
         await fs.access(safePath);
         const stats = await fs.stat(safePath);
         
@@ -31,7 +35,14 @@ export function createFileExistsTool(policy: FileSystemPolicy = DEFAULT_FILE_SYS
           size: stats.size,
           modified: stats.mtime.toISOString(),
         };
-      } catch {
+      } catch (error) {
+        if (error instanceof FileSystemPolicyError) {
+          return {
+            success: false,
+            error: error.message,
+          };
+        }
+
         return {
           exists: false,
           path: input.path,

--- a/packages/tools/src/file/operations/tools/file-exists.ts
+++ b/packages/tools/src/file/operations/tools/file-exists.ts
@@ -5,11 +5,12 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileExistsSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file exists tool
  */
-export function createFileExistsTool() {
+export function createFileExistsTool(policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY) {
   return toolBuilder()
     .name('file-exists')
     .description('Check if a file or directory exists at the specified path.')
@@ -17,9 +18,10 @@ export function createFileExistsTool() {
     .tags(['file', 'exists', 'check', 'filesystem'])
     .schema(fileExistsSchema)
     .implement(async (input) => {
+      const safePath = await policy.resolvePath(input.path, 'file existence check');
       try {
-        await fs.access(input.path);
-        const stats = await fs.stat(input.path);
+        await fs.access(safePath);
+        const stats = await fs.stat(safePath);
         
         return {
           exists: true,
@@ -38,4 +40,3 @@ export function createFileExistsTool() {
     })
     .build();
 }
-

--- a/packages/tools/src/file/operations/tools/file-reader.ts
+++ b/packages/tools/src/file/operations/tools/file-reader.ts
@@ -5,11 +5,15 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileReaderSchema } from '../types.js';
 import { promises as fs } from 'fs';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file reader tool
  */
-export function createFileReaderTool(defaultEncoding: string = 'utf8') {
+export function createFileReaderTool(
+  defaultEncoding: string = 'utf8',
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('file-reader')
     .description('Read the contents of a file from the file system. Supports text and binary files with various encodings.')
@@ -18,8 +22,9 @@ export function createFileReaderTool(defaultEncoding: string = 'utf8') {
     .schema(fileReaderSchema)
     .implementSafe(async (input) => {
       const encoding = input.encoding || defaultEncoding;
-      const content = await fs.readFile(input.path, encoding as BufferEncoding);
-      const stats = await fs.stat(input.path);
+      const safePath = await policy.resolvePath(input.path, 'file read');
+      const content = await fs.readFile(safePath, encoding as BufferEncoding);
+      const stats = await fs.stat(safePath);
 
       return {
         content,
@@ -30,4 +35,3 @@ export function createFileReaderTool(defaultEncoding: string = 'utf8') {
     })
     .build();
 }
-

--- a/packages/tools/src/file/operations/tools/file-writer.ts
+++ b/packages/tools/src/file/operations/tools/file-writer.ts
@@ -6,11 +6,16 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { fileWriterSchema } from '../types.js';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
 
 /**
  * Create file writer tool
  */
-export function createFileWriterTool(defaultEncoding: string = 'utf8', createDirsDefault: boolean = false) {
+export function createFileWriterTool(
+  defaultEncoding: string = 'utf8',
+  createDirsDefault: boolean = false,
+  policy: FileSystemPolicy = DEFAULT_FILE_SYSTEM_POLICY,
+) {
   return toolBuilder()
     .name('file-writer')
     .description('Write content to a file. Creates the file if it doesn\'t exist, or overwrites it if it does.')
@@ -20,15 +25,16 @@ export function createFileWriterTool(defaultEncoding: string = 'utf8', createDir
     .implementSafe(async (input) => {
       const encoding = input.encoding || defaultEncoding;
       const createDirs = input.createDirs ?? createDirsDefault;
+      const safePath = await policy.resolvePath(input.path, 'file write');
 
       // Create parent directories if requested
       if (createDirs) {
-        const dir = path.dirname(input.path);
+        const dir = path.dirname(safePath);
         await fs.mkdir(dir, { recursive: true });
       }
 
-      await fs.writeFile(input.path, input.content, encoding as BufferEncoding);
-      const stats = await fs.stat(input.path);
+      await fs.writeFile(safePath, input.content, encoding as BufferEncoding);
+      const stats = await fs.stat(safePath);
 
       return {
         path: input.path,
@@ -38,4 +44,3 @@ export function createFileWriterTool(defaultEncoding: string = 'utf8', createDir
     })
     .build();
 }
-

--- a/packages/tools/src/file/operations/types.ts
+++ b/packages/tools/src/file/operations/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import type { FileSystemPolicyInput } from '../confinement.js';
 
 /**
  * File reader schema
@@ -53,5 +54,5 @@ export const fileExistsSchema = z.object({
 export interface FileOperationsConfig {
   defaultEncoding?: 'utf8' | 'utf-8' | 'ascii' | 'base64' | 'hex';
   createDirsDefault?: boolean;
+  policy?: FileSystemPolicyInput;
 }
-

--- a/packages/tools/tests/file/confinement.test.ts
+++ b/packages/tools/tests/file/confinement.test.ts
@@ -1,0 +1,150 @@
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createDirectoryOperationTools,
+  createFileOperationTools,
+  createFileSystemPolicy,
+} from '../../src/file/index.js';
+
+describe('file system confinement policy', () => {
+  let workspaceRoot: string;
+  let outsideRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'agentforge-file-policy-workspace-'));
+    outsideRoot = await mkdtemp(join(tmpdir(), 'agentforge-file-policy-outside-'));
+    await writeFile(join(workspaceRoot, 'inside.txt'), 'inside');
+    await writeFile(join(outsideRoot, 'outside.txt'), 'outside');
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      rm(workspaceRoot, { recursive: true, force: true }),
+      rm(outsideRoot, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('resolves relative paths from the configured workspace root', async () => {
+    const [reader] = createFileOperationTools({
+      policy: createFileSystemPolicy({ workspaceRoot }),
+    });
+
+    await expect(reader.invoke({ path: 'inside.txt' })).resolves.toMatchObject({
+      success: true,
+      data: { content: 'inside' },
+    });
+  });
+
+  it('blocks lexical traversal before file reads or writes', async () => {
+    const [reader, writer] = createFileOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(reader.invoke({ path: join(workspaceRoot, '..', 'outside.txt') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+    await expect(writer.invoke({
+      path: `${workspaceRoot}/../escape.txt`,
+      content: 'blocked',
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining('path traversal') });
+  });
+
+  it('blocks symlink escapes for reads and deletes', async () => {
+    const linkPath = join(workspaceRoot, 'outside-link.txt');
+    await symlink(join(outsideRoot, 'outside.txt'), linkPath);
+
+    const [reader, , , deleter] = createFileOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(reader.invoke({ path: linkPath })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+    await expect(deleter.invoke({ path: linkPath })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+    await expect(readFile(join(outsideRoot, 'outside.txt'), 'utf8')).resolves.toBe('outside');
+  });
+
+  it('blocks recursive deletion of a configured root', async () => {
+    const [, , directoryDeleter] = createDirectoryOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(directoryDeleter.invoke({ path: workspaceRoot, recursive: true })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('recursive deletion of an allowed root'),
+    });
+    await expect(readFile(join(workspaceRoot, 'inside.txt'), 'utf8')).resolves.toBe('inside');
+  });
+
+  it('does not follow symlink entries while listing a confined root', async () => {
+    await symlink(outsideRoot, join(workspaceRoot, 'outside-directory-link'));
+    const [directoryList] = createDirectoryOperationTools({
+      defaultIncludeDetails: true,
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(directoryList.invoke({ path: workspaceRoot })).resolves.toMatchObject({
+      success: true,
+      data: {
+        files: expect.arrayContaining([
+          expect.objectContaining({ name: 'outside-directory-link', isDirectory: false }),
+        ]),
+      },
+    });
+  });
+
+  it('validates missing creation parents and directory traversal through one policy', async () => {
+    const [, writer] = createFileOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+    const [, directoryCreator] = createDirectoryOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(writer.invoke({
+      path: join(workspaceRoot, 'nested', 'created.txt'),
+      content: 'created',
+      createDirs: true,
+    })).resolves.toMatchObject({
+      success: true,
+      data: { path: join(workspaceRoot, 'nested', 'created.txt') },
+    });
+    await expect(directoryCreator.invoke({
+      path: `${workspaceRoot}/../outside-created`,
+      recursive: true,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining('path traversal') });
+  });
+
+  it('preserves an explicit privileged opt-out for trusted automation', async () => {
+    const [, writer] = createFileOperationTools({
+      policy: createFileSystemPolicy({
+        allowedRoots: [workspaceRoot],
+        allowOutsideRoots: true,
+      }),
+    });
+    const outsidePath = join(outsideRoot, 'privileged.txt');
+
+    await expect(writer.invoke({ path: outsidePath, content: 'allowed' })).resolves.toMatchObject({
+      success: true,
+      data: { path: outsidePath },
+    });
+    await expect(readFile(outsidePath, 'utf8')).resolves.toBe('allowed');
+  });
+
+  it('does not hide confinement errors from file-exists checks', async () => {
+    const [, , , , exists] = createFileOperationTools({
+      policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
+    });
+
+    await expect(exists.invoke({ path: join(workspaceRoot, '..', 'outside.txt') })).rejects.toMatchObject({
+      code: 'FILE_SYSTEM_POLICY_VIOLATION',
+    });
+  });
+});

--- a/packages/tools/tests/file/confinement.test.ts
+++ b/packages/tools/tests/file/confinement.test.ts
@@ -138,13 +138,14 @@ describe('file system confinement policy', () => {
     await expect(readFile(outsidePath, 'utf8')).resolves.toBe('allowed');
   });
 
-  it('does not hide confinement errors from file-exists checks', async () => {
+  it('returns confinement errors from file-exists checks as safe failures', async () => {
     const [, , , , exists] = createFileOperationTools({
       policy: createFileSystemPolicy({ allowedRoots: [workspaceRoot] }),
     });
 
-    await expect(exists.invoke({ path: join(workspaceRoot, '..', 'outside.txt') })).rejects.toMatchObject({
-      code: 'FILE_SYSTEM_POLICY_VIOLATION',
+    await expect(exists.invoke({ path: join(workspaceRoot, '..', 'outside.txt') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
     });
   });
 });

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -167,26 +167,27 @@
 ### Checklist
 - [x] Create branch `feat/st-11003-file-tool-confinement`
   - Created on 2026-07-21 from `main` after moving `ST-11003` to `In Progress` in `planning/kanban-queue.md`.
-- [ ] Create draft PR with story ID in title
-  - Use title `feat(tools): add file tool confinement controls [ST-11003]`.
-- [ ] Define test strategy before implementation: identify the practical failing automated test seam for path confinement, traversal, symlink escape, and recursive-delete safety
+- [x] Create draft PR with story ID in title
+  - Draft PR #162 created on 2026-07-21: <https://github.com/TVScoundrel/agentforge/pull/162>
+- [x] Define test strategy before implementation: identify the practical failing automated test seam for path confinement, traversal, symlink escape, and recursive-delete safety
   - Strategy: add red-first unit coverage for a shared filesystem policy resolver and the configured file/directory tool factories in `packages/tools/tests/file/confinement.test.ts`, using temporary roots and symlink fixtures where supported.
-- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
-  - Capture the expected red failure before adding the policy implementation; if platform symlink support is unavailable, record the limitation and retain traversal plus delete safety coverage.
-- [ ] Identify the existing default file read, write, append, exists, directory list/create/delete, and file-search tool paths and define the shared confinement seam
+- [x] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Added `packages/tools/tests/file/confinement.test.ts` before the production policy; the red run failed as expected because `createFileSystemPolicy` was not yet implemented (`7` tests failed).
+- [x] Identify the existing default file read, write, append, exists, directory list/create/delete, and file-search tool paths and define the shared confinement seam
   - Keep pure path utility tools unchanged; route filesystem I/O through a shared policy that can validate lexical paths, resolved existing targets, and creation/deletion parents.
-- [ ] Add a reusable filesystem confinement policy with allowed roots or workspace-relative mode and an explicit privileged escape hatch
-  - Preserve existing unrestricted operator workflows through an explicit `allowOutsideRoots`/privileged policy option while making the safe configured factory path available without bespoke wrappers.
-- [ ] Apply confinement consistently to default file read and mutation tools, directory traversal/list/search, directory creation, and recursive deletion
-  - Block `..` traversal, symlink escapes, and destructive recursive deletes outside configured roots; ensure all configured tools share the same policy semantics and typed errors.
-- [ ] Add focused tests covering path traversal, symlink escape, allowed-root boundaries, creation parents, missing targets, and recursive-delete edge cases
-  - Include both confined behavior and the documented privileged opt-out path.
-- [ ] Add or update public docs explaining model-exposed file-tool modes versus trusted local automation
-  - Document allowed roots, workspace-relative configuration, symlink behavior, deletion safeguards, compatibility, and the privileged escape hatch.
-- [ ] Add or update story documentation at `docs/st11003-file-tool-confinement-controls.md`
-  - Record the security rationale, API/configuration examples, compatibility impact, and validation evidence.
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Assess CI impact; update CI or document why no CI change is required
+- [x] Add a reusable filesystem confinement policy with allowed roots or workspace-relative mode and an explicit privileged escape hatch
+  - Added the exported `FileSystemPolicy`, `createFileSystemPolicy`, `DEFAULT_FILE_SYSTEM_POLICY`, and typed `FileSystemPolicyError`; configured policies support `allowedRoots`, `workspaceRoot`, `allowOutsideRoots`, and `allowRootDeletion`.
+- [x] Apply confinement consistently to default file read and mutation tools, directory traversal/list/search, directory creation, and recursive deletion
+  - Routed all configured file and directory I/O factories through the shared policy; pure path utilities remain unchanged. Existing standalone exports remain unrestricted for trusted automation, while configured factories enforce traversal, realpath containment, symlink, and recursive-root-deletion checks.
+- [x] Add focused tests covering path traversal, symlink escape, allowed-root boundaries, creation parents, missing targets, and recursive-delete edge cases
+  - `packages/tools/tests/file/confinement.test.ts` covers 8 focused cases, including non-following directory-list symlinks; the focused suite and full tools package suite pass, including the explicit privileged opt-out path.
+- [x] Add or update public docs explaining model-exposed file-tool modes versus trusted local automation
+  - Updated `packages/tools/README.md`, `docs-site/api/tools.md`, and `docs-site/guide/concepts/tools.md` with the shared policy configuration and model-exposure guidance.
+- [x] Add or update story documentation at `docs/st11003-file-tool-confinement-controls.md`
+  - Added the security rationale, API/configuration examples, compatibility impact, and current validation evidence.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - Focused confinement coverage plus the tools package suite cover the changed filesystem surface; no additional focused automation is currently required.
+- [x] Assess CI impact; update CI or document why no CI change is required
   - No CI change is expected if the policy is covered by the existing tools-package and workspace TypeScript, Vitest, lint, and build paths.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -189,8 +189,12 @@
   - Focused confinement coverage plus the tools package suite cover the changed filesystem surface; no additional focused automation is currently required.
 - [x] Assess CI impact; update CI or document why no CI change is required
   - No CI change is expected if the policy is covered by the existing tools-package and workspace TypeScript, Vitest, lint, and build paths.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
-- [ ] Commit completed checklist items as logical commits and push updates
-- [ ] Mark PR Ready only after all story tasks are complete
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> `226` test files passed, `9` skipped; `2534` tests passed, `110` skipped.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> passed with `0` errors and the existing `161`-warning baseline; `pnpm typecheck` and `pnpm build` also passed. Build retained the existing VitePress chunk-size warning.
+- [x] Commit completed checklist items as logical commits and push updates
+  - `b3f15c19` tracker start and `7d08f06c` implementation were pushed to `origin/feat/st-11003-file-tool-confinement`; final tracker synchronization is captured in the follow-up commit.
+- [x] Mark PR Ready only after all story tasks are complete
+  - PR #162 is ready for review on 2026-07-21 after implementation, documentation, focused and full validation, lint, typecheck, build, self-review, and tracker synchronization.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -159,3 +159,37 @@
   - PR #161 marked ready for review on 2026-07-20 after implementation, documentation, tracker synchronization, `pnpm test --run`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, and self-review.
 - [x] Wait for merge; do not merge directly from local branch
   - PR #161 merged into `main` on 2026-07-20 as commit `0f8d2f55`; post-merge tracker synchronization is being committed from local `main`.
+
+## ST-11003: Add Filesystem Confinement Controls for Default File Tools
+
+**Branch:** `feat/st-11003-file-tool-confinement`
+
+### Checklist
+- [x] Create branch `feat/st-11003-file-tool-confinement`
+  - Created on 2026-07-21 from `main` after moving `ST-11003` to `In Progress` in `planning/kanban-queue.md`.
+- [ ] Create draft PR with story ID in title
+  - Use title `feat(tools): add file tool confinement controls [ST-11003]`.
+- [ ] Define test strategy before implementation: identify the practical failing automated test seam for path confinement, traversal, symlink escape, and recursive-delete safety
+  - Strategy: add red-first unit coverage for a shared filesystem policy resolver and the configured file/directory tool factories in `packages/tools/tests/file/confinement.test.ts`, using temporary roots and symlink fixtures where supported.
+- [ ] Write or update the failing automated test before production changes when practical; if not practical, record why before implementation
+  - Capture the expected red failure before adding the policy implementation; if platform symlink support is unavailable, record the limitation and retain traversal plus delete safety coverage.
+- [ ] Identify the existing default file read, write, append, exists, directory list/create/delete, and file-search tool paths and define the shared confinement seam
+  - Keep pure path utility tools unchanged; route filesystem I/O through a shared policy that can validate lexical paths, resolved existing targets, and creation/deletion parents.
+- [ ] Add a reusable filesystem confinement policy with allowed roots or workspace-relative mode and an explicit privileged escape hatch
+  - Preserve existing unrestricted operator workflows through an explicit `allowOutsideRoots`/privileged policy option while making the safe configured factory path available without bespoke wrappers.
+- [ ] Apply confinement consistently to default file read and mutation tools, directory traversal/list/search, directory creation, and recursive deletion
+  - Block `..` traversal, symlink escapes, and destructive recursive deletes outside configured roots; ensure all configured tools share the same policy semantics and typed errors.
+- [ ] Add focused tests covering path traversal, symlink escape, allowed-root boundaries, creation parents, missing targets, and recursive-delete edge cases
+  - Include both confined behavior and the documented privileged opt-out path.
+- [ ] Add or update public docs explaining model-exposed file-tool modes versus trusted local automation
+  - Document allowed roots, workspace-relative configuration, symlink behavior, deletion safeguards, compatibility, and the privileged escape hatch.
+- [ ] Add or update story documentation at `docs/st11003-file-tool-confinement-controls.md`
+  - Record the security rationale, API/configuration examples, compatibility impact, and validation evidence.
+- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+- [ ] Assess CI impact; update CI or document why no CI change is required
+  - No CI change is expected if the policy is covered by the existing tools-package and workspace TypeScript, Vitest, lint, and build paths.
+- [ ] Run full test suite before finalizing the PR and record results
+- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [ ] Commit completed checklist items as logical commits and push updates
+- [ ] Mark PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2532,6 +2532,7 @@
 **Priority:** P1 (High)
 **Estimate:** 6 hours
 **Dependencies:** ST-11001
+**Status:** In Progress (2026-07-21)
 
 **Acceptance criteria:**
 - [ ] Default file read and mutation tools support a confinement policy such as allowed roots, workspace-relative mode, or an equivalent guardrail that can be enabled without bespoke wrapper code

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2532,14 +2532,14 @@
 **Priority:** P1 (High)
 **Estimate:** 6 hours
 **Dependencies:** ST-11001
-**Status:** In Progress (2026-07-21)
+**Status:** In Review (PR #162, 2026-07-21)
 
 **Acceptance criteria:**
-- [ ] Default file read and mutation tools support a confinement policy such as allowed roots, workspace-relative mode, or an equivalent guardrail that can be enabled without bespoke wrapper code
-- [ ] Path traversal, symlink-escape, and destructive recursive-delete edge cases are covered by focused tests for the confinement layer
-- [ ] Existing operator-controlled privileged file workflows keep a documented opt-in escape hatch instead of being broken outright
-- [ ] Public docs clearly explain which file-tool modes are suitable for model-exposed agents versus trusted local automation
-- [ ] Add or update story documentation at `docs/st11003-file-tool-confinement-controls.md`
+- [x] Default file read and mutation tools support a confinement policy such as allowed roots, workspace-relative mode, or an equivalent guardrail that can be enabled without bespoke wrapper code
+- [x] Path traversal, symlink-escape, and destructive recursive-delete edge cases are covered by focused tests for the confinement layer
+- [x] Existing operator-controlled privileged file workflows keep a documented opt-in escape hatch instead of being broken outright
+- [x] Public docs clearly explain which file-tool modes are suitable for model-exposed agents versus trusted local automation
+- [x] Add or update story documentation at `docs/st11003-file-tool-confinement-controls.md`
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
-**Last Updated:** 2026-07-20
-**Active Story:** ST-11003 - Ready on 2026-07-20; ST-11002 merged on 2026-07-20 (PR #161); ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
+**Last Updated:** 2026-07-21
+**Active Story:** ST-11003 - In Progress on 2026-07-21; ST-11002 merged on 2026-07-20 (PR #161); ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-07-21
-**Active Story:** ST-11003 - In Progress on 2026-07-21; ST-11002 merged on 2026-07-20 (PR #161); ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
+**Active Story:** ST-11003 - In Review on 2026-07-21 (PR #162); ST-11002 merged on 2026-07-20 (PR #161); ST-11005 merged on 2026-07-18 (PR #160); ST-11004 merged on 2026-07-16 (PR #159)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
-  - Depends on: `ST-11001` (merged)
 - `ST-11006` - Harden Express Chat Example Ownership Semantics
   - Depends on: `ST-11001` (merged)
 
@@ -23,7 +21,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
+  - Depends on: `ST-11001` (merged)
 
 ---
 
@@ -53,6 +52,7 @@ _No stories currently in backlog_
 - ST-11002 moved to `In Progress` on 2026-07-20 as the next dependency-ready EP-11 story; `ST-11003` and `ST-11006` remain in `Ready` behind the merged `ST-11001` policy baseline
 - ST-11002 moved to `In Review` on 2026-07-20 with PR #161 after implementation, focused and full validation, lint, typecheck, build, documentation, and tracker synchronization; `ST-11003` and `ST-11006` remain in `Ready`
 - ST-11002 merged on 2026-07-20 as PR #161 / commit `0f8d2f55`; the active EP-11 ready lane remains `ST-11003` followed by `ST-11006`
+- ST-11003 moved to `In Progress` on 2026-07-21 as the next dependency-ready EP-11 story; `ST-11006` remains in `Ready` behind the merged `ST-11001` policy baseline
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,12 +1,12 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-20
+**Last Updated:** 2026-07-21
 
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -21,14 +21,14 @@
 
 ## In Progress
 
-- `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
-  - Depends on: `ST-11001` (merged)
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11003` - Add Filesystem Confinement Controls for Default File Tools
+  - PR #162: <https://github.com/TVScoundrel/agentforge/pull/162>
 
 ---
 
@@ -53,6 +53,7 @@ _No stories currently in backlog_
 - ST-11002 moved to `In Review` on 2026-07-20 with PR #161 after implementation, focused and full validation, lint, typecheck, build, documentation, and tracker synchronization; `ST-11003` and `ST-11006` remain in `Ready`
 - ST-11002 merged on 2026-07-20 as PR #161 / commit `0f8d2f55`; the active EP-11 ready lane remains `ST-11003` followed by `ST-11006`
 - ST-11003 moved to `In Progress` on 2026-07-21 as the next dependency-ready EP-11 story; `ST-11006` remains in `Ready` behind the merged `ST-11001` policy baseline
+- ST-11003 moved to `In Review` on 2026-07-21 with PR #162 after implementation, documentation, focused and full validation, lint, typecheck, build, and tracker synchronization; `ST-11006` remains in `Ready`
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story

`ST-11003`: Add Filesystem Confinement Controls for Default File Tools

## What Changed

Added a shared `FileSystemPolicy` to the file and directory tool factories. The policy supports configured allowed roots or workspace-relative operation, rejects traversal and resolved symlink escapes, protects recursive deletion of configured roots, and preserves an explicit privileged opt-out for trusted local automation. Pure path utilities remain unchanged.

## Acceptance Criteria Coverage

- [x] Default file read and mutation tools support configurable confinement without bespoke wrappers.
- [x] Traversal, symlink escape, and destructive recursive-delete edge cases are covered by focused tests.
- [x] Privileged operator workflows retain a documented explicit opt-out.
- [x] Public docs distinguish model-exposed file tools from trusted local automation.
- [x] Story documentation is added at `docs/st11003-file-tool-confinement-controls.md`.

## Test Strategy

Red-first tests cover a shared policy resolver and configured file/directory factories using temporary roots and symlink fixtures. The suite validates workspace-relative paths, lexical traversal, resolved symlink containment, creation parents, recursive root deletion, safe directory listing, and the privileged opt-out.

## Validation Performed

Focused confinement suite: 8 tests passed. Tools package suite: 90 files passed, 9 skipped; 1153 tests passed, 110 skipped. Repo-wide `pnpm test --run` passed with 226 files passed, 9 skipped; 2534 tests passed, 110 skipped. `pnpm lint` passed with 0 errors and the existing 161-warning baseline. `pnpm typecheck` and `pnpm build` passed; build retained the existing VitePress chunk-size warning.

## Status

Ready for review. Implementation, documentation, focused and repo-wide validation, lint, typecheck, build, self-review, and tracker synchronization are complete.
