### PR TITLE
[ST-11007] Add model-safe file and web tool presets

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -1365,6 +1365,22 @@ const safeDirectoryTools = createDirectoryOperationTools({ policy });
 
 `workspaceRoot` resolves relative paths from the workspace and confines all configured operations to that root. Use `allowedRoots` for multiple permitted roots. The policy rejects lexical traversal, resolved symlink escapes, paths outside the allowed roots, and recursive deletion of an allowed root. Set `allowOutsideRoots: true` only for trusted local automation that explicitly needs unrestricted host access.
 
+### Model-Safe File and Web Preset
+
+When file and web tools are exposed to a model, use the combined preset instead of wiring separate policy objects by hand:
+
+```typescript
+import { createModelSafeToolPreset } from '@agentforge/tools';
+
+const preset = createModelSafeToolPreset({
+  fileSystem: { workspaceRoot: process.cwd() },
+});
+
+const agentTools = preset.tools;
+```
+
+The preset requires `workspaceRoot` or `allowedRoots`, applies one confinement policy to all file and directory tools, and preserves the default web blocks for localhost, private-network, link-local, metadata, and unsafe redirect destinations. Privileged override flags are forced back to safe values; use the standalone factories only for trusted operator-controlled automation.
+
 ## Utility Tools (22)
 
 ### Date/Time

--- a/docs/st11007-model-safe-tool-presets.md
+++ b/docs/st11007-model-safe-tool-presets.md
@@ -1,0 +1,30 @@
+# ST-11007: Model-Safe File and Web Tool Presets
+
+## Scope
+
+ST-11007 adds an additive `createModelSafeToolPreset` factory to `@agentforge/tools`. It combines the existing file operation, directory operation, HTTP, and scraper factories behind a single model-exposure setup while preserving the existing standalone exports for trusted automation.
+
+## Security Decisions
+
+- A filesystem `workspaceRoot` or non-empty `allowedRoots` configuration is required.
+- All configured file and directory tools share one `FileSystemPolicy`.
+- `allowOutsideRoots` and `allowRootDeletion` are forced off by the preset.
+- Web tools retain destination checks for localhost, private-network, link-local, metadata, and redirect targets.
+- Privileged web destination flags supplied to the preset are forced back to their safe defaults.
+
+## Usage
+
+```typescript
+import { createModelSafeToolPreset } from '@agentforge/tools';
+
+const { tools } = createModelSafeToolPreset({
+  fileSystem: { workspaceRoot: process.cwd() },
+});
+```
+
+Use the existing `createFileOperationTools`, `createDirectoryOperationTools`, `createHttpTools`, and `createScraperTools` factories directly for trusted operator-controlled workflows that intentionally need privileged access.
+
+## Validation
+
+- Focused red/green coverage: `pnpm --filter @agentforge/tools test --run tests/model-safe-presets.test.ts`
+- Coverage includes root requirement, workspace/public-host success, traversal, symlink escape, private destinations, unsafe redirects, and privileged override rejection.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -225,6 +225,21 @@ const safeDirectoryTools = createDirectoryOperationTools({ policy });
 
 The policy rejects `..` traversal, resolved symlink escapes, paths outside configured roots, and recursive deletion of a configured root. Use `allowedRoots` for multiple roots. Keep the default unrestricted exports for trusted local automation only; `allowOutsideRoots: true` is an explicit privileged opt-out when a configured factory must access the wider host filesystem. The `file-exists` tool preserves its legacy result shape for successful and missing-path checks, while policy violations return `{ success: false, error }`. Detailed `directory-list` results use non-following `lstat` metadata for symlink entries under both default and confined policies.
 
+For the recommended model-exposed setup, use the combined preset. It requires a workspace or allowed root, applies the same root confinement to all file and directory tools, and retains the web policy's localhost, private-network, link-local, metadata, and redirect checks:
+
+```typescript
+import { createModelSafeToolPreset } from '@agentforge/tools';
+
+const { tools } = createModelSafeToolPreset({
+  fileSystem: { workspaceRoot: process.cwd() },
+  web: { http: { defaultTimeout: 15000 } },
+});
+
+const agentTools = tools;
+```
+
+The preset deliberately ignores privileged filesystem and network opt-ins such as `allowOutsideRoots` and `allowPrivateNetwork`. Use the existing standalone factories for trusted operator-controlled automation that needs those capabilities.
+
 ### Utility Tools (22 tools)
 
 General utility tools for common operations.

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,10 +13,10 @@ export * from './data/index.js';
 
 // File Tools
 export * from './file/index.js';
