### PR TITLE
refactor(tools): harden Neo4j property and query contracts

### DIFF
--- a/docs/st09094-neo4j-property-query-contracts.md
+++ b/docs/st09094-neo4j-property-query-contracts.md
@@ -1,0 +1,31 @@
+# ST-09094: Neo4j Property and Query Payload Contracts
+
+## Scope
+
+Harden the Neo4j tools package at the property, query-parameter, node-helper, and embedding-provider error boundaries without changing public tool result shapes or database behavior.
+
+## Contract Changes
+
+- Neo4j properties and query parameters now use the shared JSON-safe `JsonValue`/`JsonObject` contracts.
+- Neo4j schemas recursively validate JSON-compatible scalar, array, nested-object, and null-prototype values while rejecting functions and `Date` instances.
+- Property filters and node creation preserve parameter binding and identifier sanitization without broad `any` payloads.
+- Embedding retry and provider error paths accept `unknown`, safely classify malformed errors, and preserve retry metadata and existing user-facing messages.
+- The connection query result default is `unknown` instead of an unconstrained `any` alias.
+
+## Test Strategy
+
+Test-first automated coverage was used. The initial focused test run failed because embedding-property schemas exposed `ZodAny` and `isRetryableError(null)` dereferenced an unknown value. The final focused suite covers supported property values, nested and null-prototype maps, rejected unsupported values, sanitized parameter binding, malformed errors, and provider error metadata. Compile-time assertions reject function and `Date` property values.
+
+## Validation
+
+- `pnpm --filter @agentforge/tools test --run tests/data/neo4j/contracts.test.ts` — passed, 5 tests.
+- `pnpm --filter @agentforge/tools typecheck` — passed.
+- `pnpm lint:explicit-any:baseline` — passed at `45/289` warnings (`tools 26/67`); this is an improvement with no baseline regression. The repository script requests a separate baseline-cap update for measured reductions, so the cap file remains unchanged in this story.
+- `pnpm --filter @agentforge/tools test --run` — passed, 93 files with 1168 tests passed and 110 skipped.
+- `pnpm lint` — passed with existing warnings and no errors.
+- `pnpm test` — passed, 231 files with 2564 tests passed and 110 skipped.
+- `pnpm build` — passed; the existing VitePress large-chunk warning remains.
+
+## CI Assessment
+
+No CI change is required. The existing package test, package typecheck, workspace lint, and explicit-`any` baseline commands cover the new contract and regression tests.

--- a/packages/tools/src/data/neo4j/connection.ts
+++ b/packages/tools/src/data/neo4j/connection.ts
@@ -6,13 +6,12 @@
 
 import neo4j, { Driver, Session, auth } from 'neo4j-driver';
 import { createLogger } from '@agentforge/core';
