### PR TITLE
ST-09089: Harden CLI JSON utility type boundaries

### DIFF
--- a/docs/st09089-cli-json-utility-type-boundaries.md
+++ b/docs/st09089-cli-json-utility-type-boundaries.md
@@ -1,0 +1,31 @@
+# ST-09089: Harden CLI JSON Utility Type Boundaries
+
+## Summary
+
+The CLI filesystem helpers exposed `any` at both JSON write and read boundaries. This allowed callers to pass values outside the JSON data model and made untyped reads silently default to an unsafe type.
+
+## Implementation
+
+- Added exported `JsonPrimitive`, `JsonObject`, and recursive `JsonValue` types to `packages/cli/src/utils/fs.ts`.
+- Changed `writeJson(...)` to accept JSON-safe values.
+- Changed `readJson<T = unknown>(...)` to use an unknown-first generic default while preserving explicit typed reads.
+- Updated the CLI project manifest model to declare its JSON object boundary explicitly.
+- Kept the existing `fs-extra` delegation, formatting option, encoding behavior, and error propagation unchanged.
+- Added focused utility coverage for nested JSON round trips, generic output, malformed JSON, and read/write filesystem failures.
+
+## Test Strategy
+
+Focused tests were added before the production contract change. The runtime tests exercise the existing `fs-extra` seam and verify that successful values and underlying errors pass through unchanged. The typecheck then validates the new JSON-safe input and unknown-first output contracts across CLI callers.
+
+## Validation
+
+- Red-first focused run: the initial command used a workspace-relative path with the package-local Vitest config and found no test files; the canonical package-relative rerun passed after the tests were added.
+- Focused CLI tests: `pnpm --filter @agentforge/cli test --run tests/utils/fs.test.ts` -> `25` passed tests.
+- CLI typecheck: `pnpm --filter @agentforge/cli typecheck` -> passed.
+- Explicit-`any` baseline: `pnpm lint:explicit-any:baseline` -> passed at `workspace 78/289`, `cli 4/24`; improved from `80/289`, `cli 6/24`.
+
+## Compatibility Notes
+
+- Existing `readJson<SomeType>(...)` calls remain supported.
+- JSON serialization still uses two-space formatting and relies on `fs-extra` for malformed-JSON and filesystem errors.
+- No CI workflow change is required because the existing CLI package test/typecheck commands and workspace explicit-`any` gate cover the changed boundary.

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,7 +3,15 @@ import chalk from 'chalk';
 import { logger } from '../utils/logger.js';
 import { exitWithCommandError } from '../utils/command-errors.js';
 import { promptProjectSetup } from '../utils/prompts.js';
-import { copyTemplate, ensureDir, isEmptyDir, writeJson, readJson, getTemplatePath } from '../utils/fs.js';
+import {
+  copyTemplate,
+  ensureDir,
+  isEmptyDir,
+  writeJson,
+  readJson,
+  getTemplatePath,
+  type JsonValue,
+} from '../utils/fs.js';
 import { installDependencies, getRunCommand, type PackageManager } from '../utils/package-manager.js';
 import { initGitRepository, createInitialCommit, isGitInstalled } from '../utils/git.js';
 
@@ -15,6 +23,7 @@ interface CreateOptions {
 }
 
 interface ProjectPackageJson {
+  [key: string]: JsonValue | undefined;
   name?: string;
   author?: string;
   description?: string;

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -7,6 +7,11 @@ import { glob } from 'glob';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+// Optional object properties are omitted by JSON serialization.
+export type JsonObject = { [key: string]: JsonValue | undefined };
+
 export async function ensureDir(dir: string): Promise<void> {
   await fs.ensureDir(dir);
 }
@@ -50,11 +55,11 @@ export async function copyTemplate(
   }
 }
 
