### PR TITLE
refactor(st-09093): Harden Thread and LangSmith Metadata Contracts

### DIFF
--- a/docs/st09093-thread-langsmith-metadata-contracts.md
+++ b/docs/st09093-thread-langsmith-metadata-contracts.md
@@ -1,0 +1,23 @@
+# ST-09093: Harden Thread and LangSmith Metadata Contracts
+
+## Summary
+
+Thread persistence and LangSmith observability metadata now use the shared `JsonObject` contract instead of `Record<string, any>`. This keeps metadata unknown-first and JSON-safe at the public boundary while preserving the existing passthrough behavior.
+
+## Implementation
+
+- Reused `JsonObject` for `ThreadConfig`, `ConversationConfig`, `LangSmithConfig`, and `TracingOptions` metadata.
+- Preserved nested values and null-prototype metadata maps without cloning in direct thread and LangSmith configuration paths.
+- Omitted `sessionId` from generated conversation metadata when it is not provided, while preserving explicitly supplied values.
+- Added compile-time coverage rejecting functions, `Date` instances, and other non-JSON metadata values.
+
+## Test Strategy
+
+Focused runtime coverage was added before the production type change and passed against the existing implementation. Compile-time assertions then failed as expected because the original `any` signatures accepted non-JSON values. The production contract change was applied only after that failing typecheck evidence, followed by focused typecheck and runtime validation.
+
+## Compatibility Notes
+
+- Existing JSON-safe metadata remains accepted and is passed through unchanged.
+- Omitted optional metadata and `sessionId` remain omitted rather than becoming `undefined` properties.
+- LangSmith environment configuration and tracing execution behavior are unchanged.
+- No CI workflow change is required because existing package, workspace, typecheck, lint, and explicit-`any` gates cover the changed contracts.

