### PR TITLE
refactor: harden core generic wrapper contracts (ST-09092)

### DIFF
--- a/docs/st09092-core-generic-wrapper-contracts.md
+++ b/docs/st09092-core-generic-wrapper-contracts.md
@@ -1,0 +1,28 @@
+# ST-09092: Harden Core Generic Wrapper Contracts
+
+## Summary
+
+The profiler and circuit-breaker wrappers used `TArgs extends any[]`, leaving generic callback argument boundaries broader than necessary. This story replaces those tuple bounds with unknown-first generics while preserving callback inference and runtime behavior.
+
+## Implementation
+
+- Changed `Profiler.profile(...)` from `TArgs extends any[]` to `TArgs extends unknown[]`.
+- Changed `CircuitBreaker.wrap(...)` from `TArgs extends any[]` to `TArgs extends unknown[]`.
+- Added focused type and runtime coverage for inferred multi-argument callbacks, successful calls, and propagated failures.
+
+## Test Strategy
+
+The focused profiler and circuit-breaker tests were added before the production type change and passed against the existing runtime. The same suite was rerun after the type-only implementation change to verify inference and behavior remained stable.
+
+## Validation
+
+- Focused tests: `pnpm --filter @agentforge/core exec vitest run tests/monitoring/profiler.test.ts tests/resources/circuit-breaker.test.ts` -> `4` passed before and after the implementation change.
+- Core package tests: `pnpm --filter @agentforge/core test --run` -> `67` files and `648` tests passed.
+- Core typecheck: `pnpm --filter @agentforge/core typecheck` -> passed.
+- Explicit-`any` baseline: `pnpm lint:explicit-any:baseline` -> passed at `workspace 74/289`, `core 17/119`; improved from `workspace 76/289`, `core 19/119`.
+
+## Compatibility Notes
+
+- Callback argument and return inference remains unchanged for existing callers.
+- Profiler sampling, report recording, error propagation, and circuit-breaker state transitions were not modified.
+- No CI workflow change is required because existing package, workspace, and explicit-`any` validation covers the changed contracts.

--- a/packages/core/src/monitoring/profiler.ts
+++ b/packages/core/src/monitoring/profiler.ts
@@ -58,7 +58,7 @@ export class Profiler {
     this.maxSamples = options.maxSamples ?? 1000;
   }
 
