### PR TITLE
fix(st-11006): harden Express chat ownership semantics

### DIFF
--- a/docs/st11006-express-chat-example-ownership-hardening.md
+++ b/docs/st11006-express-chat-example-ownership-hardening.md
@@ -1,0 +1,21 @@
+# ST-11006: Express Chat Example Ownership Hardening
+
+## Decision
+
+The example now requires a non-empty `X-Demo-User-Id` header on every chat endpoint and stores conversations under that owner scope. Missing owner identity returns `401`; cross-owner history reads and deletes behave like missing conversations instead of revealing another owner’s data.
+
+The header is an example-only ownership boundary, not authentication. The README instructs adopters to replace it with an identity established by their verified application authentication layer before exposing the API to users.
+
+## Test Strategy
+
+The example had no HTTP test harness, so focused unit coverage was added around the extracted owner-scoped conversation store and owner-header normalization. Coverage verifies blank-owner rejection, cross-owner isolation, owner-scoped listing, and owner-scoped deletion.
+
+## Compatibility
+
+This is intentionally scoped to the Express example. Existing framework APIs are unchanged, while callers of the example chat routes must now provide the documented demo owner header.
+
+## Validation
+
+- `pnpm --dir examples/integrations/express-api test` -> passed, 3 tests.
+- Standalone example typecheck remains blocked by the example not being part of `pnpm-workspace.yaml`; its dependencies (`express`, LangChain, AgentForge workspace packages, and Zod) are not installed in the example checkout.
+- No CI change is required; the example-local test script provides the focused regression command and the repository-wide gates remain the canonical final validation.

--- a/examples/integrations/express-api/README.md
+++ b/examples/integrations/express-api/README.md
@@ -1,6 +1,8 @@
 # Express.js Integration Example
 
-A production-ready Express.js REST API integration with AgentForge, featuring rate limiting, security headers, streaming, and conversation management.
+An Express.js REST API integration example with AgentForge, featuring rate limiting, security headers, streaming, and conversation management.
+
+> **Demo security boundary:** The chat routes require an `X-Demo-User-Id` header and scope conversation history to that value. This header is only an example ownership boundary, not authentication; replace it with an identity established by verified application authentication before exposing the API to users.
 
 ## Features
 
@@ -147,6 +149,14 @@ Content-Type: application/json
   "message": "Hello!"
 }
 ```
+
+Include the demo owner header with every chat request:
+
+```http
+X-Demo-User-Id: user-123
+```
+
+Conversation IDs are scoped to that owner. History, deletion, and conversation listing do not authorize access based on the caller-provided conversation ID alone; production applications must replace the demo header with a verified identity from their authentication layer.
 
 Response:
 ```json

--- a/examples/integrations/express-api/package.json
+++ b/examples/integrations/express-api/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -27,7 +28,7 @@
     "@types/express": "^5.0.0",
     "@types/cors": "^2.8.17",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
   }
 }
-

--- a/examples/integrations/express-api/src/routes/chat.ts
+++ b/examples/integrations/express-api/src/routes/chat.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import { ChatOpenAI } from '@langchain/openai';
 import { createReActAgent } from '@agentforge/patterns';
 import { z } from 'zod';
+import { createConversationStore, normalizeOwnerId, type ChatMessage } from './conversation-store.js';
 
 const router = Router();
 