--- a/docs/st09093-thread-langsmith-metadata-contracts.md
+++ b/docs/st09093-thread-langsmith-metadata-contracts.md
@@ -8,7 +8,7 @@ Thread persistence and LangSmith observability metadata now use the shared `Json
 
 - Reused `JsonObject` for `ThreadConfig`, `ConversationConfig`, `LangSmithConfig`, and `TracingOptions` metadata.
 - Preserved nested values and null-prototype metadata maps without cloning in direct thread and LangSmith configuration paths.
-- Omitted `sessionId` from generated conversation metadata when it is not provided, while preserving explicitly supplied values.
+- Omitted empty or absent `sessionId` from generated conversation metadata and used the same non-empty condition for thread ID derivation.
 - Added compile-time coverage rejecting functions, `Date` instances, and other non-JSON metadata values.
 
 ## Test Strategy
@@ -18,6 +18,6 @@ Focused runtime coverage was added before the production type change and passed 
 ## Compatibility Notes
 
 - Existing JSON-safe metadata remains accepted and is passed through unchanged.
-- Omitted optional metadata and `sessionId` remain omitted rather than becoming `undefined` properties.
+- Omitted or empty optional metadata and `sessionId` remain omitted rather than becoming `undefined` properties.
 - LangSmith environment configuration and tracing execution behavior are unchanged.
 - No CI workflow change is required because existing package, workspace, typecheck, lint, and explicit-`any` gates cover the changed contracts.

--- a/packages/core/src/langgraph/observability/langsmith.contracts.typecheck.ts
+++ b/packages/core/src/langgraph/observability/langsmith.contracts.typecheck.ts
@@ -1,0 +1,42 @@
+import type { JsonObject } from './payload.js';
+import {
+  configureLangSmith,
+  type LangSmithConfig,
+  type TracingOptions,
+  withTracing,
+} from './langsmith.js';
+
+const metadata = {
+  request: {
+    id: 'req-1',
+    tags: ['test'],
+  },
+} satisfies JsonObject;
+
+const config: LangSmithConfig = {
+  projectName: 'agentforge',
+  metadata,
+};
+configureLangSmith(config);
+
+const tracingOptions: TracingOptions = {
+  name: 'node',
+  metadata,
+};
+void tracingOptions;
+
+const tracedNode = withTracing((state: { count: number }) => state, tracingOptions);
+void tracedNode;
+
+const invalidConfig: LangSmithConfig = {
+  // @ts-expect-error LangSmith metadata must contain JSON-safe values
+  metadata: { callback: () => 'not-json' },
+};
+void invalidConfig;
+
+const invalidTracingOptions: TracingOptions = {
+  name: 'invalid-node',
+  // @ts-expect-error tracing metadata must contain JSON-safe values
+  metadata: { createdAt: new Date() },
+};
+void invalidTracingOptions;

--- a/packages/core/src/langgraph/observability/langsmith.ts
+++ b/packages/core/src/langgraph/observability/langsmith.ts
@@ -4,6 +4,8 @@
  * Helpers for configuring and using LangSmith tracing with LangGraph.
  */
 
+import type { JsonObject } from './payload.js';
+
 /**
  * LangSmith configuration options
  */
@@ -36,7 +38,7 @@ export interface LangSmithConfig {
   /**
    * Additional metadata to include in all traces
    */
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 }
 
 /**
@@ -124,7 +126,7 @@ export interface TracingOptions {
   /**
    * Additional metadata to include in the trace
    */
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 
   /**
    * Tags to categorize the trace
@@ -179,4 +181,3 @@ export function withTracing<State>(
     return await Promise.resolve(node(state));
   };
 }
-

--- a/packages/core/src/langgraph/persistence/thread.contracts.typecheck.ts
+++ b/packages/core/src/langgraph/persistence/thread.contracts.typecheck.ts
@@ -1,0 +1,39 @@
+import type { JsonObject } from '../observability/payload.js';
+import { createConversationConfig, createThreadConfig } from './thread.js';
+
+const metadata = {
+  profile: {
+    roles: ['maintainer'],
+    active: true,
+  },
+  requestId: 'req-1',
+} satisfies JsonObject;
+
+const threadConfig = createThreadConfig({
+  threadId: 'thread-1',
+  metadata,
+});
+void threadConfig;
+
+const conversationConfig = createConversationConfig({
+  userId: 'user-1',
+  metadata,
+});
+void conversationConfig;
+
+const nullPrototypeMetadata = Object.create(null) as JsonObject;
+nullPrototypeMetadata.source = 'test';
+void createThreadConfig({ metadata: nullPrototypeMetadata });
+
+const invalidThreadMetadata = createThreadConfig({
+  // @ts-expect-error thread metadata must contain JSON-safe values
+  metadata: { callback: () => 'not-json' },
+});
+void invalidThreadMetadata;
+
+const invalidConversationMetadata = createConversationConfig({
+  userId: 'user-1',
+  // @ts-expect-error conversation metadata must contain JSON-safe values
+  metadata: { createdAt: new Date() },
+});
+void invalidConversationMetadata;

--- a/packages/core/src/langgraph/persistence/thread.ts
+++ b/packages/core/src/langgraph/persistence/thread.ts
@@ -154,9 +154,10 @@ export function createThreadConfig(config: Partial<ThreadConfig> = {}): Runnable
  */
 export function createConversationConfig(config: ConversationConfig): RunnableConfig {
   const { userId, sessionId, metadata = {} } = config;
+  const hasSessionId = sessionId !== undefined && sessionId.length > 0;
 
   // Generate thread ID from user and session
-  const threadId = sessionId
+  const threadId = hasSessionId
     ? generateThreadId(`${userId}-${sessionId}`)
     : generateThreadId(userId);
 
@@ -165,7 +166,7 @@ export function createConversationConfig(config: ConversationConfig): RunnableCo
     metadata: {
       ...metadata,
       userId,
-      ...(sessionId === undefined ? {} : { sessionId }),
+      ...(hasSessionId ? { sessionId } : {}),
     },
   });
 }

--- a/packages/core/src/langgraph/persistence/thread.ts
+++ b/packages/core/src/langgraph/persistence/thread.ts
@@ -8,6 +8,7 @@
 
 import { randomUUID } from 'crypto';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { JsonObject } from '../observability/payload.js';
 
 /**
  * Configuration for a thread
@@ -31,7 +32,7 @@ export interface ThreadConfig {
   /**
    * Additional metadata for the thread
    */
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 }
 
 /**
@@ -51,7 +52,7 @@ export interface ConversationConfig {
   /**
    * Additional metadata
    */
-  metadata?: Record<string, any>;
+  metadata?: JsonObject;
 }
 
 /**
@@ -164,8 +165,7 @@ export function createConversationConfig(config: ConversationConfig): RunnableCo
     metadata: {
       ...metadata,
       userId,
-      sessionId,
+      ...(sessionId === undefined ? {} : { sessionId }),
     },
   });
 }
-

--- a/packages/core/tests/langgraph/observability/langsmith.test.ts
+++ b/packages/core/tests/langgraph/observability/langsmith.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { JsonObject } from '../../../src/langgraph/observability/payload.js';
 import {
   configureLangSmith,
   getLangSmithConfig,
@@ -93,6 +94,25 @@ describe('LangSmith Integration', () => {
 
       expect(getLangSmithConfig()).toEqual(config);
     });
+
+    it('should preserve nested JSON metadata and null-prototype maps', () => {
+      const metadata = Object.create(null) as JsonObject;
+      metadata.project = {
+        labels: ['production'],
+        sampling: { rate: 0.5 },
+      };
+
+      configureLangSmith({ metadata });
+
+      expect(getLangSmithConfig()?.metadata).toBe(metadata);
+      expect(Object.getPrototypeOf(getLangSmithConfig()?.metadata)).toBeNull();
+    });
+
+    it('should preserve omitted metadata', () => {
+      configureLangSmith({ projectName: 'test-project' });
+
+      expect(getLangSmithConfig()).toEqual({ projectName: 'test-project' });
+    });
   });
 
   describe('isTracingEnabled', () => {
@@ -130,6 +150,19 @@ describe('LangSmith Integration', () => {
 
       const result = await tracedNode({ count: 0 });
       expect(result.count).toBe(1);
+    });
+
+    it('should accept nested JSON metadata at the tracing boundary', async () => {
+      const node = (state: { count: number }) => ({ count: state.count + 1 });
+
+      const tracedNode = withTracing(node, {
+        name: 'metadata-node',
+        metadata: {
+          request: { id: 'req-1', tags: ['test'] },
+        },
+      });
+
+      await expect(tracedNode({ count: 0 })).resolves.toEqual({ count: 1 });
     });
 
     it('should work with async nodes', async () => {
@@ -172,4 +205,3 @@ describe('LangSmith Integration', () => {
     });
   });
 });
-

--- a/packages/core/tests/langgraph/persistence/thread.test.ts
+++ b/packages/core/tests/langgraph/persistence/thread.test.ts
@@ -161,6 +161,19 @@ describe('Thread Management', () => {
       expect(config2.metadata?.sessionId).toBe('session-2');
     });
 
+    it('should omit empty session IDs from the thread ID and metadata', () => {
+      const emptySessionConfig = createConversationConfig({
+        userId: 'user-123',
+        sessionId: '',
+      });
+      const userOnlyConfig = createConversationConfig({ userId: 'user-123' });
+
+      expect(emptySessionConfig.configurable?.thread_id).toBe(
+        userOnlyConfig.configurable?.thread_id
+      );
+      expect(emptySessionConfig.metadata).not.toHaveProperty('sessionId');
+    });
+
     it('should include additional metadata', () => {
       const config = createConversationConfig({
         userId: 'user-123',
@@ -183,6 +196,7 @@ describe('Thread Management', () => {
         userId: 'user-123',
         nested: { enabled: true, labels: ['one', 'two'] },
       });
+      expect(config.metadata).not.toHaveProperty('sessionId');
     });
 
     it('should merge metadata with user and session info', () => {

--- a/packages/core/tests/langgraph/persistence/thread.test.ts
+++ b/packages/core/tests/langgraph/persistence/thread.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { JsonObject } from '../../../src/langgraph/observability/payload.js';
 import {
   generateThreadId,
   createThreadConfig,
@@ -84,6 +85,34 @@ describe('Thread Management', () => {
       expect(config.metadata).toEqual(metadata);
     });
 
+    it('should preserve nested JSON metadata and null-prototype maps', () => {
+      const metadata = Object.create(null) as JsonObject;
+      metadata.profile = {
+        roles: ['maintainer'],
+        preferences: { compact: true },
+      };
+
+      const config = createThreadConfig({
+        threadId: 'test-thread',
+        metadata,
+      });
+
+      expect(config.metadata).toBe(metadata);
+      expect(config.metadata).toEqual({
+        profile: {
+          roles: ['maintainer'],
+          preferences: { compact: true },
+        },
+      });
+      expect(Object.getPrototypeOf(config.metadata)).toBeNull();
+    });
+
+    it('should omit metadata when it is not provided', () => {
+      const config = createThreadConfig({ threadId: 'test-thread' });
+
+      expect(config).not.toHaveProperty('metadata');
+    });
+
     it('should create config with all options', () => {
       const config = createThreadConfig({
         threadId: 'test-thread',
@@ -142,6 +171,20 @@ describe('Thread Management', () => {
       expect(config.metadata?.custom).toBe('value');
     });
 
+    it('should preserve nested metadata values when adding conversation fields', () => {
+      const config = createConversationConfig({
+        userId: 'user-123',
+        metadata: {
+          nested: { enabled: true, labels: ['one', 'two'] },
+        },
+      });
+
+      expect(config.metadata).toEqual({
+        userId: 'user-123',
+        nested: { enabled: true, labels: ['one', 'two'] },
+      });
+    });
+
     it('should merge metadata with user and session info', () => {
       const config = createConversationConfig({
         userId: 'user-123',
@@ -157,4 +200,3 @@ describe('Thread Management', () => {
     });
   });
 });
-

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3856,14 +3856,30 @@ Implementation notes:
 **Branch:** `refactor/st-09093-thread-langsmith-metadata-contracts`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09093-thread-langsmith-metadata-contracts` from `main`