+export * from './model-safe.js';
 
 // Utility Tools
 export * from './utility/index.js';
 
 // Agent Tools
 export * from './agent/index.js';
-

--- a/packages/tools/src/model-safe.ts
+++ b/packages/tools/src/model-safe.ts
@@ -1,0 +1,83 @@
+import { createDirectoryOperationTools } from './file/directory/index.js';
+import type { DirectoryOperationsConfig } from './file/directory/types.js';
+import {
+  createFileSystemPolicy,
+  type FileSystemPolicyOptions,
+} from './file/confinement.js';
+import { createFileOperationTools } from './file/operations/index.js';
+import type { FileOperationsConfig } from './file/operations/types.js';
+import { DEFAULT_DESTINATION_POLICY, type DestinationPolicy } from './web/egress-policy.js';
+import { createHttpTools } from './web/http/index.js';
+import type { HttpToolsConfig } from './web/http/types.js';
+import { createScraperTools } from './web/scraper/index.js';
+import type { ScraperToolsConfig } from './web/scraper/types.js';
+
+export interface ModelSafeToolPresetOptions {
+  fileSystem?: FileSystemPolicyOptions;
+  file?: Omit<FileOperationsConfig, 'policy'>;
+  directory?: Omit<DirectoryOperationsConfig, 'policy'>;
+  web?: {
+    http?: Omit<HttpToolsConfig, 'destinationPolicy'>;
+    scraper?: Omit<ScraperToolsConfig, 'destinationPolicy'>;
+    destinationPolicy?: DestinationPolicy;
+  };
+}
+
+type FileTool = ReturnType<typeof createFileOperationTools>[number];
+type DirectoryTool = ReturnType<typeof createDirectoryOperationTools>[number];
+type WebTool = ReturnType<typeof createHttpTools>[number] | ReturnType<typeof createScraperTools>[number];
+
+export interface ModelSafeToolPreset {
+  fileTools: FileTool[];
+  directoryTools: DirectoryTool[];
+  webTools: WebTool[];
+  tools: Array<FileTool | DirectoryTool | WebTool>;
+}
+
+function requireFilesystemRoot(options: FileSystemPolicyOptions | undefined): FileSystemPolicyOptions {
+  if (!options?.workspaceRoot && !options?.allowedRoots?.length) {
+    throw new Error('Model-safe tool preset requires workspaceRoot or allowedRoots');
+  }
+
+  return {
+    ...options,
+    allowOutsideRoots: false,
+    allowRootDeletion: false,
+  };
+}
+
+function modelSafeDestinationPolicy(policy: DestinationPolicy = {}): DestinationPolicy {
+  return {
+    ...DEFAULT_DESTINATION_POLICY,
+    ...policy,
+    allowLocalhost: false,
+    allowPrivateNetwork: false,
+    allowLinkLocal: false,
+    allowMetadata: false,
+  };
+}
+
+/**
+ * Create the recommended tool collection for model-controlled file and web access.
+ *
+ * A filesystem root is required, and privileged filesystem/network policy flags are
+ * intentionally forced back to their safe defaults. Trusted automation should use
+ * the existing standalone factories when it needs broader access.
+ */
+export function createModelSafeToolPreset(options: ModelSafeToolPresetOptions = {}): ModelSafeToolPreset {
+  const fileSystemPolicy = createFileSystemPolicy(requireFilesystemRoot(options.fileSystem));
+  const destinationPolicy = modelSafeDestinationPolicy(options.web?.destinationPolicy);
+  const fileTools = createFileOperationTools({ ...options.file, policy: fileSystemPolicy });
+  const directoryTools = createDirectoryOperationTools({ ...options.directory, policy: fileSystemPolicy });
+  const webTools = [
+    ...createHttpTools({ ...options.web?.http, destinationPolicy }),
+    ...createScraperTools({ ...options.web?.scraper, destinationPolicy }),
+  ];
+
+  return {
+    fileTools,
+    directoryTools,
+    webTools,
+    tools: [...fileTools, ...directoryTools, ...webTools],
+  };
+}