-  profile<TArgs extends any[], TReturn>(
+  profile<TArgs extends unknown[], TReturn>(
     name: string,
     fn: (...args: TArgs) => Promise<TReturn>
   ): (...args: TArgs) => Promise<TReturn> {
@@ -198,4 +198,3 @@ export class Profiler {
 export function createProfiler(options?: ProfilerOptions): Profiler {
   return new Profiler(options);
 }
-

--- a/packages/core/src/resources/circuit-breaker.ts
+++ b/packages/core/src/resources/circuit-breaker.ts
@@ -70,7 +70,7 @@ export class CircuitBreaker {
     }
   }
 
-  wrap<TArgs extends any[], TReturn>(
+  wrap<TArgs extends unknown[], TReturn>(
     fn: (...args: TArgs) => Promise<TReturn>
   ): (...args: TArgs) => Promise<TReturn> {
     return async (...args: TArgs) => {
@@ -191,4 +191,3 @@ export class CircuitBreaker {
 export function createCircuitBreaker(options: CircuitBreakerOptions): CircuitBreaker {
   return new CircuitBreaker(options);
 }
-

--- a/packages/core/tests/monitoring/profiler.test.ts
+++ b/packages/core/tests/monitoring/profiler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { Profiler } from '../../src/monitoring/profiler.js';
+
+describe('Profiler', () => {
+  it('preserves wrapped function argument and return inference', async () => {
+    const profiler = new Profiler({ enabled: false });
+    const wrapped = profiler.profile('format', async (count: number, label: string) => `${label}:${count}`);
+
+    expectTypeOf(wrapped).toEqualTypeOf<(count: number, label: string) => Promise<string>>();
+    await expect(wrapped(3, 'items')).resolves.toBe('items:3');
+  });
+
+  it('records successful and failed wrapped calls', async () => {
+    const profiler = new Profiler();
+    const succeeds = profiler.profile('success', async (value: number) => value * 2);
+    const fails = profiler.profile('failure', async () => {
+      throw new Error('failed');
+    });
+
+    await expect(succeeds(4)).resolves.toBe(8);
+    await expect(fails()).rejects.toThrow('failed');
+
+    const report = profiler.getReport();
+    expect(report.success.calls).toBe(1);
+    expect(report.failure.calls).toBe(1);
+  });
+});

--- a/packages/core/tests/resources/circuit-breaker.test.ts
+++ b/packages/core/tests/resources/circuit-breaker.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { CircuitBreaker } from '../../src/resources/circuit-breaker.js';
+
+describe('CircuitBreaker', () => {
+  it('preserves wrapped function argument and return inference', async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 2, resetTimeout: 1000 });
+    const wrapped = breaker.wrap(async (id: number, prefix: string) => `${prefix}:${id}`);
+
+    expectTypeOf(wrapped).toEqualTypeOf<(id: number, prefix: string) => Promise<string>>();
+    await expect(wrapped(7, 'job')).resolves.toBe('job:7');
+  });
+
+  it('records success and rethrows failures through the circuit', async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 2, resetTimeout: 1000 });
+    const succeeds = breaker.wrap(async () => 'ok');
+    const fails = breaker.wrap(async () => {
+      throw new Error('failed');
+    });
+
+    await expect(succeeds()).resolves.toBe('ok');
+    await expect(fails()).rejects.toThrow('failed');
+
+    expect(breaker.getStats()).toMatchObject({
+      successes: 1,
+      failures: 1,
+      totalCalls: 2,
+    });
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3822,13 +3822,21 @@ Implementation notes:
 **Branch:** `refactor/st-09092-core-generic-wrapper-contracts`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09092-core-generic-wrapper-contracts` from `main`
-- [ ] Inspect and type the profiler and circuit-breaker wrapper argument tuples with unknown-first generics
-- [ ] Preserve callback inference, invocation, profiling, retry, and circuit-state behavior
-- [ ] Add focused runtime and type-boundary coverage for zero-argument, multi-argument, async, thrown-error, and rejected-promise callbacks
-- [ ] Record explicit-`any` warning deltas in story documentation
-- [ ] Add or update story documentation at `docs/st09092-core-generic-wrapper-contracts.md`
-- [ ] Run core tests, typecheck, lint, and the explicit-any baseline gate
+- [x] Create branch `refactor/st-09092-core-generic-wrapper-contracts` from `main`
+- [x] Inspect and type the profiler and circuit-breaker wrapper argument tuples with unknown-first generics
+- [x] Preserve callback inference, invocation, profiling, retry, and circuit-state behavior
+- [x] Add focused runtime and type-boundary coverage for zero-argument, multi-argument, async, thrown-error, and rejected-promise callbacks
+  - Test-first coverage was added before the production type change; the focused suite covers inferred multi-argument callbacks, successful calls, and propagated failures.
+- [x] Record explicit-`any` warning deltas in story documentation
+  - Baseline improved from `workspace 76/289`, `core 19/119` to `workspace 74/289`, `core 17/119`.
+- [x] Add or update story documentation at `docs/st09092-core-generic-wrapper-contracts.md`
+- [x] Assess CI impact
+  - No CI workflow change is required; existing package, workspace, and explicit-`any` validation covers the changed contracts.
+- [x] Run core tests, typecheck, lint, and the explicit-any baseline gate
+  - Focused tests -> `4` passed before and after implementation.
+  - `pnpm --filter @agentforge/core test --run` -> `67` files, `648` tests passed.
+  - `pnpm --filter @agentforge/core typecheck` -> passed.
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 74/289`, `core 17/119`.
 - [ ] Run the full test suite and workspace lint before finalizing the PR
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3837,9 +3837,15 @@ Implementation notes:
   - `pnpm --filter @agentforge/core test --run` -> `67` files, `648` tests passed.
   - `pnpm --filter @agentforge/core typecheck` -> passed.
   - `pnpm lint:explicit-any:baseline` -> passed at `workspace 74/289`, `core 17/119`.
-- [ ] Run the full test suite and workspace lint before finalizing the PR
-- [ ] Commit completed checklist items and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Run the full test suite and workspace lint before finalizing the PR
+  - `pnpm test --run` -> `230` files passed, `9` skipped; `2552` tests passed, `110` skipped.
+  - `pnpm lint` -> passed with existing warning-only baseline and `0` errors.
+  - `pnpm typecheck` -> passed for all 6 workspace packages.
+  - `git diff --check` -> passed.
+- [x] Commit completed checklist items and push updates
+  - Implementation commit `3d4d2c03` pushed to `origin/refactor/st-09092-core-generic-wrapper-contracts`; draft PR #168 opened.
+- [x] Mark the PR Ready only after all story tasks are complete
+  - Final self-review found no correctness, security, or scope issues; PR #168 is ready for review.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2428,7 +2428,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] Replace the `any[]` generic argument seams in `packages/core/src/monitoring/profiler.ts` and `packages/core/src/resources/circuit-breaker.ts` with unknown-first tuple contracts while preserving inference for wrapped functions.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-08-02
-**Active Story:** No EP-09 story active; ST-09092 through ST-09094 are queued in Backlog.
+**Active Story:** ST-09092 (In Progress)
 
 ---
 
@@ -146,6 +146,7 @@ Recent improvement snapshot:
 - `ST-09091` moved to In Progress on 2026-08-02 as the next dependency-ready EP-09 type-boundary slice.
 - `ST-09091` merged on 2026-08-02 as PR #167 after typing directory-list results and adding focused listing coverage; the prior accepted queue was empty before the next grooming batch.
 - `ST-09092` through `ST-09094` were added on 2026-08-02 as independent, low-risk type-boundary slices covering core generic wrappers, core metadata maps, and Neo4j property/query payloads.
+- `ST-09092` moved to In Progress on 2026-08-03 as the next deterministic EP-09 type-boundary slice.
 
 ## Scope
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,7 +2,7 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-08-02
+**Last Updated:** 2026-08-03
 **Active Story:** ST-09092 (In Progress)
 
 ---

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,10 +5,10 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
-- **Backlog:** 4 stories
+- **Backlog:** 3 stories
 
 ---
 
@@ -20,7 +20,7 @@ None currently.
 
 ## In Progress
 
-None currently.
+- `ST-09092` — Harden Core Generic Wrapper Contracts
 
 ---
 
@@ -38,7 +38,6 @@ _No stories currently blocked_
 
 ## Backlog
 
-- `ST-09092` — Harden Core Generic Wrapper Contracts (P2, 2h, independent)
 - `ST-09093` — Harden Thread and LangSmith Metadata Contracts (P2, 2h, independent)
 - `ST-09094` — Harden Neo4j Property and Query Payload Contracts (P2, 3h, independent)
 - `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance (P2, 2h, depends on merged ST-11003 and ST-11007)
@@ -64,6 +63,7 @@ _No stories currently blocked_
 - ST-09091 merged on 2026-08-02 as PR #167 / commit `11ed07e6`; removed from the active queue and archived as done before the next EP-09 grooming batch
 - ST-09092, ST-09093, and ST-09094 added to Backlog on 2026-08-02 after source review identified three independent, low-risk EP-09 type-boundary improvements across core wrappers, metadata maps, and Neo4j payloads
 - ST-11009 added to Backlog on 2026-08-02 after source review found model-facing skill examples still wire unrestricted file tools despite the merged model-safe preset
+- ST-09092 moved to In Progress on 2026-08-03 as the next deterministic EP-09 story; the remaining EP-09 and EP-11 follow-ons remain in Backlog
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,6 +1,6 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-08-02
+**Last Updated:** 2026-08-03
 
 ## Queue Status Summary
 


### PR DESCRIPTION
## Story

`ST-09092: Harden Core Generic Wrapper Contracts`

## What Changed

- Replaced `TArgs extends any[]` with `TArgs extends unknown[]` in `Profiler.profile(...)` and `CircuitBreaker.wrap(...)`.
- Added focused profiler and circuit-breaker runtime and type-inference tests.
- Added story documentation and updated the EP-09 checklist.

## Acceptance Criteria Coverage

- [x] Core generic wrapper argument tuples use unknown-first contracts.
- [x] Existing callback inference, invocation, profiling, retry, and circuit-state behavior is preserved.
- [x] Focused coverage covers multi-argument inference, zero-argument calls, async success, and propagated failures.
- [x] Explicit-`any` baseline improves without regression.
- [x] Story documentation is present at `docs/st09092-core-generic-wrapper-contracts.md`.

## Test Strategy

Focused automated tests were added before the production type change, run against the existing runtime, and rerun after implementation. The tests use `expectTypeOf` to lock down callback argument and return inference.

## Validation Performed

- Focused tests: `4` passed before and after implementation.
- `pnpm --filter @agentforge/core test --run`: `67` files and `648` tests passed.
- `pnpm --filter @agentforge/core typecheck`: passed.
- `pnpm --filter @agentforge/core lint`: passed with `34` existing warnings and `0` errors.
- `pnpm lint:explicit-any:baseline`: passed; baseline improved from `workspace 76/289`, `core 19/119` to `workspace 74/289`, `core 17/119`.
- No CI workflow change is required.
- `pnpm test --run`: `230` files passed, `9` skipped; `2552` tests passed, `110` skipped.
- `pnpm lint`: passed with existing warning-only baseline and `0` errors.
- `pnpm typecheck`: passed for all 6 workspace packages.
- `git diff --check`: passed.

## Status

Ready for review. Final self-review found no correctness, security, or scope issues.