-- [ ] Define a compatible unknown-first JSON-safe metadata contract for thread persistence and LangSmith observability
-- [ ] Preserve metadata passthrough, optional fields, tracing compatibility, and thread serialization behavior
-- [ ] Add focused coverage for nested JSON values, null-prototype maps, omitted metadata, and non-JSON boundary values
-- [ ] Record explicit-`any` warning deltas in story documentation
-- [ ] Add or update story documentation at `docs/st09093-thread-langsmith-metadata-contracts.md`
-- [ ] Run core tests, typecheck, lint, and the explicit-any baseline gate
-- [ ] Run the full test suite and workspace lint before finalizing the PR
+- [x] Create branch `refactor/st-09093-thread-langsmith-metadata-contracts` from `main`
+  - Created from clean `main` at the start of story execution.
+- [x] Define a compatible unknown-first JSON-safe metadata contract for thread persistence and LangSmith observability
+  - Reused the shared `JsonObject` contract for thread, conversation, LangSmith, and tracing metadata.
+- [x] Preserve metadata passthrough, optional fields, tracing compatibility, and thread serialization behavior
+  - Preserved direct metadata references and tracing execution; omitted absent `sessionId` instead of emitting an undefined JSON value.
+- [x] Add focused coverage for nested JSON values, null-prototype maps, omitted metadata, and non-JSON boundary values
+  - Added runtime coverage plus compile-time `@ts-expect-error` assertions for function and `Date` metadata values.
+- [x] Record explicit-`any` warning deltas in story documentation
+  - Baseline improved from `workspace 74/289`, `core 17/119` to `workspace 70/289`, `core 13/119`.
+- [x] Add or update story documentation at `docs/st09093-thread-langsmith-metadata-contracts.md`
+- [x] Assess CI impact
+  - No CI workflow change is required; existing package, workspace, typecheck, lint, and explicit-`any` validation covers the changed contracts.
+- [x] Run core tests, typecheck, lint, and the explicit-any baseline gate
+  - Focused tests -> `34` passed before and after the implementation change.
+  - `pnpm --filter @agentforge/core test --run` -> `67` files, `654` tests passed.
+  - `pnpm --filter @agentforge/core typecheck` -> passed.
+  - `pnpm --filter @agentforge/core lint` -> passed with existing warning-only baseline and `0` errors.
+  - `pnpm lint:explicit-any:baseline` -> passed at `workspace 70/289`, `core 13/119`.
+- [x] Run the full test suite and workspace lint before finalizing the PR
+  - `pnpm release:validate` -> build passed; `230` files passed, `9` skipped; `2558` tests passed, `110` skipped.
+  - `pnpm lint` -> passed with existing warning-only baseline and `0` errors.
+  - `pnpm typecheck` -> passed for all 6 workspace packages.
+  - `git diff --check` -> passed.
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3880,8 +3880,10 @@ Implementation notes:
   - `pnpm lint` -> passed with existing warning-only baseline and `0` errors.
   - `pnpm typecheck` -> passed for all 6 workspace packages.
   - `git diff --check` -> passed.