--- a/packages/tools/tests/model-safe-presets.test.ts
+++ b/packages/tools/tests/model-safe-presets.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createModelSafeToolPreset } from '../src/model-safe.js';
+
+vi.mock('axios');
+
+const mockedAxios = vi.mocked(axios);
+
+describe('model-safe tool preset', () => {
+  let workspaceRoot: string;
+  let outsideRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'agentforge-model-safe-workspace-'));
+    outsideRoot = await mkdtemp(join(tmpdir(), 'agentforge-model-safe-outside-'));
+    await writeFile(join(workspaceRoot, 'inside.txt'), 'inside');
+    await writeFile(join(outsideRoot, 'outside.txt'), 'outside');
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      rm(workspaceRoot, { recursive: true, force: true }),
+      rm(outsideRoot, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('requires an explicit filesystem root', () => {
+    expect(() => createModelSafeToolPreset()).toThrow('requires workspaceRoot or allowedRoots');
+  });
+
+  it('combines confined file tools with policy-checked web tools', async () => {
+    const preset = createModelSafeToolPreset({ fileSystem: { workspaceRoot } });
+    const fileReader = preset.fileTools.find((tool) => tool.metadata.name === 'file-reader')!;
+    const httpGet = preset.webTools.find((tool) => tool.metadata.name === 'http-get')!;
+
+    await expect(fileReader.invoke({ path: 'inside.txt' })).resolves.toMatchObject({
+      success: true,
+      data: { content: 'inside' },
+    });
+    await expect(fileReader.invoke({ path: join(outsideRoot, 'outside.txt') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+    await expect(httpGet.invoke({ url: 'http://127.0.0.1/internal' })).rejects.toMatchObject({ reason: 'localhost' });
+    expect(preset.tools).toHaveLength(preset.fileTools.length + preset.directoryTools.length + preset.webTools.length);
+  });
+
+  it('blocks symlink escapes and private redirect targets', async () => {
+    await symlink(join(outsideRoot, 'outside.txt'), join(workspaceRoot, 'outside-link.txt'));
+    const preset = createModelSafeToolPreset({ fileSystem: { workspaceRoot } });
+    const fileReader = preset.fileTools.find((tool) => tool.metadata.name === 'file-reader')!;
+    const httpGet = preset.webTools.find((tool) => tool.metadata.name === 'http-get')!;
+
+    await expect(fileReader.invoke({ path: join(workspaceRoot, 'outside-link.txt') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+
+    mockedAxios
+      .mockResolvedValueOnce({ status: 302, headers: { location: 'http://192.168.1.20/internal' }, config: {}, data: undefined })
+      .mockResolvedValueOnce({ status: 200, headers: {}, config: {}, data: { ok: true } });
+    await expect(httpGet.invoke({ url: 'http://93.184.216.34/start' })).rejects.toMatchObject({ reason: 'private-network' });
+    expect(mockedAxios).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows configured workspace and public-host use while forcing safe policy flags', async () => {
+    const preset = createModelSafeToolPreset({
+      fileSystem: { workspaceRoot, allowOutsideRoots: true, allowRootDeletion: true },
+      web: { destinationPolicy: { allowPrivateNetwork: true, allowMetadata: true, allowLocalhost: true } },
+    });
+    const httpGet = preset.webTools.find((tool) => tool.metadata.name === 'http-get')!;
+    mockedAxios.mockResolvedValue({ status: 200, headers: {}, config: {}, data: { ok: true } });
+
+    await expect(httpGet.invoke({ url: 'http://127.0.0.1/should-still-be-blocked' })).rejects.toMatchObject({ reason: 'localhost' });
+    await expect(httpGet.invoke({ url: 'http://93.184.216.34/public' })).resolves.toEqual({ ok: true });
+  });
+});

--- a/packages/tools/tests/model-safe-presets.test.ts
+++ b/packages/tools/tests/model-safe-presets.test.ts
@@ -72,10 +72,21 @@ describe('model-safe tool preset', () => {
       fileSystem: { workspaceRoot, allowOutsideRoots: true, allowRootDeletion: true },
       web: { destinationPolicy: { allowPrivateNetwork: true, allowMetadata: true, allowLocalhost: true } },
     });
+    const fileReader = preset.fileTools.find((tool) => tool.metadata.name === 'file-reader')!;
+    const directoryDeleter = preset.directoryTools.find((tool) => tool.metadata.name === 'directory-delete')!;
     const httpGet = preset.webTools.find((tool) => tool.metadata.name === 'http-get')!;
     mockedAxios.mockResolvedValue({ status: 200, headers: {}, config: {}, data: { ok: true } });
 
+    await expect(fileReader.invoke({ path: join(outsideRoot, 'outside.txt') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+    await expect(directoryDeleter.invoke({ path: workspaceRoot, recursive: true })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('recursive deletion of an allowed root'),
+    });
     await expect(httpGet.invoke({ url: 'http://127.0.0.1/should-still-be-blocked' })).rejects.toMatchObject({ reason: 'localhost' });
+    await expect(httpGet.invoke({ url: 'http://169.254.169.254/latest/meta-data/' })).rejects.toMatchObject({ reason: 'metadata' });
     await expect(httpGet.invoke({ url: 'http://93.184.216.34/public' })).resolves.toEqual({ ok: true });
   });
 });

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -244,13 +244,26 @@
 **Branch:** `feat/st-11007-model-safe-tool-presets`
 
 ### Checklist
-- [ ] Create branch `feat/st-11007-model-safe-tool-presets`
-- [ ] Define focused tests for combined filesystem confinement and web destination-policy behavior
-- [ ] Add explicit model-safe factory or preset APIs without changing unrestricted trusted exports
-- [ ] Prove safe presets reject traversal, symlink escapes, private/metadata destinations, and unsafe redirects
-- [ ] Update public tool documentation and examples with the recommended model-exposed setup
-- [ ] Add or update story documentation at `docs/st11007-model-safe-tool-presets.md`
-- [ ] Run tools tests, typecheck, lint, and build
+- [x] Create branch `feat/st-11007-model-safe-tool-presets`
+  - Created on 2026-07-28 from `main` after moving `ST-11007` to `In Progress` in `planning/kanban-queue.md`.
+- [x] Define focused tests for combined filesystem confinement and web destination-policy behavior
+  - Test-first strategy: add focused red/green coverage for named model-safe file and web factories, proving the existing confinement and destination policies remain active through the combined preset surface.
+- [x] Add explicit model-safe factory or preset APIs without changing unrestricted trusted exports
+  - Added exported `createModelSafeToolPreset`, which combines file, directory, HTTP, and scraper tools while leaving standalone factories unchanged.
+- [x] Prove safe presets reject traversal, symlink escapes, private/metadata destinations, and unsafe redirects
+  - Added four focused tests covering explicit-root requirements, workspace/public-host success, traversal, symlink escapes, private destinations, redirect revalidation, and forced-safe override flags.
+- [x] Update public tool documentation and examples with the recommended model-exposed setup
+  - Updated `packages/tools/README.md` and `docs-site/api/tools.md` with the combined preset usage and trusted-automation compatibility boundary.
+- [x] Add or update story documentation at `docs/st11007-model-safe-tool-presets.md`
+  - Added the story scope, security decisions, usage guidance, and validation evidence.
+- [x] Assess CI impact; update CI or document why no CI change is required
+  - No CI change is required because the preset is covered by the existing tools-package Vitest, TypeScript, workspace lint, and build paths.
+- [x] Run tools tests, typecheck, lint, and build
+  - `pnpm --filter @agentforge/tools test --run` -> `91` passed, `9` skipped files; `1157` passed, `110` skipped tests.
+  - `pnpm --filter @agentforge/tools typecheck` -> passed.
+  - `pnpm lint` -> passed with the existing `161`-warning baseline and `0` errors.
+  - `pnpm build` -> passed for all workspace build targets with the existing VitePress chunk-size warning.
+  - `pnpm test --run` -> `227` passed, `9` skipped files; `2538` passed, `110` skipped tests.
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -264,6 +264,7 @@
   - `pnpm lint` -> passed with the existing `161`-warning baseline and `0` errors.
   - `pnpm build` -> passed for all workspace build targets with the existing VitePress chunk-size warning.
   - `pnpm test --run` -> `227` passed, `9` skipped files; `2538` passed, `110` skipped tests.
+  - Follow-up review coverage adds direct assertions for forced filesystem root confinement/root-deletion flags and forced metadata/private/local web destination blocks.
 - [x] Commit completed checklist items and push updates
   - `69bf3aa1` `feat(st-11007): add model-safe tool preset` pushed to `origin/feat/st-11007-model-safe-tool-presets`; draft PR #164 created with the required story, acceptance, test, validation, and status sections.
 - [x] Mark the PR Ready only after all story tasks are complete

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -264,8 +264,10 @@
   - `pnpm lint` -> passed with the existing `161`-warning baseline and `0` errors.
   - `pnpm build` -> passed for all workspace build targets with the existing VitePress chunk-size warning.
   - `pnpm test --run` -> `227` passed, `9` skipped files; `2538` passed, `110` skipped tests.
-- [ ] Commit completed checklist items and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items and push updates
+  - `69bf3aa1` `feat(st-11007): add model-safe tool preset` pushed to `origin/feat/st-11007-model-safe-tool-presets`; draft PR #164 created with the required story, acceptance, test, validation, and status sections.
+- [x] Mark the PR Ready only after all story tasks are complete
+  - PR #164 marked ready for review after the final self-review, tracker synchronization, and validation evidence were completed.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
-**Last Updated:** 2026-07-27
-**Active Story:** ST-11006 - Merged on 2026-07-27 (PR #163); ST-11007 and ST-11008 are now Ready
+**Last Updated:** 2026-07-28
+**Active Story:** ST-11007 - In Progress; ST-11008 remains Ready
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-07-28
-**Active Story:** ST-11007 - In Progress; ST-11008 remains Ready
+**Active Story:** ST-11007 - In Review (PR #164); ST-11008 remains Ready
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -4,8 +4,8 @@
 
 ## Queue Status Summary
 
-- **Ready:** 4 stories
-- **In Progress:** 0 stories
+- **Ready:** 3 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-11007` - Add Model-Safe File and Web Tool Presets
-  - Depends on: `ST-11002` and `ST-11003` (merged)
 - `ST-11008` - Tighten Express Example CORS and Request Limits
   - Depends on: `ST-11006` (merged)
 - `ST-09089` - Harden CLI JSON Utility Type Boundaries
@@ -27,7 +25,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-11007` - Add Model-Safe File and Web Tool Presets
+  - Depends on: `ST-11002` and `ST-11003` (merged)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 3 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -25,14 +25,15 @@
 
 ## In Progress
 
-- `ST-11007` - Add Model-Safe File and Web Tool Presets
-  - Depends on: `ST-11002` and `ST-11003` (merged)
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11007` - Add Model-Safe File and Web Tool Presets
+  - Depends on: `ST-11002` and `ST-11003` (merged)
+  - PR: #164
 
 ---
 


### PR DESCRIPTION
## Story

`ST-11007` - Add Model-Safe File and Web Tool Presets

## What Changed

- Added exported `createModelSafeToolPreset` for combined model-exposed file, directory, HTTP, and scraper tools.
- Required an explicit `workspaceRoot` or `allowedRoots` filesystem boundary.
- Forced filesystem root confinement and safe web destination flags while preserving trusted standalone factories.
- Added focused security regression coverage and public/API/story documentation.

## Acceptance Criteria Coverage

- Model-safe factory combines filesystem confinement and default web destination policy.
- Existing unrestricted standalone exports remain unchanged for trusted automation.
- Tests cover traversal, symlink escapes, private/metadata destinations, unsafe redirects, public-host use, and privileged override rejection.
- Package README, docs-site API guidance, and `docs/st11007-model-safe-tool-presets.md` document the recommended setup.

## Test Strategy

Red/green focused Vitest coverage for the new preset using temporary filesystem roots and mocked Axios/DNS boundaries; existing policy suites remain unchanged.

## Validation Performed

- `pnpm --filter @agentforge/tools test --run` - 91 passed, 9 skipped files; 1157 passed, 110 skipped tests.
- `pnpm --filter @agentforge/tools typecheck` - passed.
- `pnpm lint` - passed with existing 161-warning baseline, 0 errors.
- `pnpm build` - passed with existing VitePress chunk-size warning.
- `pnpm test --run` - 227 passed, 9 skipped files; 2538 passed, 110 skipped tests.

## Status

Ready for review. CI impact assessment: no CI change required; the existing tools-package and workspace validation paths cover this additive API.