-export async function writeJson(filePath: string, data: any): Promise<void> {
+export async function writeJson(filePath: string, data: JsonValue): Promise<void> {
   await fs.writeJson(filePath, data, { spaces: 2 });
 }
 
-export async function readJson<T = any>(filePath: string): Promise<T> {
+export async function readJson<T = unknown>(filePath: string): Promise<T> {
   return fs.readJson(filePath);
 }
 
@@ -96,4 +101,3 @@ export async function isEmptyDir(dir: string): Promise<boolean> {
   const files = await fs.readdir(dir);
   return files.length === 0;
 }
-

--- a/packages/cli/tests/utils/fs.test.ts
+++ b/packages/cli/tests/utils/fs.test.ts
@@ -11,6 +11,7 @@ import {
   findFiles,
   readFile,
   writeFile,
+  type JsonValue,
 } from '../../src/utils/fs.js';
 import fs from 'fs-extra';
 import path from 'path';
@@ -42,6 +43,31 @@ describe('File System Utils', () => {
 
       expect(fs.writeJson).toHaveBeenCalledWith('/test/package.json', data, { spaces: 2 });
     });
+
+    it('supports JSON-safe nested values for round trips', async () => {
+      const data: JsonValue = {
+        name: 'test',
+        enabled: true,
+        tags: ['cli', 'json'],
+        metadata: { count: 2, optional: null },
+      };
+      vi.mocked(fs.writeJson).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.readJson).mockResolvedValueOnce(data);
+
+      await writeJson('/test/config.json', data);
+      const result = await readJson<JsonValue>('/test/config.json');
+
+      expect(result).toEqual(data);
+      expect(fs.writeJson).toHaveBeenCalledWith('/test/config.json', data, { spaces: 2 });
+      expect(fs.readJson).toHaveBeenCalledWith('/test/config.json');
+    });
+
+    it('propagates filesystem write failures', async () => {
+      const error = new Error('permission denied');
+      vi.mocked(fs.writeJson).mockRejectedValueOnce(error);
+
+      await expect(writeJson('/test/config.json', { name: 'test' })).rejects.toBe(error);
+    });
   });
 
   describe('readJson', () => {
@@ -66,6 +92,20 @@ describe('File System Utils', () => {
       const result = await readJson<PackageJson>('/test/package.json');
       expect(result.name).toBe('test');
       expect(result.version).toBe('1.0.0');
+    });
+
+    it('propagates malformed JSON errors', async () => {
+      const error = new SyntaxError('Unexpected token');
+      vi.mocked(fs.readJson).mockRejectedValueOnce(error);
+
+      await expect(readJson('/test/malformed.json')).rejects.toBe(error);
+    });
+
+    it('propagates filesystem read failures', async () => {
+      const error = new Error('file not found');
+      vi.mocked(fs.readJson).mockRejectedValueOnce(error);
+
+      await expect(readJson('/test/missing.json')).rejects.toBe(error);
     });
   });
 