-import type { Neo4jConfig } from './types.js';
+import type { Neo4jConfig, Neo4jPropertyValue } from './types.js';
 
 const logger = createLogger('agentforge:tools:neo4j:pool');
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Keep legacy query helper compatibility for untyped callers.
-type Neo4jQueryResult = any;
-type Neo4jQueryParameters = Record<string, unknown>;
+type Neo4jQueryResult = unknown;
+type Neo4jQueryParameters = Record<string, Neo4jPropertyValue>;
 
 /**
  * Neo4j connection pool singleton

--- a/packages/tools/src/data/neo4j/contracts.typecheck.ts
+++ b/packages/tools/src/data/neo4j/contracts.typecheck.ts
@@ -1,0 +1,20 @@
+import type { Neo4jProperties } from './types.js';
+
+const validProperties = {
+  name: 'Ada',
+  active: true,
+  score: 4,
+  tags: ['graph', 'json'],
+  profile: { role: 'admin' },
+} satisfies Neo4jProperties;
+
+void validProperties;
+
+// @ts-expect-error Functions are not JSON-safe Neo4j property values.
+const functionProperty = { callback: () => 'not a property' } satisfies Neo4jProperties;
+
+// @ts-expect-error Date instances are not JSON-safe Neo4j property values.
+const dateProperty = { createdAt: new Date() } satisfies Neo4jProperties;
+
+void functionProperty;
+void dateProperty;

--- a/packages/tools/src/data/neo4j/embeddings/providers/cohere.ts
+++ b/packages/tools/src/data/neo4j/embeddings/providers/cohere.ts
@@ -7,7 +7,7 @@
 
 import axios from 'axios';
 import type { IEmbeddingProvider, EmbeddingResult, BatchEmbeddingResult } from '../types.js';
-import { retryWithBackoff } from '../utils.js';
+import { retryWithBackoff, withProviderErrorMetadata } from '../utils.js';
 
 /**
  * Cohere embedding provider
@@ -74,27 +74,23 @@ export class CohereEmbeddingProvider implements IEmbeddingProvider {
             totalTokens: response.data.meta.billed_units.input_tokens || 0,
           } : undefined,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const status = error.response?.status;
-          const message = error.response?.data?.message || error.message;
-          let wrappedError: any;
+          const providerMessage = error.response?.data?.message || error.message;
+          let message: string;
 
           if (status === 401) {
-            wrappedError = new Error(`Cohere API authentication failed. Please check your COHERE_API_KEY. ${message}`);
+            message = `Cohere API authentication failed. Please check your COHERE_API_KEY. ${providerMessage}`;
           } else if (status === 429) {
-            wrappedError = new Error(`Cohere API rate limit exceeded. ${message}`);
+            message = `Cohere API rate limit exceeded. ${providerMessage}`;
           } else if (status === 400) {
-            wrappedError = new Error(`Cohere API request invalid: ${message}`);
+            message = `Cohere API request invalid: ${providerMessage}`;
           } else {
-            wrappedError = new Error(`Cohere API error (${status}): ${message}`);
+            message = `Cohere API error (${status}): ${providerMessage}`;
           }
 
-          // Preserve error metadata for retry logic
-          if (error.code) wrappedError.code = error.code;
-          if (error.response) wrappedError.response = error.response;
-
-          throw wrappedError;
+          throw withProviderErrorMetadata(error, message);
         }
 
         throw error;
@@ -102,4 +98,3 @@ export class CohereEmbeddingProvider implements IEmbeddingProvider {
     });
   }
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/providers/huggingface.ts
+++ b/packages/tools/src/data/neo4j/embeddings/providers/huggingface.ts
@@ -7,7 +7,7 @@
 
 import axios from 'axios';
 import type { IEmbeddingProvider, EmbeddingResult, BatchEmbeddingResult } from '../types.js';
-import { retryWithBackoff } from '../utils.js';
+import { retryWithBackoff, withProviderErrorMetadata } from '../utils.js';
 
 /**
  * HuggingFace embedding provider
@@ -59,29 +59,25 @@ export class HuggingFaceEmbeddingProvider implements IEmbeddingProvider {
           model: modelToUse,
           dimensions: embedding.length,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const status = error.response?.status;
           const message = error.response?.data?.error || error.message;
-          let wrappedError: any;
+          let messageText: string;
 
           if (status === 401) {
-            wrappedError = new Error(`HuggingFace API authentication failed. Please check your HUGGINGFACE_API_KEY. ${message}`);
+            messageText = `HuggingFace API authentication failed. Please check your HUGGINGFACE_API_KEY. ${message}`;
           } else if (status === 429) {
-            wrappedError = new Error(`HuggingFace API rate limit exceeded. ${message}`);
+            messageText = `HuggingFace API rate limit exceeded. ${message}`;
           } else if (status === 400) {
-            wrappedError = new Error(`HuggingFace API request invalid: ${message}`);
+            messageText = `HuggingFace API request invalid: ${message}`;
           } else if (status === 503) {
-            wrappedError = new Error(`HuggingFace model is loading. Please retry in a moment. ${message}`);
+            messageText = `HuggingFace model is loading. Please retry in a moment. ${message}`;
           } else {
-            wrappedError = new Error(`HuggingFace API error (${status}): ${message}`);
+            messageText = `HuggingFace API error (${status}): ${message}`;
           }
 
-          // Preserve error metadata for retry logic
-          if (error.code) wrappedError.code = error.code;
-          if (error.response) wrappedError.response = error.response;
-
-          throw wrappedError;
+          throw withProviderErrorMetadata(error, messageText);
         }
 
         throw error;
@@ -118,29 +114,25 @@ export class HuggingFaceEmbeddingProvider implements IEmbeddingProvider {
           model: modelToUse,
           dimensions,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const status = error.response?.status;
           const message = error.response?.data?.error || error.message;
-          let wrappedError: any;
+          let messageText: string;
 
           if (status === 401) {
-            wrappedError = new Error(`HuggingFace API authentication failed. Please check your HUGGINGFACE_API_KEY. ${message}`);
+            messageText = `HuggingFace API authentication failed. Please check your HUGGINGFACE_API_KEY. ${message}`;
           } else if (status === 429) {
-            wrappedError = new Error(`HuggingFace API rate limit exceeded. ${message}`);
+            messageText = `HuggingFace API rate limit exceeded. ${message}`;
           } else if (status === 400) {
-            wrappedError = new Error(`HuggingFace API request invalid: ${message}`);
+            messageText = `HuggingFace API request invalid: ${message}`;
           } else if (status === 503) {
-            wrappedError = new Error(`HuggingFace model is loading. Please retry in a moment. ${message}`);
+            messageText = `HuggingFace model is loading. Please retry in a moment. ${message}`;
           } else {
-            wrappedError = new Error(`HuggingFace API error (${status}): ${message}`);
+            messageText = `HuggingFace API error (${status}): ${message}`;
           }
 
-          // Preserve error metadata for retry logic
-          if (error.code) wrappedError.code = error.code;
-          if (error.response) wrappedError.response = error.response;
-
-          throw wrappedError;
+          throw withProviderErrorMetadata(error, messageText);
         }
 
         throw error;
@@ -148,4 +140,3 @@ export class HuggingFaceEmbeddingProvider implements IEmbeddingProvider {
     });
   }
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/providers/ollama.ts
+++ b/packages/tools/src/data/neo4j/embeddings/providers/ollama.ts
@@ -7,7 +7,7 @@
 
 import axios from 'axios';
 import type { IEmbeddingProvider, EmbeddingResult, BatchEmbeddingResult } from '../types.js';
-import { retryWithBackoff } from '../utils.js';
+import { retryWithBackoff, withProviderErrorMetadata } from '../utils.js';
 
 /**
  * Ollama embedding provider (local, privacy-focused)
@@ -54,27 +54,23 @@ export class OllamaEmbeddingProvider implements IEmbeddingProvider {
           model: modelToUse,
           dimensions: embedding.length,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const status = error.response?.status;
           const message = error.response?.data?.error || error.message;
-          let wrappedError: any;
+          let messageText: string;
 
           if (error.code === 'ECONNREFUSED') {
-            wrappedError = new Error(`Cannot connect to Ollama at ${this.baseUrl}. Make sure Ollama is running locally.`);
+            messageText = `Cannot connect to Ollama at ${this.baseUrl}. Make sure Ollama is running locally.`;
           } else if (status === 404) {
-            wrappedError = new Error(`Ollama model not found. Pull it with: ollama pull <model-name>`);
+            messageText = 'Ollama model not found. Pull it with: ollama pull <model-name>';
           } else if (status === 400) {
-            wrappedError = new Error(`Ollama API request invalid: ${message}`);
+            messageText = `Ollama API request invalid: ${message}`;
           } else {
-            wrappedError = new Error(`Ollama API error (${status}): ${message}`);
+            messageText = `Ollama API error (${status}): ${message}`;
           }
 
-          // Preserve error metadata for retry logic
-          if (error.code) wrappedError.code = error.code;
-          if (error.response) wrappedError.response = error.response;
-
-          throw wrappedError;
+          throw withProviderErrorMetadata(error, messageText);
         }
 
         throw error;
@@ -102,4 +98,3 @@ export class OllamaEmbeddingProvider implements IEmbeddingProvider {
     };
   }
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/providers/openai.ts
+++ b/packages/tools/src/data/neo4j/embeddings/providers/openai.ts
@@ -8,7 +8,7 @@
 
 import axios from 'axios';
 import type { IEmbeddingProvider, EmbeddingResult, BatchEmbeddingResult } from '../types.js';
-import { getOpenAIApiKey, retryWithBackoff, validateText, validateBatch } from '../utils.js';
+import { getOpenAIApiKey, retryWithBackoff, validateText, validateBatch, withProviderErrorMetadata } from '../utils.js';
 
 /**
  * OpenAI API response structure for embeddings
@@ -95,31 +95,22 @@ export class OpenAIEmbeddingProvider implements IEmbeddingProvider {
             totalTokens: data.usage.total_tokens,
           },
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Create error with helpful message while preserving metadata for retry logic
-        let wrappedError: any;
+        let message: string;
+        const response = axios.isAxiosError(error) ? error.response : undefined;
 
-        if (error.response?.status === 401) {
-          wrappedError = new Error(
-            'Invalid OpenAI API key. Get your key at https://platform.openai.com/api-keys'
-          );
-        } else if (error.response?.status === 429) {
-          wrappedError = new Error(
-            'OpenAI API rate limit exceeded. Please try again later or upgrade your plan.'
-          );
-        } else if (error.response?.status === 400) {
-          wrappedError = new Error(
-            `OpenAI API error: ${error.response.data?.error?.message || 'Bad request'}`
-          );
+        if (response?.status === 401) {
+          message = 'Invalid OpenAI API key. Get your key at https://platform.openai.com/api-keys';
+        } else if (response?.status === 429) {
+          message = 'OpenAI API rate limit exceeded. Please try again later or upgrade your plan.';
+        } else if (response?.status === 400) {
+          message = `OpenAI API error: ${response.data?.error?.message || 'Bad request'}`;
         } else {
-          wrappedError = new Error(`OpenAI embedding generation failed: ${error.message}`);
+          message = `OpenAI embedding generation failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
         }
 
-        // Preserve error metadata for retry logic
-        if (error.code) wrappedError.code = error.code;
-        if (error.response) wrappedError.response = error.response;
-
-        throw wrappedError;
+        throw withProviderErrorMetadata(error, message);
       }
     });
   }
@@ -174,33 +165,23 @@ export class OpenAIEmbeddingProvider implements IEmbeddingProvider {
             totalTokens: data.usage.total_tokens,
           },
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Create error with helpful message while preserving metadata for retry logic
-        let wrappedError: any;
+        let message: string;
+        const response = axios.isAxiosError(error) ? error.response : undefined;
 
-        if (error.response?.status === 401) {
-          wrappedError = new Error(
-            'Invalid OpenAI API key. Get your key at https://platform.openai.com/api-keys'
-          );
-        } else if (error.response?.status === 429) {
-          wrappedError = new Error(
-            'OpenAI API rate limit exceeded. Please try again later or upgrade your plan.'
-          );
-        } else if (error.response?.status === 400) {
-          wrappedError = new Error(
-            `OpenAI API error: ${error.response.data?.error?.message || 'Bad request'}`
-          );
+        if (response?.status === 401) {
+          message = 'Invalid OpenAI API key. Get your key at https://platform.openai.com/api-keys';
+        } else if (response?.status === 429) {
+          message = 'OpenAI API rate limit exceeded. Please try again later or upgrade your plan.';
+        } else if (response?.status === 400) {
+          message = `OpenAI API error: ${response.data?.error?.message || 'Bad request'}`;
         } else {
-          wrappedError = new Error(`OpenAI batch embedding generation failed: ${error.message}`);
+          message = `OpenAI batch embedding generation failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
         }
 
-        // Preserve error metadata for retry logic
-        if (error.code) wrappedError.code = error.code;
-        if (error.response) wrappedError.response = error.response;
-
-        throw wrappedError;
+        throw withProviderErrorMetadata(error, message);
       }
     });
   }
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/providers/voyage.ts
+++ b/packages/tools/src/data/neo4j/embeddings/providers/voyage.ts
@@ -7,7 +7,7 @@
 
 import axios from 'axios';
 import type { IEmbeddingProvider, EmbeddingResult, BatchEmbeddingResult } from '../types.js';
-import { retryWithBackoff } from '../utils.js';
+import { retryWithBackoff, withProviderErrorMetadata } from '../utils.js';
 
 /**
  * Voyage AI embedding provider
@@ -60,7 +60,7 @@ export class VoyageEmbeddingProvider implements IEmbeddingProvider {
           }
         );
 
-        const embeddings = response.data.data.map((item: any) => item.embedding);
+        const embeddings = response.data.data.map((item: { embedding: number[] }) => item.embedding);
         const dimensions = embeddings[0]?.length || 0;
 
         return {
@@ -72,27 +72,23 @@ export class VoyageEmbeddingProvider implements IEmbeddingProvider {
             totalTokens: response.data.usage.total_tokens || 0,
           } : undefined,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const status = error.response?.status;
           const message = error.response?.data?.message || error.message;
-          let wrappedError: any;
+          let messageText: string;
 
           if (status === 401) {
-            wrappedError = new Error(`Voyage AI API authentication failed. Please check your VOYAGE_API_KEY. ${message}`);
+            messageText = `Voyage AI API authentication failed. Please check your VOYAGE_API_KEY. ${message}`;
           } else if (status === 429) {
-            wrappedError = new Error(`Voyage AI API rate limit exceeded. ${message}`);
+            messageText = `Voyage AI API rate limit exceeded. ${message}`;
           } else if (status === 400) {
-            wrappedError = new Error(`Voyage AI API request invalid: ${message}`);
+            messageText = `Voyage AI API request invalid: ${message}`;
           } else {
-            wrappedError = new Error(`Voyage AI API error (${status}): ${message}`);
+            messageText = `Voyage AI API error (${status}): ${message}`;
           }
 
-          // Preserve error metadata for retry logic
-          if (error.code) wrappedError.code = error.code;
-          if (error.response) wrappedError.response = error.response;
-
-          throw wrappedError;
+          throw withProviderErrorMetadata(error, messageText);
         }
 
         throw error;
@@ -100,4 +96,3 @@ export class VoyageEmbeddingProvider implements IEmbeddingProvider {
     });
   }
 }
-

--- a/packages/tools/src/data/neo4j/embeddings/utils.ts
+++ b/packages/tools/src/data/neo4j/embeddings/utils.ts
@@ -6,6 +6,20 @@
 
 import type { EmbeddingRetryConfig } from './types.js';
 
+export type EmbeddingProviderError = Error & {
+  code?: string;
+  response?: unknown;
+};
+
+export function withProviderErrorMetadata(error: unknown, message: string): EmbeddingProviderError {
+  const wrappedError = new Error(message) as EmbeddingProviderError;
+  if (!isRecord(error)) return wrappedError;
+
+  if (typeof error.code === 'string') wrappedError.code = error.code;
+  if (error.response !== undefined) wrappedError.response = error.response;
+  return wrappedError;
+}
+
 /**
  * Default retry configuration for embedding API calls
  */