-// In-memory conversation storage (use Redis/DB in production)
-const conversations = new Map<string, any[]>();
+// In-memory conversation storage (use Redis/DB in production).
+// The demo owner header must be replaced with verified application identity.
+const conversations = createConversationStore();
 
 // Initialize model
 const model = new ChatOpenAI({
@@ -37,9 +39,20 @@ const chatSchema = z.object({
  *   "conversationId": "optional-id",
  *   "message": "Hello!"
  * }
+ *
+ * Header:
+ * X-Demo-User-Id: user-123
  */
 router.post('/message', async (req, res) => {
   try {
+    const ownerId = normalizeOwnerId(req.get('x-demo-user-id'));
+    if (!ownerId) {
+      return res.status(401).json({
+        error: 'Missing conversation owner',
+        message: 'Provide X-Demo-User-Id for this demo; replace it with verified application identity in production.',
+      });
+    }
+
     const validation = chatSchema.safeParse(req.body);
     if (!validation.success) {
       return res.status(400).json({
@@ -51,7 +64,8 @@ router.post('/message', async (req, res) => {
     const { conversationId = `conv-${Date.now()}`, message } = validation.data;
 
     // Get or create conversation history
-    const history = conversations.get(conversationId) || [];
+    const conversation = conversations.get(ownerId, conversationId) || { conversationId, messages: [] as ChatMessage[] };
+    const history = conversation.messages;
     
     // Add user message to history
     history.push({ role: 'user', content: message });
@@ -61,11 +75,11 @@ router.post('/message', async (req, res) => {
       messages: history,
     });
 
-    const response = result.messages[result.messages.length - 1].content;
+    const response = String(result.messages[result.messages.length - 1].content);
     
     // Add assistant response to history
     history.push({ role: 'assistant', content: response });
-    conversations.set(conversationId, history);
+    conversations.set(ownerId, conversation);
 
     res.json({
       success: true,
@@ -73,11 +87,11 @@ router.post('/message', async (req, res) => {
       message: response,
       messageCount: history.length,
     });
-  } catch (error: any) {
+  } catch (error) {
     console.error('Chat error:', error);
     res.status(500).json({
       success: false,
-      error: error.message,
+      error: error instanceof Error ? error.message : 'Unknown chat error',
     });
   }
 });
@@ -87,10 +101,18 @@ router.post('/message', async (req, res) => {
  * GET /api/chat/history/:conversationId
  */
 router.get('/history/:conversationId', (req, res) => {
-  const { conversationId } = req.params;
-  const history = conversations.get(conversationId);
+  const ownerId = normalizeOwnerId(req.get('x-demo-user-id'));
+  if (!ownerId) {
+    return res.status(401).json({
+      error: 'Missing conversation owner',
+      message: 'Provide X-Demo-User-Id for this demo; replace it with verified application identity in production.',
+    });
+  }
 
-  if (!history) {
+  const { conversationId } = req.params;
+  const conversation = conversations.get(ownerId, conversationId);
+
+  if (!conversation) {
     return res.status(404).json({
       error: 'Conversation not found',
     });
@@ -98,8 +120,8 @@ router.get('/history/:conversationId', (req, res) => {
 
   res.json({
     conversationId,
-    messages: history,
-    messageCount: history.length,
+    messages: conversation.messages,
+    messageCount: conversation.messages.length,
   });
 });
 
@@ -108,8 +130,16 @@ router.get('/history/:conversationId', (req, res) => {
  * DELETE /api/chat/history/:conversationId
  */
 router.delete('/history/:conversationId', (req, res) => {
+  const ownerId = normalizeOwnerId(req.get('x-demo-user-id'));
+  if (!ownerId) {
+    return res.status(401).json({
+      error: 'Missing conversation owner',
+      message: 'Provide X-Demo-User-Id for this demo; replace it with verified application identity in production.',
+    });
+  }
+
   const { conversationId } = req.params;
-  const existed = conversations.delete(conversationId);
+  const existed = conversations.delete(ownerId, conversationId);
 
   res.json({
     success: true,
@@ -122,9 +152,17 @@ router.delete('/history/:conversationId', (req, res) => {
  * GET /api/chat/conversations
  */
 router.get('/conversations', (req, res) => {
-  const conversationList = Array.from(conversations.keys()).map(id => ({
-    conversationId: id,
-    messageCount: conversations.get(id)?.length || 0,
+  const ownerId = normalizeOwnerId(req.get('x-demo-user-id'));
+  if (!ownerId) {
+    return res.status(401).json({
+      error: 'Missing conversation owner',
+      message: 'Provide X-Demo-User-Id for this demo; replace it with verified application identity in production.',
+    });
+  }
+
+  const conversationList = conversations.list(ownerId).map(({ conversationId, messages }) => ({
+    conversationId,
+    messageCount: messages.length,
   }));
 
   res.json({
@@ -134,4 +172,3 @@ router.get('/conversations', (req, res) => {
 });
 
 export { router as chatRouter };
-

--- a/examples/integrations/express-api/src/routes/conversation-store.test.ts
+++ b/examples/integrations/express-api/src/routes/conversation-store.test.ts
@@ -14,6 +14,9 @@ describe('conversation ownership boundaries', () => {
 
     store.set('user-1', conversation);
 
+    const stored = store.get('user-1', 'conv-1');
+    expect(stored).toEqual(conversation);
+    stored?.messages.push({ role: 'user', content: 'should not leak' });
     expect(store.get('user-1', 'conv-1')).toEqual(conversation);
     expect(store.get('user-2', 'conv-1')).toBeUndefined();
     expect(store.list('user-2')).toEqual([]);

--- a/examples/integrations/express-api/src/routes/conversation-store.test.ts
+++ b/examples/integrations/express-api/src/routes/conversation-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createConversationStore, normalizeOwnerId } from './conversation-store.js';
+
+describe('conversation ownership boundaries', () => {
+  it('requires a non-empty owner identifier', () => {
+    expect(normalizeOwnerId(undefined)).toBeUndefined();
+    expect(normalizeOwnerId('   ')).toBeUndefined();
+    expect(normalizeOwnerId(' user-1 ')).toBe('user-1');
+  });
+
+  it('isolates conversations between owners', () => {
+    const store = createConversationStore();
+    const conversation = { conversationId: 'conv-1', messages: [] };
+
+    store.set('user-1', conversation);
+
+    expect(store.get('user-1', 'conv-1')).toEqual(conversation);
+    expect(store.get('user-2', 'conv-1')).toBeUndefined();
+    expect(store.list('user-2')).toEqual([]);
+    expect(store.delete('user-2', 'conv-1')).toBe(false);
+    expect(store.get('user-1', 'conv-1')).toEqual(conversation);
+  });
+
+  it('lists and deletes only the requesting owner’s conversations', () => {
+    const store = createConversationStore();
+    store.set('user-1', { conversationId: 'conv-1', messages: [] });
+    store.set('user-1', { conversationId: 'conv-2', messages: [] });
+    store.set('user-2', { conversationId: 'conv-3', messages: [] });
+
+    expect(store.list('user-1').map(({ conversationId }) => conversationId)).toEqual(['conv-1', 'conv-2']);
+    expect(store.delete('user-1', 'conv-1')).toBe(true);
+    expect(store.list('user-1').map(({ conversationId }) => conversationId)).toEqual(['conv-2']);
+    expect(store.get('user-2', 'conv-3')).toEqual({ conversationId: 'conv-3', messages: [] });
+  });
+});

--- a/examples/integrations/express-api/src/routes/conversation-store.ts
+++ b/examples/integrations/express-api/src/routes/conversation-store.ts
@@ -1,0 +1,51 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface Conversation {
+  conversationId: string;
+  messages: ChatMessage[];
+}
+
+interface StoredConversation extends Conversation {
+  ownerId: string;
+}
+
+export interface ConversationStore {
+  get(ownerId: string, conversationId: string): Conversation | undefined;
+  set(ownerId: string, conversation: Conversation): void;
+  delete(ownerId: string, conversationId: string): boolean;
+  list(ownerId: string): Conversation[];
+}
+
+function conversationKey(ownerId: string, conversationId: string): string {
+  return `${ownerId}\u0000${conversationId}`;
+}
+
+export function createConversationStore(): ConversationStore {
+  const conversations = new Map<string, StoredConversation>();
+
+  return {
+    get(ownerId, conversationId) {
+      const conversation = conversations.get(conversationKey(ownerId, conversationId));
+      return conversation ? { conversationId: conversation.conversationId, messages: conversation.messages } : undefined;
+    },
+    set(ownerId, conversation) {
+      conversations.set(conversationKey(ownerId, conversation.conversationId), { ownerId, ...conversation });
+    },
+    delete(ownerId, conversationId) {
+      return conversations.delete(conversationKey(ownerId, conversationId));
+    },
+    list(ownerId) {
+      return Array.from(conversations.values())
+        .filter((conversation) => conversation.ownerId === ownerId)
+        .map(({ conversationId, messages }) => ({ conversationId, messages }));
+    },
+  };
+}
+
+export function normalizeOwnerId(value: string | undefined): string | undefined {
+  const ownerId = value?.trim();
+  return ownerId || undefined;
+}

--- a/examples/integrations/express-api/src/routes/conversation-store.ts
+++ b/examples/integrations/express-api/src/routes/conversation-store.ts
@@ -29,10 +29,16 @@ export function createConversationStore(): ConversationStore {
   return {
     get(ownerId, conversationId) {
       const conversation = conversations.get(conversationKey(ownerId, conversationId));
-      return conversation ? { conversationId: conversation.conversationId, messages: conversation.messages } : undefined;
+      return conversation
+        ? { conversationId: conversation.conversationId, messages: [...conversation.messages] }
+        : undefined;
     },
     set(ownerId, conversation) {
-      conversations.set(conversationKey(ownerId, conversation.conversationId), { ownerId, ...conversation });
+      conversations.set(conversationKey(ownerId, conversation.conversationId), {
+        ownerId,
+        conversationId: conversation.conversationId,
+        messages: [...conversation.messages],
+      });
     },
     delete(ownerId, conversationId) {
       return conversations.delete(conversationKey(ownerId, conversationId));
@@ -40,7 +46,7 @@ export function createConversationStore(): ConversationStore {
     list(ownerId) {
       return Array.from(conversations.values())
         .filter((conversation) => conversation.ownerId === ownerId)
-        .map(({ conversationId, messages }) => ({ conversationId, messages }));
+        .map(({ conversationId, messages }) => ({ conversationId, messages: [...messages] }));
     },
   };
 }

--- a/examples/integrations/express-api/tsconfig.json
+++ b/examples/integrations/express-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
@@ -7,4 +7,3 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }
-

--- a/examples/integrations/express-api/vitest.config.ts
+++ b/examples/integrations/express-api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -209,15 +209,29 @@
 ### Checklist
 - [ ] Create branch `fix/st-11006-express-chat-example-ownership-hardening`
 - [ ] Create a draft PR with the story ID in the title
-- [ ] Define the test strategy for conversation ownership and the documented demo-only guardrail path
-- [ ] Add or update failing route tests before production changes where a practical seam exists
-- [ ] Enforce a minimal ownership boundary or clearly document the intentionally unauthenticated demo-only behavior adjacent to the routes and README
-- [ ] Ensure history retrieval, deletion, listing, and message mutation do not imply that caller-provided IDs provide production authorization
-- [ ] Add focused example route coverage for the chosen ownership or guardrail behavior
-- [ ] Add or update story documentation at `docs/st11006-express-chat-example-ownership-hardening.md`
-- [ ] Assess CI impact and record why no CI change is required unless the example needs a new test command
-- [ ] Run the supported example tests and the repository's canonical full test, lint, typecheck, and build validation
-- [ ] Commit completed checklist items as logical story-linked commits and push updates
+- [x] Define the test strategy for conversation ownership and the documented demo-only guardrail path
+  - Use focused unit coverage for the extracted owner-scoped conversation store and owner-header validation because the example has no HTTP test harness or test dependency; preserve the route behavior through those stable seams.
+- [x] Add or update failing route tests before production changes where a practical seam exists
+  - Added owner-scoping tests first; the initial run is expected to fail until the store and ownership helpers are implemented.
+- [x] Enforce a minimal ownership boundary or clearly document the intentionally unauthenticated demo-only behavior adjacent to the routes and README
+  - Added required `X-Demo-User-Id` ownership scoping and documented that it must be replaced with verified application identity in production.
+- [x] Ensure history retrieval, deletion, listing, and message mutation do not imply that caller-provided IDs provide production authorization
+  - All four chat endpoints now require owner scope; cross-owner reads/deletes are treated as not found.
+- [x] Add focused example route coverage for the chosen ownership or guardrail behavior
+  - `pnpm --dir examples/integrations/express-api test` -> passed, 1 file and 3 tests.
+- [x] Add or update story documentation at `docs/st11006-express-chat-example-ownership-hardening.md`
+  - Added the ownership decision, compatibility boundary, test strategy, and validation evidence.
+- [x] Assess CI impact and record why no CI change is required unless the example needs a new test command
+  - No CI change is required; the example-local Vitest script provides focused coverage and repository gates remain unchanged.
+- [x] Run the supported example tests and the repository's canonical full test, lint, typecheck, and build validation
+  - `pnpm test --run` -> 226 files passed, 9 skipped; 2534 tests passed, 110 skipped.
+  - `pnpm lint` -> passed with existing warning-only baseline and 0 errors.
+  - `pnpm typecheck` -> passed for all 6 workspace packages.
+  - `pnpm build` -> passed for all 8 build targets.
+  - Standalone example typecheck remains unavailable because the example is outside `pnpm-workspace.yaml` and its declared dependencies are not installed in the checkout.
+- [x] Commit completed checklist items as logical story-linked commits and push updates
+- [ ] Mark the PR Ready only after all story tasks are complete
+- [ ] Wait for merge; do not merge directly from local branch
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch
 

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -208,7 +208,8 @@
 
 ### Checklist
 - [ ] Create branch `fix/st-11006-express-chat-example-ownership-hardening`
-- [ ] Create a draft PR with the story ID in the title
+- [x] Create a draft PR with the story ID in the title
+  - Draft PR #163 created: <https://github.com/TVScoundrel/agentforge/pull/163>
 - [x] Define the test strategy for conversation ownership and the documented demo-only guardrail path
   - Use focused unit coverage for the extracted owner-scoped conversation store and owner-header validation because the example has no HTTP test harness or test dependency; preserve the route behavior through those stable seams.
 - [x] Add or update failing route tests before production changes where a practical seam exists
@@ -230,9 +231,8 @@
   - `pnpm build` -> passed for all 8 build targets.
   - Standalone example typecheck remains unavailable because the example is outside `pnpm-workspace.yaml` and its declared dependencies are not installed in the checkout.
 - [x] Commit completed checklist items as logical story-linked commits and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
-- [ ] Wait for merge; do not merge directly from local branch
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Mark the PR Ready only after all story tasks are complete
+  - PR #163 marked ready for review after tracker synchronization and self-review.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2617,13 +2617,14 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** ST-11001
+**Status:** In Progress
 
 **Acceptance criteria:**
-- [ ] The Express chat example either enforces a minimal ownership/auth boundary for conversation history endpoints or is clearly documented as intentionally unauthenticated demo-only code with safer production guidance adjacent to the route handlers and README
-- [ ] Example tests or focused route coverage prove the intended ownership behavior or documented guardrail path
-- [ ] Example docs stop implying that caller-provided conversation IDs are sufficient for production history retrieval/deletion flows
-- [ ] The story remains scoped to the example integration and does not attempt to invent a production auth framework for all adopters
-- [ ] Add or update story documentation at `docs/st11006-express-chat-example-ownership-hardening.md`
+- [x] The Express chat example requires a non-empty demo owner header, scopes conversation storage and all history operations to that owner, and documents the header as a demo-only guardrail rather than authentication
+- [x] Focused ownership-store tests prove missing-owner rejection, cross-owner isolation, owner-scoped listing, and owner-scoped deletion
+- [x] Example docs stop implying that caller-provided conversation IDs are sufficient for production history retrieval/deletion flows
+- [x] The story remains scoped to the example integration and does not attempt to invent a production auth framework for all adopters
+- [x] Add or update story documentation at `docs/st11006-express-chat-example-ownership-hardening.md`
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-07-27
-**Active Story:** ST-11006 - In Progress; ST-11007 and ST-11008 remain queued backlog follow-ons after the merged web/file policy work
+**Active Story:** ST-11006 - In Review (PR #163); ST-11007 and ST-11008 remain queued backlog follow-ons after the merged web/file policy work
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 4 stories
 
@@ -20,14 +20,15 @@ None currently.
 
 ## In Progress
 
-- `ST-11006` - Harden Express Chat Example Ownership Semantics
-  - Depends on: `ST-11001` (merged)
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11006` - Harden Express Chat Example Ownership Semantics
+  - Depends on: `ST-11001` (merged)
+  - PR: <https://github.com/TVScoundrel/agentforge/pull/163>
 
 ---
 
@@ -62,7 +63,7 @@ _No stories currently blocked_
 - ST-11003 moved to `In Review` on 2026-07-21 with PR #162 after implementation, documentation, focused and full validation, lint, typecheck, build, and tracker synchronization; `ST-11006` remains in `Ready`
 - ST-11003 merged on 2026-07-21 as PR #162 / commit `31e2270b`; removed from the active queue, archived as done, and left `ST-11006` as the next dependency-ready story
 - ST-11007, ST-11008, ST-09089, and ST-09091 added to Backlog on 2026-07-27 after source review identified bounded, low-risk follow-on improvements for EP-11 and EP-09; `ST-11006` was the only Ready story before moving to In Progress
-- ST-11006 moved to In Progress on 2026-07-27 after the planning commit was pushed; implementation is scoped to the Express example ownership boundary and adjacent guidance
+- ST-11006 moved to In Review on 2026-07-27 with PR #163 after focused ownership tests, full test, lint, workspace typecheck, build, documentation, and self-review completed
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story

`ST-11006` - Harden Express Chat Example Ownership Semantics

## What Changed

- Added owner-scoped conversation storage for the Express chat example.
- Required a non-empty `X-Demo-User-Id` header for message, history, deletion, and listing endpoints.
- Made cross-owner reads and deletes behave as missing conversations.
- Added focused ownership tests and an example-local Vitest command.
- Updated the README and story documentation to state that the demo header is not authentication.
- Corrected the example TypeScript config to extend the repository config.

## Acceptance Criteria Coverage

- Conversation history operations are scoped to the owner identifier.
- Focused tests cover missing owners, cross-owner isolation, owner-scoped listing, and deletion.
- Documentation no longer presents caller-provided conversation IDs as production authorization.
- Scope remains limited to the Express example; no application-wide auth framework was introduced.

## Test Strategy

The example had no HTTP test harness, so the ownership boundary is extracted into a small store and normalization seam with focused unit coverage. The routes use that same store for every conversation operation.

## Validation Performed

- `pnpm --dir examples/integrations/express-api test` - passed, 1 file and 3 tests.
- `pnpm test --run` - passed, 226 files and 2,534 tests; 9 files and 110 tests skipped.
- `pnpm lint` - passed with the existing warning-only baseline.
- `pnpm typecheck` - passed for all 6 workspace packages.
- `pnpm build` - passed for all 8 build targets.
- Standalone example typecheck remains unavailable because the example is outside `pnpm-workspace.yaml` and its declared dependencies are not installed in this checkout.

## Status

Draft, ready for review after final tracker synchronization.
