### PR TITLE
ST-09091: Type directory listing results

### DIFF
--- a/docs/st09091-directory-list-result-typing.md
+++ b/docs/st09091-directory-list-result-typing.md
@@ -1,0 +1,29 @@
+# ST-09091: Type Directory Listing Results
+
+## Summary
+
+The directory-list tool returned an unstructured `any[]` for its entries, forcing consumers to infer fields and weakening the public filesystem boundary. This story gives the result a stable exported model without changing traversal or serialization behavior.
+
+## Implementation
+
+- Added exported `DirectoryListEntry` and `DirectoryListResult` interfaces in `packages/tools/src/file/directory/types.ts`.
+- Replaced the recursive helper's `Promise<any[]>` and local `any[]` contracts with `DirectoryListEntry[]`.
+- Kept detail metadata optional because `fullPath`, `size`, and `modified` are emitted only when `includeDetails` is enabled.
+- Preserved recursive traversal, extension filtering, relative paths, counts, `lstat` detail lookup, and filesystem-policy resolution.
+- Added focused coverage for empty, flat, recursive, filtered, detailed, and policy-constrained listings plus consumer-facing model assignability.
+
+## Test Strategy
+
+The focused suite was added before the production type change and passed against the existing runtime. This confirms the requested behavior before tightening the compile-time contract; tools typecheck then verifies that the exported model and implementation agree.
+
+## Validation
+
+- Focused tools tests: `pnpm --filter @agentforge/tools test --run tests/file/directory-list.test.ts` -> `6` passed tests before and after the type change.
+- Tools typecheck: `pnpm --filter @agentforge/tools typecheck` -> passed.
+- Explicit-`any` baseline: `pnpm lint:explicit-any:baseline` -> passed at `workspace 76/289`, `tools 51/67`; improved from `workspace 78/289`, `tools 53/67`.
+
+## Compatibility Notes
+
+- Public fields and serialized output remain unchanged.
+- Detail-only fields remain optional in the shared entry model to represent both default and detailed results.
+- No CI workflow change is required because existing tools package validation and workspace explicit-`any` checks cover the changed boundary.