-- [ ] Commit completed checklist items and push updates
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Commit completed checklist items and push updates
+  - Implementation commit `d8fcd511` is pushed to `origin/refactor/st-09093-thread-langsmith-metadata-contracts`; draft PR #169 was opened.
+- [x] Mark the PR Ready only after all story tasks are complete
+  - PR #169 was marked ready for review after the validated body and review-state tracker synchronization.
 - [ ] Wait for merge; do not merge directly from local branch
 
 ---

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2445,7 +2445,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] Replace the `Record<string, any>` metadata seams in `packages/core/src/langgraph/persistence/thread.ts` and `packages/core/src/langgraph/observability/langsmith.ts` with shared or locally defined unknown-first JSON-safe contracts.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2445,7 +2445,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] Replace the `Record<string, any>` metadata seams in `packages/core/src/langgraph/persistence/thread.ts` and `packages/core/src/langgraph/observability/langsmith.ts` with shared or locally defined unknown-first JSON-safe contracts.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-08-03
-**Active Story:** No EP-09 story active; `ST-09093` and `ST-09094` are Ready.
+**Last Updated:** 2026-08-04
+**Active Story:** `ST-09093` — Harden Thread and LangSmith Metadata Contracts.
 
 ---
 
@@ -148,6 +148,7 @@ Recent improvement snapshot:
 - `ST-09092` through `ST-09094` were added on 2026-08-02 as independent, low-risk type-boundary slices covering core generic wrappers, core metadata maps, and Neo4j property/query payloads.
 - `ST-09092` moved to In Progress on 2026-08-03 as the next deterministic EP-09 type-boundary slice.
 - `ST-09092` merged on 2026-08-03 as PR #168 after hardening core profiler and circuit-breaker generic wrapper contracts; `ST-09093` and `ST-09094` are now Ready.