@@ -251,4 +291,3 @@ describe('File System Utils', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3752,13 +3752,27 @@ Implementation notes:
 **Branch:** `refactor/st-09089-cli-json-utility-type-boundaries`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09089-cli-json-utility-type-boundaries`
-- [ ] Define focused tests for JSON round trips, malformed JSON, generic output usage, and filesystem failures
-- [ ] Replace explicit `any` contracts in `packages/cli/src/utils/fs.ts` with JSON-safe input and unknown-first generic output
-- [ ] Preserve current encoding defaults, error propagation, and public helper behavior
-- [ ] Record explicit-`any` warning deltas in story documentation
-- [ ] Add or update story documentation at `docs/st09089-cli-json-utility-type-boundaries.md`
-- [ ] Run CLI tests, typecheck, lint, and the explicit-any baseline gate
+- [x] Create branch `refactor/st-09089-cli-json-utility-type-boundaries`
+- [x] Define focused tests for JSON round trips, malformed JSON, generic output usage, and filesystem failures
+  - Added round-trip, malformed JSON, generic output, and read/write failure coverage in `packages/cli/tests/utils/fs.test.ts`.
+- [x] Replace explicit `any` contracts in `packages/cli/src/utils/fs.ts` with JSON-safe input and unknown-first generic output
+  - Added exported recursive JSON types, `writeJson(..., data: JsonValue)`, and `readJson<T = unknown>(...)`; updated the project manifest model to satisfy the JSON object boundary.
+- [x] Preserve current encoding defaults, error propagation, and public helper behavior
+  - Retained `fs-extra` delegation and `{ spaces: 2 }` formatting; focused tests verify value and error propagation.
+- [x] Record explicit-`any` warning deltas in story documentation
+  - Recorded in `docs/st09089-cli-json-utility-type-boundaries.md`; baseline improved from `workspace 80/289`, `cli 6/24` to `workspace 78/289`, `cli 4/24`.
+- [x] Add or update story documentation at `docs/st09089-cli-json-utility-type-boundaries.md`
+- [x] Assess CI impact
+  - No CI workflow change required; existing CLI package validation and workspace explicit-`any` baseline coverage are sufficient.
+- [x] Run CLI tests, typecheck, lint, and the explicit-any baseline gate
+  - `pnpm --filter @agentforge/cli test --run` -> `21` files passed, `196` tests passed
+  - `pnpm --filter @agentforge/cli typecheck` -> passed
+  - `pnpm --filter @agentforge/cli lint` -> passed
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 78/289`, `cli 4/24`
+- [x] Run the full test suite and workspace lint before finalizing the PR
+  - `pnpm test --run` -> `227` files passed, `9` skipped; `2542` tests passed, `110` skipped
+  - `pnpm lint` -> passed with existing warning-only baseline and `0` errors
+  - `git diff --check` -> passed
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3773,8 +3773,10 @@ Implementation notes:
   - `pnpm test --run` -> `227` files passed, `9` skipped; `2542` tests passed, `110` skipped
   - `pnpm lint` -> passed with existing warning-only baseline and `0` errors
   - `git diff --check` -> passed
-- [ ] Commit completed checklist items and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items and push updates
+  - Implementation commit `c6d4ad91` is pushed to `origin/refactor/st-09089-cli-json-utility-type-boundaries`; tracker synchronization follows in the review-state commit.
+- [x] Mark the PR Ready only after all story tasks are complete
+  - Draft PR #166 was created with a validated body and will be marked ready after the review-state tracker sync is pushed.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3776,7 +3776,7 @@ Implementation notes:
 - [x] Commit completed checklist items and push updates
   - Implementation commit `c6d4ad91` is pushed to `origin/refactor/st-09089-cli-json-utility-type-boundaries`; tracker synchronization follows in the review-state commit.
 - [x] Mark the PR Ready only after all story tasks are complete
-  - Draft PR #166 was created with a validated body and will be marked ready after the review-state tracker sync is pushed.
+  - PR #166 was marked ready for review after the validated body and review-state tracker sync were pushed.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2394,7 +2394,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] Replace the explicit `any` contracts in `packages/cli/src/utils/fs.ts` with JSON-safe input and unknown-first generic output while preserving current public helper behavior.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2394,7 +2394,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review (PR #166)
 
 **Acceptance criteria:**
 - [ ] Replace the explicit `any` contracts in `packages/cli/src/utils/fs.ts` with JSON-safe input and unknown-first generic output while preserving current public helper behavior.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-07-27
-**Active Story:** No EP-09 story active; `ST-09089` and `ST-09091` are queued backlog follow-ons while `ST-11006` remains the next Ready story
+**Last Updated:** 2026-07-31
+**Active Story:** ST-09089 (In Progress)
 
 ---
 
@@ -141,6 +141,7 @@ Recent improvement snapshot:
 ---
 
 - `ST-09089` and `ST-09091` were added on 2026-07-27 as small follow-on type-boundary slices covering CLI JSON helpers and the directory-list result model; `ST-09091` depends on the merged filesystem-confinement work in `ST-11003`.
+- `ST-09089` moved to In Progress on 2026-07-31 as the next dependency-ready EP-09 type-boundary slice.
 
 ## Scope
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-07-31
-**Active Story:** ST-09089 (In Progress)
+**Active Story:** ST-09089 (In Review, PR #166)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-30
+**Last Updated:** 2026-07-31
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,8 +14,6 @@
 
 ## Ready
 
-- `ST-09089` - Harden CLI JSON Utility Type Boundaries
-  - Depends on: None
 - `ST-09091` - Type Directory Listing Results
   - Depends on: `ST-11003` (merged)
 
@@ -23,7 +21,8 @@
 
 ## In Progress
 
-None currently.
+- `ST-09089` - Harden CLI JSON Utility Type Boundaries
+  - Depends on: None
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -21,14 +21,15 @@
 
 ## In Progress
 
-- `ST-09089` - Harden CLI JSON Utility Type Boundaries
-  - Depends on: None
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09089` - Harden CLI JSON Utility Type Boundaries
+  - Depends on: None
+  - PR: #166
 
 ---
 


### PR DESCRIPTION
## Story

`ST-09089` - Harden CLI JSON Utility Type Boundaries

## What Changed

- Replaced the CLI filesystem helper `any` contracts with exported recursive JSON types.
- Changed `writeJson` to accept JSON-safe values and `readJson` to default to `unknown` while preserving explicit generic usage.
- Updated the CLI project manifest model for the JSON object boundary.
- Added focused coverage for JSON round trips, generic output, malformed JSON, and filesystem failures.
- Added story documentation and recorded the explicit-`any` warning improvement.

## Acceptance Criteria Coverage

- JSON-safe input and unknown-first generic output are implemented in `packages/cli/src/utils/fs.ts`.
- Existing formatting, `fs-extra` delegation, encoding behavior, malformed-JSON errors, and filesystem error propagation are preserved.
- Focused tests cover round trips, malformed JSON, generic output, and read/write failures.
- CLI tests, typecheck, lint, and the explicit-`any` baseline pass without regression; the baseline improves from `80/289` to `78/289`.
- Story documentation is in `docs/st09089-cli-json-utility-type-boundaries.md`.

## Test Strategy

Red-first focused coverage was added at the existing mocked `fs-extra` seam before the production signature change. Runtime tests verify pass-through behavior and errors; package typecheck validates the compile-time JSON boundaries.

## Validation Performed

- `pnpm --filter @agentforge/cli test --run` -> `21` files passed, `196` tests passed
- `pnpm --filter @agentforge/cli typecheck` -> passed
- `pnpm --filter @agentforge/cli lint` -> passed
- `pnpm lint:explicit-any:baseline` -> passed at `workspace 78/289`, `cli 4/24`
- `pnpm test --run` -> `227` files passed, `9` skipped; `2542` tests passed, `110` skipped
- `pnpm lint` -> passed with existing warning-only baseline and `0` errors
- `git diff --check` -> passed

## Status

Ready for review. The tracker transition is committed in `33788b86`.