--- a/packages/tools/src/file/directory/tools/directory-list.ts
+++ b/packages/tools/src/file/directory/tools/directory-list.ts
@@ -3,7 +3,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { directoryListSchema } from '../types.js';
+import { directoryListSchema, type DirectoryListEntry, type DirectoryListResult } from '../types.js';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { DEFAULT_FILE_SYSTEM_POLICY, type FileSystemPolicy } from '../../confinement.js';
@@ -25,9 +25,9 @@ export function createDirectoryListTool(
     .implementSafe(async (input) => {
       const safePath = await policy.resolvePath(input.path, 'directory listing');
       const includeDetails = input.includeDetails ?? defaultIncludeDetails;
-      const listFiles = async (dir: string, recursive: boolean): Promise<any[]> => {
+      const listFiles = async (dir: string, recursive: boolean): Promise<DirectoryListEntry[]> => {
         const entries = await fs.readdir(dir, { withFileTypes: true });
-        const files: any[] = [];
+        const files: DirectoryListEntry[] = [];
 
         for (const entry of entries) {
           const fullPath = path.join(dir, entry.name);
@@ -73,11 +73,13 @@ export function createDirectoryListTool(
       const recursive = input.recursive ?? defaultRecursive;
       const files = await listFiles(safePath, recursive);
 
-      return {
+      const result: DirectoryListResult = {
         path: input.path,
         files,
         count: files.length,
       };
+
+      return result;
     })
     .build();
 }

--- a/packages/tools/src/file/directory/types.ts
+++ b/packages/tools/src/file/directory/types.ts
@@ -18,6 +18,29 @@ export const directoryListSchema = z.object({
 });
 
 /**
+ * A single entry returned by the directory-list tool.
+ * Detail fields are present only when includeDetails is enabled.
+ */
+export interface DirectoryListEntry {
+  name: string;
+  path: string;
+  isFile: boolean;
+  isDirectory: boolean;
+  fullPath?: string;
+  size?: number;
+  modified?: string;
+}
+
+/**
+ * Stable result shape returned by the directory-list tool.
+ */
+export interface DirectoryListResult {
+  path: string;
+  files: DirectoryListEntry[];
+  count: number;
+}
+
+/**
  * Directory create schema
  */
 export const directoryCreateSchema = z.object({

--- a/packages/tools/tests/file/directory-list.test.ts
+++ b/packages/tools/tests/file/directory-list.test.ts
@@ -1,0 +1,125 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createDirectoryListTool,
+  createFileSystemPolicy,
+  type DirectoryListEntry,
+  type DirectoryListResult,
+} from '../../src/file/index.js';
+
+describe('directory-list result model', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'agentforge-directory-list-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('returns an empty typed result for an empty directory', async () => {
+    const directoryList = createDirectoryListTool();
+
+    const result = await directoryList.invoke({ path: workspaceRoot });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { path: workspaceRoot, files: [], count: 0 },
+    });
+  });
+
+  it('lists flat files and directories with the stable common fields', async () => {
+    await writeFile(join(workspaceRoot, 'readme.md'), '# AgentForge');
+    await mkdir(join(workspaceRoot, 'src'));
+    const directoryList = createDirectoryListTool();
+
+    const result = await directoryList.invoke({ path: workspaceRoot });
+
+    expect(result).toMatchObject({ success: true });
+    expect(result.data?.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'readme.md',
+        path: 'readme.md',
+        isFile: true,
+        isDirectory: false,
+      }),
+      expect.objectContaining({
+        name: 'src',
+        path: 'src',
+        isFile: false,
+        isDirectory: true,
+      }),
+    ]));
+  });
+
+  it('lists nested files recursively and filters file extensions', async () => {
+    await mkdir(join(workspaceRoot, 'nested'));
+    await writeFile(join(workspaceRoot, 'root.ts'), 'export {}');
+    await writeFile(join(workspaceRoot, 'root.md'), '# Root');
+    await writeFile(join(workspaceRoot, 'nested', 'child.ts'), 'export {}');
+    await writeFile(join(workspaceRoot, 'nested', 'child.md'), '# Child');
+    const directoryList = createDirectoryListTool(true);
+
+    const result = await directoryList.invoke({
+      path: workspaceRoot,
+      recursive: true,
+      extension: '.ts',
+    });
+
+    expect(result).toMatchObject({ success: true });
+    const names = result.data?.files.map((file) => file.name);
+    expect(names).toEqual(expect.arrayContaining(['root.ts', 'nested', 'child.ts']));
+    expect(names).not.toContain('root.md');
+    expect(names).not.toContain('child.md');
+  });
+
+  it('includes detail metadata when requested', async () => {
+    const filePath = join(workspaceRoot, 'data.json');
+    await writeFile(filePath, '{}');
+    const directoryList = createDirectoryListTool(false, true);
+
+    const result = await directoryList.invoke({ path: workspaceRoot, includeDetails: true });
+
+    expect(result).toMatchObject({ success: true });
+    expect(result.data?.files).toEqual([
+      expect.objectContaining({
+        name: 'data.json',
+        fullPath: filePath,
+        size: 2,
+        modified: expect.any(String),
+      }),
+    ]);
+  });
+
+  it('preserves filesystem policy enforcement for typed results', async () => {
+    const directoryList = createDirectoryListTool(false, false, createFileSystemPolicy({
+      allowedRoots: [workspaceRoot],
+    }));
+
+    const result = await directoryList.invoke({ path: join(workspaceRoot, '..') });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+  });
+
+  it('exposes assignable entry and result models for consumers', () => {
+    const entry: DirectoryListEntry = {
+      name: 'README.md',
+      path: 'README.md',
+      isFile: true,
+      isDirectory: false,
+    };
+    const result: DirectoryListResult = {
+      path: '/workspace',
+      files: [entry],
+      count: 1,
+    };
+
+    expect(result.files[0]).toBe(entry);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3811,5 +3811,5 @@ Implementation notes:
 - [x] Commit completed checklist items and push updates
   - Implementation commit `05450805` is pushed to `origin/refactor/st-09091-directory-list-result-typing`; review-state synchronization follows in the tracker commit.
 - [x] Mark the PR Ready only after all story tasks are complete
-  - Draft PR #167 was created with a validated body and will be marked ready after the review-state tracker synchronization is pushed.
+  - PR #167 was marked ready for review after the validated body and review-state tracker synchronization were pushed.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3808,6 +3808,8 @@ Implementation notes:
   - `pnpm test --run` -> `228` files passed, `9` skipped; `2548` tests passed, `110` skipped
   - `pnpm lint` -> passed with existing warning-only baseline and `0` errors
   - `git diff --check` -> passed
-- [ ] Commit completed checklist items and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items and push updates
+  - Implementation commit `05450805` is pushed to `origin/refactor/st-09091-directory-list-result-typing`; review-state synchronization follows in the tracker commit.
+- [x] Mark the PR Ready only after all story tasks are complete
+  - Draft PR #167 was created with a validated body and will be marked ready after the review-state tracker synchronization is pushed.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3787,13 +3787,27 @@ Implementation notes:
 **Branch:** `refactor/st-09091-directory-list-result-typing`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09091-directory-list-result-typing`
-- [ ] Define focused type and runtime tests for empty, flat, nested, filtered, and detailed listings
-- [ ] Replace `Promise<any[]>` and `any[]` contracts in the directory-list tool with an exported result model
-- [ ] Preserve filesystem-policy enforcement and existing output serialization
-- [ ] Record explicit-`any` warning deltas in story documentation
-- [ ] Add or update story documentation at `docs/st09091-directory-list-result-typing.md`
-- [ ] Run tools tests, typecheck, lint, and the explicit-any baseline gate
+- [x] Create branch `refactor/st-09091-directory-list-result-typing`
+- [x] Define focused type and runtime tests for empty, flat, nested, filtered, and detailed listings
+  - Added `packages/tools/tests/file/directory-list.test.ts` with six runtime/type-boundary tests, including filesystem-policy enforcement.
+- [x] Replace `Promise<any[]>` and `any[]` contracts in the directory-list tool with an exported result model
+  - Added exported `DirectoryListEntry` and `DirectoryListResult` models and typed the recursive listing helper and result.
+- [x] Preserve filesystem-policy enforcement and existing output serialization
+  - Retained policy resolution, recursive traversal, extension filtering, detail metadata, relative paths, and count behavior.
+- [x] Record explicit-`any` warning deltas in story documentation
+  - Recorded in `docs/st09091-directory-list-result-typing.md`; baseline improved from `workspace 78/289`, `tools 53/67` to `workspace 76/289`, `tools 51/67`.
+- [x] Add or update story documentation at `docs/st09091-directory-list-result-typing.md`
+- [x] Assess CI impact
+  - No CI workflow change required; existing tools package validation and workspace explicit-`any` checks cover the changed boundary.
+- [x] Run tools tests, typecheck, lint, and the explicit-any baseline gate
+  - `pnpm --filter @agentforge/tools test --run` -> `92` files passed, `9` skipped; `1163` tests passed, `110` skipped
+  - `pnpm --filter @agentforge/tools typecheck` -> passed
+  - `pnpm --filter @agentforge/tools lint` -> passed with existing warning-only baseline and `0` errors
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 76/289`, `tools 51/67`
+- [x] Run the full test suite and workspace lint before finalizing the PR
+  - `pnpm test --run` -> `228` files passed, `9` skipped; `2548` tests passed, `110` skipped
+  - `pnpm lint` -> passed with existing warning-only baseline and `0` errors
+  - `git diff --check` -> passed
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2411,7 +2411,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-11003 (merged)
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] Replace the `Promise<any[]>` and `any[]` directory-list result contracts with an exported typed result model while preserving existing fields and serialization.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2411,7 +2411,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-11003 (merged)
-**Status:** In Progress
+**Status:** In Review (PR #167)
 
 **Acceptance criteria:**
 - [ ] Replace the `Promise<any[]>` and `any[]` directory-list result contracts with an exported typed result model while preserving existing fields and serialization.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-08-02
-**Active Story:** ST-09091 (In Progress)
+**Active Story:** ST-09091 (In Review, PR #167)
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-07-31
-**Active Story:** ST-09091 (Ready)
+**Last Updated:** 2026-08-02
+**Active Story:** ST-09091 (In Progress)
 
 ---
 
@@ -143,6 +143,7 @@ Recent improvement snapshot:
 - `ST-09089` and `ST-09091` were added on 2026-07-27 as small follow-on type-boundary slices covering CLI JSON helpers and the directory-list result model; `ST-09091` depends on the merged filesystem-confinement work in `ST-11003`.
 - `ST-09089` moved to In Progress on 2026-07-31 as the next dependency-ready EP-09 type-boundary slice.
 - `ST-09089` merged on 2026-07-31 as PR #166 after tightening CLI JSON utility boundaries and improving the explicit-`any` baseline; `ST-09091` is now the next Ready story.
+- `ST-09091` moved to In Progress on 2026-08-02 as the next dependency-ready EP-09 type-boundary slice.
 
 ## Scope
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-07-31
+**Last Updated:** 2026-08-02
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,14 +14,14 @@
 
 ## Ready
 
-- `ST-09091` - Type Directory Listing Results
-  - Depends on: `ST-11003` (merged)
+None currently.
 
 ---
 
 ## In Progress
 
-None currently.
+- `ST-09091` - Type Directory Listing Results
+  - Depends on: `ST-11003` (merged)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,14 +20,15 @@ None currently.
 
 ## In Progress
 
-- `ST-09091` - Type Directory Listing Results
-  - Depends on: `ST-11003` (merged)
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09091` - Type Directory Listing Results
+  - Depends on: `ST-11003` (merged)
+  - PR: #167
 
 ---
 


### PR DESCRIPTION
## Story

`ST-09091` - Type Directory Listing Results

## What Changed

- Added exported `DirectoryListEntry` and `DirectoryListResult` models for the directory-list tool.
- Replaced the recursive helper's `Promise<any[]>` and local `any[]` contracts with the typed entry model.
- Preserved recursive traversal, extension filtering, detail metadata, relative paths, count behavior, and filesystem-policy enforcement.
- Added focused tests for empty, flat, nested, filtered, detailed, and policy-constrained listings plus consumer model assignability.
- Added story documentation and recorded the explicit-`any` baseline improvement.

## Acceptance Criteria Coverage

- The directory-list tool now exposes a stable typed result model through the public directory types.
- Existing fields and serialization remain unchanged; detail-only fields are optional and remain emitted only when requested.
- Focused runtime and type-boundary tests cover all requested listing modes and policy enforcement.
- Tools tests, typecheck, lint, and the explicit-`any` baseline pass without regression; the baseline improves from `78/289` to `76/289`.
- Story documentation is in `docs/st09091-directory-list-result-typing.md`.

## Test Strategy

The focused suite was added before the production type change and passed against the existing runtime. The implementation then replaced only the compile-time contracts, with tools typecheck validating the exported model and recursive helper agreement.

## Validation Performed

- `pnpm --filter @agentforge/tools test --run tests/file/directory-list.test.ts` -> `6` passed tests
- `pnpm --filter @agentforge/tools test --run` -> `92` files passed, `9` skipped; `1163` tests passed, `110` skipped
- `pnpm --filter @agentforge/tools typecheck` -> passed
- `pnpm --filter @agentforge/tools lint` -> passed with existing warning-only baseline and `0` errors
- `pnpm lint:explicit-any:baseline` -> passed at `workspace 76/289`, `tools 51/67`
- `pnpm test --run` -> `228` files passed, `9` skipped; `2548` tests passed, `110` skipped
- `pnpm lint` -> passed with existing warning-only baseline and `0` errors
- `git diff --check` -> passed

## Status

Ready for review. The tracker transition is committed in `d3d02819`.