@@ -19,24 +33,35 @@ export const DEFAULT_RETRY_CONFIG: EmbeddingRetryConfig = {
 /**
  * Check if error is retryable (network errors, timeouts, 5xx errors, rate limits)
  */
-export function isRetryableError(error: any): boolean {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isRetryableError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+
+  const response = isRecord(error.response) ? error.response : undefined;
+  const status = typeof response?.status === 'number' ? response.status : undefined;
+  const code = typeof error.code === 'string' ? error.code : undefined;
+  const message = typeof error.message === 'string' ? error.message : undefined;
+
   // Network errors
-  if (error.code === 'ECONNRESET' || error.code === 'ETIMEDOUT' || error.code === 'ENOTFOUND') {
+  if (code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'ENOTFOUND') {
     return true;
   }
 
   // Timeout errors
-  if (error.code === 'ECONNABORTED' || error.message?.includes('timeout')) {
+  if (code === 'ECONNABORTED' || message?.includes('timeout')) {
     return true;
   }
 
   // 5xx server errors (but not 4xx client errors)
-  if (error.response?.status >= 500 && error.response?.status < 600) {
+  if (status !== undefined && status >= 500 && status < 600) {
     return true;
   }
 
   // Rate limiting (429) - retryable with backoff
-  if (error.response?.status === 429) {
+  if (status === 429) {
     return true;
   }
 
@@ -57,13 +82,13 @@ export async function retryWithBackoff<T>(
   fn: () => Promise<T>,
   config: EmbeddingRetryConfig = DEFAULT_RETRY_CONFIG
 ): Promise<T> {
-  let lastError: any;
+  let lastError: unknown;
   let delay = config.initialDelay;
 
   for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
     try {
       return await fn();
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error;
 
       // Don't retry if error is not retryable
@@ -172,4 +197,3 @@ export function validateBatch(texts: string[]): void {
     }
   });
 }
-

--- a/packages/tools/src/data/neo4j/tools/neo4j-create-node-with-embedding.ts
+++ b/packages/tools/src/data/neo4j/tools/neo4j-create-node-with-embedding.ts
@@ -7,6 +7,7 @@
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { neo4jCreateNodeWithEmbeddingSchema } from '../types.js';
+import type { Neo4jProperties } from '../types.js';
 import { neo4jPool } from '../connection.js';
 import { formatResults } from '../utils/result-formatter.js';
 import { embeddingManager } from '../embeddings/embedding-manager.js';
@@ -68,7 +69,7 @@ export function createNeo4jCreateNodeWithEmbeddingTool() {
 
         try {
           // Build properties object with embedding
-          const allProperties: Record<string, any> = {
+          const allProperties: Neo4jProperties = {
             ...input.properties,
           };
           allProperties[input.embeddingProperty || 'embedding'] = embeddingResult.embedding;
@@ -130,4 +131,3 @@ export function createNeo4jCreateNodeWithEmbeddingTool() {
     })
     .build();
 }
-

--- a/packages/tools/src/data/neo4j/tools/neo4j-find-nodes.ts
+++ b/packages/tools/src/data/neo4j/tools/neo4j-find-nodes.ts
@@ -6,6 +6,7 @@
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { neo4jFindNodesSchema } from '../types.js';
+import type { Neo4jPropertyValue } from '../types.js';
 import { neo4jPool } from '../connection.js';
 import { formatResults } from '../utils/result-formatter.js';
 import { validateLabel, buildPropertyFilter } from '../utils/cypher-sanitizer.js';
@@ -41,7 +42,7 @@ export function createNeo4jFindNodesTool() {
         try {
           // Build the Cypher query with safe identifiers
           let cypher = `MATCH (n:${safeLabel})`;
-          let parameters: Record<string, any> = {};
+          let parameters: Record<string, Neo4jPropertyValue> = {};
 
           // Add property filters if provided (using safe parameter binding)
           if (input.properties && Object.keys(input.properties).length > 0) {
@@ -52,7 +53,7 @@ export function createNeo4jFindNodesTool() {
 
           // Use parameter for limit to be extra safe
           cypher += ` RETURN n LIMIT $limit`;
-          parameters.limit = input.limit;
+          parameters.limit = input.limit ?? 100;
 
           const result = await session.run(cypher, parameters);
           const formattedResults = formatResults(result.records);
@@ -83,4 +84,3 @@ export function createNeo4jFindNodesTool() {
     })
     .build();
 }
-

--- a/packages/tools/src/data/neo4j/types.ts
+++ b/packages/tools/src/data/neo4j/types.ts
@@ -5,6 +5,25 @@
  */
 
 import { z } from 'zod';
+import type { JsonObject, JsonValue } from '@agentforge/core';
+
+/** JSON-compatible values accepted by Neo4j payload boundaries. */
+export type Neo4jPropertyValue = JsonValue;
+export type Neo4jProperties = JsonObject;
+
+const neo4jJsonValueSchema: z.ZodType<Neo4jPropertyValue> = z.lazy(() => z.union([
+  z.string(),
+  z.number().finite(),
+  z.boolean(),
+  z.null(),
+  z.array(neo4jJsonValueSchema),
+  z.record(z.string(), neo4jJsonValueSchema),
+])).describe('JSON-safe Neo4j property value');
+
+const neo4jPropertiesSchema: z.ZodType<Neo4jProperties> = z.record(
+  z.string(),
+  neo4jJsonValueSchema
+);
 
 /**
  * Neo4j connection configuration
@@ -23,7 +42,7 @@ export interface Neo4jConfig {
  */
 export const neo4jQuerySchema = z.object({
   cypher: z.string().describe('Cypher query to execute'),
-  parameters: z.record(z.any()).optional().describe('Query parameters for parameterized queries'),
+  parameters: neo4jPropertiesSchema.optional().describe('Query parameters for parameterized queries'),
   database: z.string().optional().describe('Database name (defaults to configured database)'),
 });
 
@@ -39,7 +58,7 @@ export const neo4jGetSchemaSchema = z.object({
  */
 export const neo4jFindNodesSchema = z.object({
   label: z.string().describe('Node label to search for'),
-  properties: z.record(z.any()).optional().describe('Properties to match (key-value pairs)'),
+  properties: neo4jPropertiesSchema.optional().describe('Properties to match (key-value pairs)'),
   limit: z.number().default(100).describe('Maximum number of nodes to return'),
   database: z.string().optional().describe('Database name (defaults to configured database)'),
 });
@@ -85,7 +104,7 @@ export const neo4jVectorSearchWithEmbeddingSchema = z.object({
  */
 export const neo4jCreateNodeWithEmbeddingSchema = z.object({
   label: z.string().describe('Node label'),
-  properties: z.record(z.string(), z.any().describe('Property value')).describe('Node properties (key-value pairs)'),
+  properties: neo4jPropertiesSchema.describe('Node properties (key-value pairs)'),
   textProperty: z.string().describe('Name of the property containing text to embed'),
   embeddingProperty: z.string().default('embedding').describe('Name of the property to store the embedding vector'),
   model: z.string().optional().describe('Embedding model to use (defaults to configured model)'),
@@ -98,7 +117,7 @@ export const neo4jCreateNodeWithEmbeddingSchema = z.object({
 export interface Neo4jNode {
   identity: string | number;
   labels: string[];
-  properties: Record<string, any>;
+  properties: Neo4jProperties;
 }
 
 /**
@@ -109,7 +128,7 @@ export interface Neo4jRelationship {
   type: string;
   start: string | number;
   end: string | number;
-  properties: Record<string, any>;
+  properties: Neo4jProperties;
 }
 
 /**
@@ -156,4 +175,3 @@ export interface Neo4jToolsConfig {
   maxConnectionPoolSize?: number;
   connectionTimeout?: number;
 }
-

--- a/packages/tools/src/data/neo4j/utils/cypher-sanitizer.ts
+++ b/packages/tools/src/data/neo4j/utils/cypher-sanitizer.ts
@@ -4,6 +4,8 @@
  * Provides safe escaping and validation for Cypher identifiers to prevent injection attacks.
  */
 
+import type { Neo4jProperties, Neo4jPropertyValue } from '../types.js';
+
 /**
  * Validate and escape a Cypher identifier (label, property key, relationship type)
  * 
@@ -102,9 +104,9 @@ export function validateDirection(direction: string): 'OUTGOING' | 'INCOMING' | 
  * @returns Object with WHERE clause and parameters
  */
 export function buildPropertyFilter(
-  properties: Record<string, any>,
+  properties: Neo4jProperties,
   nodeVar: string = 'n'
-): { whereClause: string; parameters: Record<string, any> } {
+): { whereClause: string; parameters: Record<string, Neo4jPropertyValue> } {
   const keys = Object.keys(properties);
   
   if (keys.length === 0) {
@@ -121,7 +123,7 @@ export function buildPropertyFilter(
     return `${safeNodeVar}.${safeKey} = $${paramName}`;
   });
 
-  const parameters: Record<string, any> = {};
+  const parameters: Record<string, Neo4jPropertyValue> = {};
   keys.forEach((key, index) => {
     parameters[`prop_${index}`] = properties[key];
   });
@@ -131,4 +133,3 @@ export function buildPropertyFilter(
     parameters,
   };
 }
-

--- a/packages/tools/tests/data/neo4j/contracts.test.ts
+++ b/packages/tools/tests/data/neo4j/contracts.test.ts
@@ -6,6 +6,7 @@ import {
   neo4jFindNodesSchema,
   neo4jQuerySchema,
 } from '../../../src/data/neo4j/types.js';
+import type { Neo4jProperties } from '../../../src/data/neo4j/types.js';
 import { buildPropertyFilter } from '../../../src/data/neo4j/utils/cypher-sanitizer.js';
 import {
   isRetryableError,
@@ -14,7 +15,7 @@ import {
 
 describe('Neo4j payload contracts', () => {
   it('accepts scalar, array, nested-object, and null-prototype payload values', () => {
-    const properties = Object.create(null) as Record<string, unknown>;
+    const properties = Object.create(null) as Neo4jProperties;
     properties.name = 'Ada';
     properties.tags = ['graph', 'json'];
     properties.profile = { active: true, score: 4 };
@@ -51,7 +52,7 @@ describe('Neo4j payload contracts', () => {
   });
 
   it('binds supported values while sanitizing property identifiers', () => {
-    const properties = Object.create(null) as Record<string, unknown>;
+    const properties = Object.create(null) as Neo4jProperties;
     properties.name = 'Ada';
     properties['profile.active'] = true;
     properties.tags = ['admin', 'reviewer'];

--- a/packages/tools/tests/data/neo4j/contracts.test.ts
+++ b/packages/tools/tests/data/neo4j/contracts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  neo4jCreateNodeWithEmbeddingSchema,
+  neo4jFindNodesSchema,
+  neo4jQuerySchema,
+} from '../../../src/data/neo4j/types.js';
+import { buildPropertyFilter } from '../../../src/data/neo4j/utils/cypher-sanitizer.js';
+import {
+  isRetryableError,
+  withProviderErrorMetadata,
+} from '../../../src/data/neo4j/embeddings/utils.js';
+
+describe('Neo4j payload contracts', () => {
+  it('accepts scalar, array, nested-object, and null-prototype payload values', () => {
+    const properties = Object.create(null) as Record<string, unknown>;
+    properties.name = 'Ada';
+    properties.tags = ['graph', 'json'];
+    properties.profile = { active: true, score: 4 };
+
+    expect(neo4jQuerySchema.parse({
+      cypher: 'RETURN $properties',
+      parameters: properties,
+    }).parameters).toEqual(properties);
+
+    expect(neo4jFindNodesSchema.parse({
+      label: 'Person',
+      properties,
+    }).properties).toEqual(properties);
+
+    expect(neo4jCreateNodeWithEmbeddingSchema.parse({
+      label: 'Person',
+      properties,
+      textProperty: 'name',
+    }).properties).toEqual(properties);
+  });
+
+  it('uses unknown-first schemas for Neo4j property payload values', () => {
+    expect(neo4jQuerySchema.shape.parameters?.unwrap()).toBeInstanceOf(z.ZodRecord);
+    expect(neo4jFindNodesSchema.shape.properties?.unwrap()).toBeInstanceOf(z.ZodRecord);
+    expect(neo4jCreateNodeWithEmbeddingSchema.shape.properties.element).toBeInstanceOf(z.ZodLazy);
+    expect(() => neo4jFindNodesSchema.parse({
+      label: 'Person',
+      properties: { createdAt: new Date() },
+    })).toThrow();
+    expect(() => neo4jFindNodesSchema.parse({
+      label: 'Person',
+      properties: { callback: () => 'unsupported' },
+    })).toThrow();
+  });
+
+  it('binds supported values while sanitizing property identifiers', () => {
+    const properties = Object.create(null) as Record<string, unknown>;
+    properties.name = 'Ada';
+    properties['profile.active'] = true;
+    properties.tags = ['admin', 'reviewer'];
+
+    expect(buildPropertyFilter(properties, 'node')).toEqual({
+      whereClause: 'WHERE node.name = $prop_0 AND node.`profile.active` = $prop_1 AND node.tags = $prop_2',
+      parameters: {
+        prop_0: 'Ada',
+        prop_1: true,
+        prop_2: ['admin', 'reviewer'],
+      },
+    });
+  });
+
+  it('does not treat malformed unknown errors as retryable', () => {
+    expect(isRetryableError(null)).toBe(false);
+    expect(isRetryableError('provider failed')).toBe(false);
+    expect(isRetryableError({ response: { status: 503 } })).toBe(true);
+  });
+
+  it('preserves provider failure metadata without requiring an any-shaped error', () => {
+    const upstreamError = Object.assign(new Error('upstream failed'), {
+      code: 'ECONNRESET',
+      response: { status: 503 },
+    });
+
+    const wrappedError = withProviderErrorMetadata(upstreamError, 'provider failed');
+
+    expect(wrappedError.message).toBe('provider failed');
+    expect(wrappedError.code).toBe('ECONNRESET');
+    expect(wrappedError.response).toEqual({ status: 503 });
+    expect(isRetryableError(wrappedError)).toBe(true);
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3902,6 +3902,6 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09094-neo4j-property-query-contracts.md`
 - [x] Run tools tests, typecheck, lint, and the explicit-any baseline gate — tools 93 passed/9 skipped; typecheck, workspace lint, and baseline passed
 - [x] Run the full test suite and workspace lint before finalizing the PR — 231 passed/9 skipped files; 2564 passed/110 skipped tests; workspace lint passed
-- [ ] Commit completed checklist items and push updates
+- [x] Commit completed checklist items and push updates — implementation commit `24dce727` pushed to PR #170
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -3894,14 +3894,14 @@ Implementation notes:
 **Branch:** `refactor/st-09094-neo4j-property-query-contracts`
 
 ### Checklist
-- [ ] Create branch `refactor/st-09094-neo4j-property-query-contracts` from `main`
-- [ ] Replace Neo4j property, Cypher parameter, node-helper, and embedding error `any` seams with compatible contracts
-- [ ] Preserve property serialization, parameter binding, sanitization, public result shapes, and provider error behavior
-- [ ] Add focused coverage for supported property values, unsupported values, null-prototype maps, sanitized parameters, and provider failures
-- [ ] Record explicit-`any` warning deltas in story documentation
-- [ ] Add or update story documentation at `docs/st09094-neo4j-property-query-contracts.md`
-- [ ] Run tools tests, typecheck, lint, and the explicit-any baseline gate
-- [ ] Run the full test suite and workspace lint before finalizing the PR
+- [x] Create branch `refactor/st-09094-neo4j-property-query-contracts` from `main` — branch created and pushed; draft PR #170 opened
+- [x] Replace Neo4j property, Cypher parameter, node-helper, and embedding error `any` seams with compatible contracts
+- [x] Preserve property serialization, parameter binding, sanitization, public result shapes, and provider error behavior
+- [x] Add focused coverage for supported property values, unsupported values, null-prototype maps, sanitized parameters, and provider failures
+- [x] Record explicit-`any` warning deltas in story documentation — measured source scan improved to 45/289 warnings (`tools 26/67`)
+- [x] Add or update story documentation at `docs/st09094-neo4j-property-query-contracts.md`
+- [x] Run tools tests, typecheck, lint, and the explicit-any baseline gate — tools 93 passed/9 skipped; typecheck, workspace lint, and baseline passed
+- [x] Run the full test suite and workspace lint before finalizing the PR — 231 passed/9 skipped files; 2564 passed/110 skipped tests; workspace lint passed
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2462,7 +2462,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** None
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] Replace the remaining `Record<string, any>` and `any` payload seams in the Neo4j property types, Cypher sanitizer, node helpers, and embedding error paths with compatible unknown-first or JSON-safe contracts.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2465,11 +2465,11 @@
 **Status:** In Progress
 
 **Acceptance criteria:**
-- [ ] Replace the remaining `Record<string, any>` and `any` payload seams in the Neo4j property types, Cypher sanitizer, node helpers, and embedding error paths with compatible unknown-first or JSON-safe contracts.
-- [ ] Preserve property serialization, parameter binding, identifier sanitization, embedding-provider error handling, and public Neo4j tool result shapes.
-- [ ] Add focused coverage for scalar, array, nested-object, null-prototype, and unsupported property values plus sanitized query parameters and provider failures.
-- [ ] `pnpm --filter @agentforge/tools test --run`, `pnpm --filter @agentforge/tools typecheck`, and `pnpm lint:explicit-any:baseline` pass with no baseline regression.
-- [ ] Add or update story documentation at `docs/st09094-neo4j-property-query-contracts.md`
+- [x] Replace the remaining `Record<string, any>` and `any` payload seams in the Neo4j property types, Cypher sanitizer, node helpers, and embedding error paths with compatible unknown-first or JSON-safe contracts.
+- [x] Preserve property serialization, parameter binding, identifier sanitization, embedding-provider error handling, and public Neo4j tool result shapes.
+- [x] Add focused coverage for scalar, array, nested-object, null-prototype, and unsupported property values plus sanitized query parameters and provider failures.
+- [x] `pnpm --filter @agentforge/tools test --run`, `pnpm --filter @agentforge/tools typecheck`, and `pnpm lint:explicit-any:baseline` pass with no baseline regression.
+- [x] Add or update story documentation at `docs/st09094-neo4j-property-query-contracts.md`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2462,7 +2462,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 3 hours
 **Dependencies:** None
-**Status:** In Progress
+**Status:** In Review (PR #170)
 
 **Acceptance criteria:**
 - [x] Replace the remaining `Record<string, any>` and `any` payload seams in the Neo4j property types, Cypher sanitizer, node helpers, and embedding error paths with compatible unknown-first or JSON-safe contracts.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-08-04
-**Active Story:** No EP-09 story active; `ST-09094` is next in Ready.
+**Last Updated:** 2026-08-05
+**Active Story:** `ST-09094` — Harden Neo4j Property and Query Payload Contracts (In Progress)
 
 ---
 
@@ -151,6 +151,7 @@ Recent improvement snapshot:
 - `ST-09093` moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary slice.
 - `ST-09093` moved to In Review on 2026-08-04 as PR #169 after hardening thread and LangSmith metadata contracts; `ST-09094` remains Ready.
 - `ST-09093` merged on 2026-08-04 as PR #169 after hardening thread and LangSmith metadata contracts; `ST-09094` remains the next Ready story.
+- `ST-09094` moved to In Progress on 2026-08-05 as the next deterministic EP-09 Neo4j property/query payload-boundary story.
 
 ## Scope
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-08-05
-**Active Story:** `ST-09094` — Harden Neo4j Property and Query Payload Contracts (In Progress)
+**Active Story:** `ST-09094` — Harden Neo4j Property and Query Payload Contracts (In Review, PR #170)
 
 ---
 
@@ -152,6 +152,7 @@ Recent improvement snapshot:
 - `ST-09093` moved to In Review on 2026-08-04 as PR #169 after hardening thread and LangSmith metadata contracts; `ST-09094` remains Ready.
 - `ST-09093` merged on 2026-08-04 as PR #169 after hardening thread and LangSmith metadata contracts; `ST-09094` remains the next Ready story.
 - `ST-09094` moved to In Progress on 2026-08-05 as the next deterministic EP-09 Neo4j property/query payload-boundary story.
+- `ST-09094` moved to In Review on 2026-08-05 as PR #170 after completing implementation and validation.
 
 ## Scope
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 1 story
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,13 +20,13 @@
 
 ## In Progress
 
-- `ST-09094` — Harden Neo4j Property and Query Payload Contracts
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-09094` — Harden Neo4j Property and Query Payload Contracts (PR #170)
 
 ---
 
@@ -67,6 +67,7 @@ None currently.
 - ST-09093 moved to In Review on 2026-08-04 with PR #169 after implementation, documentation, focused and full validation, lint, typecheck, baseline, and tracker synchronization; `ST-09094` and `ST-11009` remain in Ready
 - ST-09093 merged on 2026-08-04 as PR #169 / commit `f54a2f5c`; removed from the active queue, archived as done, and `ST-09094` followed by `ST-11009` remains the dependency-ready Ready lane
 - ST-09094 moved to In Progress on 2026-08-05 as the next deterministic EP-09 Neo4j payload-boundary story; `ST-11009` remains in Ready
+- ST-09094 moved to In Review on 2026-08-05 with PR #170 after implementation, focused and full validation, lint, typecheck, build, documentation, and explicit-any baseline verification; `ST-11009` remains in Ready
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-08-04
+**Last Updated:** 2026-08-05
 
 ## Queue Status Summary
 
-- **Ready:** 2 stories
-- **In Progress:** 0 stories
+- **Ready:** 1 story
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,14 +14,13 @@
 
 ## Ready
 
-- `ST-09094` — Harden Neo4j Property and Query Payload Contracts
 - `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance
 
 ---
 
 ## In Progress
 
-None currently.
+- `ST-09094` — Harden Neo4j Property and Query Payload Contracts
 
 ---
 
@@ -67,6 +66,7 @@ None currently.
 - ST-09093 moved to In Progress on 2026-08-04 as the next deterministic EP-09 metadata-boundary story; `ST-09094` and `ST-11009` remain in Ready
 - ST-09093 moved to In Review on 2026-08-04 with PR #169 after implementation, documentation, focused and full validation, lint, typecheck, baseline, and tracker synchronization; `ST-09094` and `ST-11009` remain in Ready
 - ST-09093 merged on 2026-08-04 as PR #169 / commit `f54a2f5c`; removed from the active queue, archived as done, and `ST-09094` followed by `ST-11009` remains the dependency-ready Ready lane
+- ST-09094 moved to In Progress on 2026-08-05 as the next deterministic EP-09 Neo4j payload-boundary story; `ST-11009` remains in Ready
 
 - Complete: ST-01001 - foundation established (merged 2026-02-17)
 - Complete: ST-01002 - connection manager implemented (merged 2026-02-17)


### PR DESCRIPTION
## Story

ST-09094 — Harden Neo4j Property and Query Payload Contracts

## What Changed

- Harden Neo4j property, Cypher parameter, node-helper, connection result, and embedding error boundaries.
- Preserve serialization, parameter binding, identifier sanitization, provider error handling, and public tool result shapes.
- Add focused runtime and compile-time coverage plus story documentation.

## Acceptance Criteria Coverage

- [x] Replace remaining Neo4j `any` payload seams with compatible unknown-first or JSON-safe contracts.
- [x] Preserve existing Neo4j behavior and public result shapes.
- [x] Cover supported and unsupported properties, null-prototype maps, sanitized parameters, and provider failures.
- [x] Pass tools tests, typecheck, explicit-any baseline, full tests, workspace lint, and build.
- [x] Add `docs/st09094-neo4j-property-query-contracts.md`.

## Test Strategy

Test-first focused coverage for the Neo4j property serialization, query sanitization, and embedding-provider error seams, followed by the canonical package and workspace validation commands.

## Validation Performed

Focused contract tests, tools typecheck, explicit-any baseline, complete tools suite, workspace lint, full workspace test suite, and workspace build all pass. The baseline scan improved to `45/289` warnings (`tools 26/67`) without changing the committed cap file.

## Status

Ready for review.