+- `ST-09093` moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary slice.
 
 ## Scope
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-08-04
-**Active Story:** `ST-09093` — Harden Thread and LangSmith Metadata Contracts.
+**Active Story:** `ST-09093` — Harden Thread and LangSmith Metadata Contracts (In Review).
 
 ---
 
@@ -149,6 +149,7 @@ Recent improvement snapshot:
 - `ST-09092` moved to In Progress on 2026-08-03 as the next deterministic EP-09 type-boundary slice.
 - `ST-09092` merged on 2026-08-03 as PR #168 after hardening core profiler and circuit-breaker generic wrapper contracts; `ST-09093` and `ST-09094` are now Ready.
 - `ST-09093` moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary slice.
+- `ST-09093` moved to In Review on 2026-08-04 as PR #169 after hardening thread and LangSmith metadata contracts; `ST-09094` remains Ready.
 
 ## Scope
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 2 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -21,13 +21,13 @@
 
 ## In Progress
 
-- `ST-09093` — Harden Thread and LangSmith Metadata Contracts
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09093` — Harden Thread and LangSmith Metadata Contracts
 
 ---
 
@@ -65,6 +65,7 @@ None currently.
 - ST-09092 moved to In Progress on 2026-08-03 as the next deterministic EP-09 story; the remaining EP-09 and EP-11 follow-ons remained in Backlog
 - ST-09092 merged on 2026-08-03 as PR #168 / commit `4c7a99c1`; removed from the active queue, archived as done, and all three dependency-ready follow-ons were promoted to Ready
 - ST-09093 moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary story; `ST-09094` and `ST-11009` remain in Ready
+- ST-09093 moved to In Review on 2026-08-04 with PR #169 after implementation, documentation, focused and full validation, lint, typecheck, baseline, and tracker synchronization; `ST-09094` and `ST-11009` remain in Ready
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-08-03
+**Last Updated:** 2026-08-04
 
 ## Queue Status Summary
 
-- **Ready:** 3 stories
-- **In Progress:** 0 stories
+- **Ready:** 2 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,7 +14,6 @@
 
 ## Ready
 
-- `ST-09093` — Harden Thread and LangSmith Metadata Contracts
 - `ST-09094` — Harden Neo4j Property and Query Payload Contracts
 - `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance
 
@@ -22,7 +21,7 @@
 
 ## In Progress
 
-None currently.
+- `ST-09093` — Harden Thread and LangSmith Metadata Contracts
 
 ---
 
@@ -65,6 +64,7 @@ None currently.
 - ST-11009 added to Backlog on 2026-08-02 after source review found model-facing skill examples still wire unrestricted file tools despite the merged model-safe preset
 - ST-09092 moved to In Progress on 2026-08-03 as the next deterministic EP-09 story; the remaining EP-09 and EP-11 follow-ons remained in Backlog
 - ST-09092 merged on 2026-08-03 as PR #168 / commit `4c7a99c1`; removed from the active queue, archived as done, and all three dependency-ready follow-ons were promoted to Ready
+- ST-09093 moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary story; `ST-09094` and `ST-11009` remain in Ready
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story

`ST-09093` — Harden Thread and LangSmith Metadata Contracts

## What Changed

- Replaced `Record<string, any>` metadata seams in thread persistence and LangSmith observability with the shared `JsonObject` contract.
- Preserved nested JSON values, null-prototype metadata passthrough, optional metadata behavior, tracing execution, and thread configuration semantics.
- Omitted empty or absent `sessionId` from generated conversation metadata and used the same non-empty condition for thread ID derivation.
- Added runtime regression coverage and source-level typecheck assertions for invalid non-JSON metadata.
- Added `docs/st09093-thread-langsmith-metadata-contracts.md` and synchronized the story/feature/queue trackers.

## Acceptance Criteria Coverage

- Unknown-first JSON-safe contracts: covered by shared `JsonObject` types and compile-time rejection of function/`Date` values.
- Metadata passthrough and optional fields: covered by nested, null-prototype, omitted-metadata, empty-session, and conversation configuration tests.
- LangSmith compatibility: existing configuration/tracing tests remain green, with nested metadata coverage added.
- Validation commands pass without explicit-`any` baseline regression; baseline improved from workspace `74/289`, core `17/119` to workspace `70/289`, core `13/119`.
- Story documentation added at `docs/st09093-thread-langsmith-metadata-contracts.md`.

## Test Strategy

Focused runtime tests were added before the production type change and passed against the existing implementation. Compile-time `@ts-expect-error` assertions then failed as expected because the original signatures accepted non-JSON values. Production typing was tightened only after that failing evidence, followed by focused typecheck and runtime validation.

## Validation Performed

- `pnpm --filter @agentforge/core exec vitest run tests/langgraph/persistence/thread.test.ts tests/langgraph/observability/langsmith.test.ts` -> 35 passed.
- `pnpm --filter @agentforge/core test --run` -> 67 files and 654 tests passed.
- `pnpm --filter @agentforge/core typecheck` -> passed.
- `pnpm --filter @agentforge/core lint` -> passed with existing warning-only baseline and 0 errors.
- `pnpm lint:explicit-any:baseline` -> passed at workspace 70/289 and core 13/119.
- `pnpm release:validate` -> build passed; 230 files passed, 9 skipped; 2559 tests passed, 110 skipped.
- `pnpm lint` -> passed with existing warning-only baseline and 0 errors.
- `pnpm typecheck` -> passed for all 6 workspace packages.
- `git diff --check` -> passed.

## Status

Implementation is complete and the PR is ready for review. No CI workflow change is required.
