### PR TITLE
fix: harden skill agent filesystem guidance (ST-11009)

### DIFF
--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -261,7 +261,7 @@ import { createModelSafeToolPreset } from '@agentforge/tools';
 
 const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
 const { fileTools, directoryTools } = createModelSafeToolPreset({
-  fileSystem: { workspaceRoot: path.join(__dirname, '..') },
+  fileSystem: { workspaceRoot: process.cwd() },
 });
 
 // 4. Create the LLM

--- a/docs-site/tutorials/skill-powered-agent.md
+++ b/docs-site/tutorials/skill-powered-agent.md
@@ -257,11 +257,12 @@ The `toActivationTools()` method returns two tools pre-wired to the registry:
 
 ```typescript
 // 3. Get activation tools + file tools that skills reference
-import { createFileReaderTool, createFileSearchTool } from '@agentforge/tools';
+import { createModelSafeToolPreset } from '@agentforge/tools';
 
 const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
-const fileReader = createFileReaderTool();
-const fileSearch = createFileSearchTool();
+const { fileTools, directoryTools } = createModelSafeToolPreset({
+  fileSystem: { workspaceRoot: path.join(__dirname, '..') },
+});
 
 // 4. Create the LLM
 const llm = new ChatOpenAI({
@@ -272,7 +273,7 @@ const llm = new ChatOpenAI({
 // 5. Build the agent with skill tools + file tools
 const agent = createReActAgent({
   model: llm,
-  tools: [activateSkill, readSkillResource, fileReader, fileSearch],
+  tools: [activateSkill, readSkillResource, ...fileTools, ...directoryTools],
   systemPrompt: `You are a coding assistant with access to specialized skills.
 
 ${skillPrompt}
@@ -283,6 +284,8 @@ then follow those instructions to complete the task.
 Use read-skill-resource to load any referenced templates or files.`,
 });
 ```
+
+The activation tools intentionally remain separate: `read-skill-resource` applies the registry's skill-root trust policy to references and scripts. The preset is for model-controlled project paths and requires an explicit `workspaceRoot` (or `allowedRoots`); it rejects `..` traversal, symlink escapes, and absolute paths outside that boundary. Unrestricted filesystem factories are reserved for trusted local automation. See the repository [security policy](https://github.com/TVScoundrel/agentforge/blob/main/SECURITY.md) for the complete boundary model.
 
 ## Step 7: Run Your Skill-Powered Agent
 
@@ -393,7 +396,7 @@ Here's the full `src/index.ts` putting it all together:
 ```typescript
 import { SkillRegistry, SkillRegistryEvent } from '@agentforge/skills';
 import { createReActAgent } from '@agentforge/patterns';
-import { createFileReaderTool, createFileSearchTool } from '@agentforge/tools';
+import { createModelSafeToolPreset } from '@agentforge/tools';
 import { ChatOpenAI } from '@langchain/openai';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -426,15 +429,16 @@ skillRegistry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, (data) => {
 // 3. Generate prompt and tools
 const skillPrompt = skillRegistry.generatePrompt();
 const [activateSkill, readSkillResource] = skillRegistry.toActivationTools();
-const fileReader = createFileReaderTool();
-const fileSearch = createFileSearchTool();
+const { fileTools, directoryTools } = createModelSafeToolPreset({
+  fileSystem: { workspaceRoot: path.join(__dirname, '..') },
+});
 
 // 4. Create agent
 const llm = new ChatOpenAI({ modelName: 'gpt-4o', temperature: 0 });
 
 const agent = createReActAgent({
   model: llm,
-  tools: [activateSkill, readSkillResource, fileReader, fileSearch],
+  tools: [activateSkill, readSkillResource, ...fileTools, ...directoryTools],
   systemPrompt: `You are a coding assistant with access to specialized skills.
 
 ${skillPrompt}

--- a/docs/st11009-skill-agent-filesystem-guidance.md
+++ b/docs/st11009-skill-agent-filesystem-guidance.md
@@ -1,0 +1,17 @@
+# ST-11009: Skill Agent Filesystem Guidance
+
+## Decision
+
+Model-facing file and directory tools in the skill-powered-agent guidance now come from `createModelSafeToolPreset` and require an explicit workspace root. The standalone unrestricted filesystem factories remain available only for trusted, operator-controlled automation.
+
+Skill activation and resource loading remain separate. `SkillRegistry.toActivationTools()` continues to enforce skill-root trust, including the distinction between trusted workspace resources and untrusted scripts; generic filesystem tools do not replace that path.
+
+## Validation Strategy
+
+The example exports its model-facing filesystem setup through `createWorkspaceFileTools`. Focused automated coverage verifies that a relative workspace file remains readable while both traversal and absolute outside-root paths are rejected. The example-local Vitest configuration makes this validation directly runnable without expanding the root test-project include patterns.
+
+No CI workflow file change is required. The example is registered in `pnpm-workspace.yaml` so repository install and recursive typecheck paths can include it, while the example exposes a focused `test` script for its boundary behavior.
+
+## Security Boundary
+
+The shared preset enforces the repository policy described in [`SECURITY.md`](../SECURITY.md). Callers must provide `workspaceRoot` or `allowedRoots`; privileged opt-outs are intentionally not honored by the model-safe preset.

--- a/examples/applications/skill-aware-agent/README.md
+++ b/examples/applications/skill-aware-agent/README.md
@@ -10,6 +10,7 @@ Demonstrates an AgentForge agent that discovers, activates, and uses skills from
 4. **Resource loading** — Agent calls `read-skill-resource` to load reference docs
 5. **Trust enforcement** — Scripts from untrusted roots are blocked
 6. **Mixed trust levels** — Workspace skills have full access, community skills are restricted
+7. **Confined model file access** — Model-facing file and directory tools use `createModelSafeToolPreset` with an explicit repository root
 
 ## Skill Roots
 
@@ -32,3 +33,13 @@ The demo runs without an actual LLM call — it demonstrates the framework integ
 3. Creating activation tools
 4. Simulating skill activation and resource loading
 5. Demonstrating trust policy enforcement (script blocked from untrusted root)
+6. Creating model-facing filesystem tools that reject traversal and paths outside the repository root
+
+`SkillRegistry.toActivationTools()` remains the trusted path for loading skill resources. Do not replace it with generic filesystem tools. Conversely, do not expose unrestricted file/directory factories to a model: use `createModelSafeToolPreset` with an explicit `workspaceRoot` or `allowedRoots`. See the repository [security policy](../../../SECURITY.md) for the boundary model.
+
+## Validation
+
+```bash
+pnpm --dir examples/applications/skill-aware-agent test
+pnpm --dir examples/applications/skill-aware-agent typecheck
+```

--- a/examples/applications/skill-aware-agent/package.json
+++ b/examples/applications/skill-aware-agent/package.json
@@ -5,16 +5,20 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "lint": "eslint src",
     "start": "tsx src/index.ts",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@agentforge/core": "workspace:*",
-    "@agentforge/skills": "workspace:*"
+    "@agentforge/skills": "workspace:*",
+    "@agentforge/tools": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/examples/applications/skill-aware-agent/src/filesystem-tools.test.ts
+++ b/examples/applications/skill-aware-agent/src/filesystem-tools.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createWorkspaceFileTools } from './filesystem-tools.js';
 
@@ -24,15 +24,18 @@ describe('skill-aware agent filesystem tools', () => {
 
   it('preserves workspace reads while rejecting traversal and outside-root access', async () => {
     const { fileTools } = createWorkspaceFileTools(workspaceRoot);
-    const fileReader = fileTools[0] as {
+    const fileReader = fileTools.find((tool) => tool.metadata.name === 'file-reader') as {
       invoke(input: { path: string }): Promise<unknown>;
-    };
+    } | undefined;
+    if (!fileReader) {
+      throw new Error('Expected model-safe preset to include file-reader');
+    }
 
     await expect(fileReader.invoke({ path: 'inside.ts' })).resolves.toMatchObject({
       success: true,
       data: { content: 'export const inside = true;' },
     });
-    await expect(fileReader.invoke({ path: join('..', outsideRoot.split('/').at(-1)!, 'outside.ts') }))
+    await expect(fileReader.invoke({ path: join('..', basename(outsideRoot), 'outside.ts') }))
       .resolves.toMatchObject({ success: false, error: expect.stringContaining('path traversal') });
     await expect(fileReader.invoke({ path: join(outsideRoot, 'outside.ts') })).resolves.toMatchObject({
       success: false,

--- a/examples/applications/skill-aware-agent/src/filesystem-tools.test.ts
+++ b/examples/applications/skill-aware-agent/src/filesystem-tools.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorkspaceFileTools } from './filesystem-tools.js';
+
+describe('skill-aware agent filesystem tools', () => {
+  let workspaceRoot: string;
+  let outsideRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'skill-aware-workspace-'));
+    outsideRoot = await mkdtemp(join(tmpdir(), 'skill-aware-outside-'));
+    await writeFile(join(workspaceRoot, 'inside.ts'), 'export const inside = true;');
+    await writeFile(join(outsideRoot, 'outside.ts'), 'export const outside = true;');
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      rm(workspaceRoot, { recursive: true, force: true }),
+      rm(outsideRoot, { recursive: true, force: true }),
+    ]);
+  });
+
+  it('preserves workspace reads while rejecting traversal and outside-root access', async () => {
+    const { fileTools } = createWorkspaceFileTools(workspaceRoot);
+    const fileReader = fileTools[0] as {
+      invoke(input: { path: string }): Promise<unknown>;
+    };
+
+    await expect(fileReader.invoke({ path: 'inside.ts' })).resolves.toMatchObject({
+      success: true,
+      data: { content: 'export const inside = true;' },
+    });
+    await expect(fileReader.invoke({ path: join('..', outsideRoot.split('/').at(-1)!, 'outside.ts') }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining('path traversal') });
+    await expect(fileReader.invoke({ path: join(outsideRoot, 'outside.ts') })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining('outside the allowed roots'),
+    });
+  });
+});

--- a/examples/applications/skill-aware-agent/src/filesystem-tools.ts
+++ b/examples/applications/skill-aware-agent/src/filesystem-tools.ts
@@ -1,0 +1,14 @@
+import { createModelSafeToolPreset } from '@agentforge/tools';
+
+/**
+ * Creates only the model-facing filesystem tools for this example.
+ * Skill activation/resource tools remain governed by SkillRegistry trust policy.
+ */
+export function createWorkspaceFileTools(workspaceRoot: string) {
+  const preset = createModelSafeToolPreset({ fileSystem: { workspaceRoot } });
+  return {
+    fileTools: preset.fileTools,
+    directoryTools: preset.directoryTools,
+    tools: [...preset.fileTools, ...preset.directoryTools],
+  };
+}

--- a/examples/applications/skill-aware-agent/src/index.ts
+++ b/examples/applications/skill-aware-agent/src/index.ts
@@ -18,8 +18,10 @@ import {
   SkillRegistryEvent,
   type SkillRegistryConfig,
 } from '@agentforge/skills';
+import { createWorkspaceFileTools } from './filesystem-tools.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(__dirname, '../../../..');
 
 // ─── Configuration ───────────────────────────────────────────────────────
 
@@ -68,6 +70,11 @@ async function main(): Promise<void> {
   // ── 4. Obtain activation tools ─────────────────────────────────────
   const [activateSkill, readResource] = registry.toActivationTools();
   console.log(`🔧 Activation tools ready: ${activateSkill.metadata.name}, ${readResource.metadata.name}\n`);
+
+  // These tools may receive model-controlled paths, so they require an explicit
+  // workspace boundary. Skill resources continue through the registry tools above.
+  const workspaceFileTools = createWorkspaceFileTools(workspaceRoot);
+  console.log(`🔒 Model-facing workspace file tools ready: ${workspaceFileTools.tools.length}\n`);
 
   // ── 5. Activate skills ─────────────────────────────────────────────
   console.log('── Activate workspace skill: code-review ──');

--- a/examples/applications/skill-aware-agent/tsconfig.json
+++ b/examples/applications/skill-aware-agent/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"

--- a/examples/applications/skill-aware-agent/vitest.config.ts
+++ b/examples/applications/skill-aware-agent/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -324,5 +324,6 @@
   - Pre-existing incompatibility resolved: the example extended missing `tsconfig.base.json` and was absent from `pnpm-workspace.yaml`; it now extends the repository `tsconfig.json` and is a linked workspace project.
 - [x] Commit completed checklist items and push updates
   - Implementation commit `d7e1fb20` pushed to the story branch; draft PR #171 opened on 2026-08-07.
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Mark the PR Ready only after all story tasks are complete
+  - PR #171 marked ready for review on 2026-08-07 after acceptance criteria, focused validation, full validation, and self-review completed.
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -322,6 +322,7 @@
   - Example evidence: `pnpm --dir examples/applications/skill-aware-agent lint`, `test` (1 passed), and `typecheck` all pass.
   - Full validation evidence: `pnpm test` passes (231 files passed, 9 skipped; 2564 tests passed, 110 skipped), `pnpm lint` passes with existing warnings, and `pnpm typecheck` passes.
   - Pre-existing incompatibility resolved: the example extended missing `tsconfig.base.json` and was absent from `pnpm-workspace.yaml`; it now extends the repository `tsconfig.json` and is a linked workspace project.
-- [ ] Commit completed checklist items and push updates
+- [x] Commit completed checklist items and push updates
+  - Implementation commit `d7e1fb20` pushed to the story branch; draft PR #171 opened on 2026-08-07.
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-11-story-tasks.md
+++ b/planning/checklists/epic-11-story-tasks.md
@@ -309,13 +309,19 @@
 **Branch:** `fix/st-11009-skill-agent-filesystem-guidance`
 
 ### Checklist
-- [ ] Create branch `fix/st-11009-skill-agent-filesystem-guidance` from `main`
-- [ ] Replace unrestricted model-facing file-tool setup in the skill-powered-agent tutorial and example with a shared filesystem policy or `createModelSafeToolPreset`
-- [ ] Preserve trusted workspace-skill resource loading and intended file-search/read behavior while requiring an explicit root
-- [ ] Add focused example or documentation validation for traversal and outside-root rejection
-- [ ] Update README/tutorial/API guidance and cross-link `SECURITY.md`
-- [ ] Add or update story documentation at `docs/st11009-skill-agent-filesystem-guidance.md`
-- [ ] Run supported example tests, lint, and typecheck; record any pre-existing example-only incompatibility
+- [x] Create branch `fix/st-11009-skill-agent-filesystem-guidance` from `main`
+- [x] Replace unrestricted model-facing file-tool setup in the skill-powered-agent tutorial and example with a shared filesystem policy or `createModelSafeToolPreset`
+- [x] Preserve trusted workspace-skill resource loading and intended file-search/read behavior while requiring an explicit root
+- [x] Add focused example or documentation validation for traversal and outside-root rejection
+  - Test-first decision (2026-08-07): add focused automated coverage around an exported example filesystem-tool helper; the test must fail before the helper is implemented, then pass once it uses `createModelSafeToolPreset` with an explicit workspace root.
+- [x] Update README/tutorial/API guidance and cross-link `SECURITY.md`
+- [x] Add or update story documentation at `docs/st11009-skill-agent-filesystem-guidance.md`
+- [x] Run supported example tests, lint, and typecheck; record any pre-existing example-only incompatibility
+  - CI impact assessment (2026-08-07): no CI workflow file change is required; registering the existing example in `pnpm-workspace.yaml` lets the repository's recursive install/typecheck path cover it, while its package-local test script provides focused boundary validation.
+  - Red test evidence: before production implementation, root Vitest returned exit 1 because the standalone example test was outside every configured project include. This established the missing practical test seam; the example-local config was added with the implementation so the boundary test could run directly.
+  - Example evidence: `pnpm --dir examples/applications/skill-aware-agent lint`, `test` (1 passed), and `typecheck` all pass.
+  - Full validation evidence: `pnpm test` passes (231 files passed, 9 skipped; 2564 tests passed, 110 skipped), `pnpm lint` passes with existing warnings, and `pnpm typecheck` passes.
+  - Pre-existing incompatibility resolved: the example extended missing `tsconfig.base.json` and was absent from `pnpm-workspace.yaml`; it now extends the repository `tsconfig.json` and is a linked workspace project.
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2721,15 +2721,15 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-11003 and ST-11007 (merged)
-**Status:** Ready
+**Status:** In Progress
 
 **Acceptance criteria:**
-- [ ] Update the skill-powered-agent tutorial and example setup to use a shared filesystem policy or `createModelSafeToolPreset` for model-facing file and directory tools instead of unrestricted factories.
-- [ ] Preserve trusted workspace-skill resource loading and the example's intended file-search/read behavior while requiring an explicit workspace or allowed root.
-- [ ] Add focused example or documentation validation that the model-facing setup rejects traversal and outside-root access and clearly distinguishes trusted local automation from model-exposed tools.
-- [ ] Update the relevant README/tutorial/API guidance and cross-link the repository security policy without changing unrelated skill trust behavior.
-- [ ] Run the supported example tests, `pnpm lint`, and `pnpm typecheck` or document any pre-existing example-only incompatibility.
-- [ ] Add or update story documentation at `docs/st11009-skill-agent-filesystem-guidance.md`
+- [x] Update the skill-powered-agent tutorial and example setup to use a shared filesystem policy or `createModelSafeToolPreset` for model-facing file and directory tools instead of unrestricted factories.
+- [x] Preserve trusted workspace-skill resource loading and the example's intended file-search/read behavior while requiring an explicit workspace or allowed root.
+- [x] Add focused example or documentation validation that the model-facing setup rejects traversal and outside-root access and clearly distinguishes trusted local automation from model-exposed tools.
+- [x] Update the relevant README/tutorial/API guidance and cross-link the repository security policy without changing unrelated skill trust behavior.
+- [x] Run the supported example tests, `pnpm lint`, and `pnpm typecheck` or document any pre-existing example-only incompatibility.
+- [x] Add or update story documentation at `docs/st11009-skill-agent-filesystem-guidance.md`
 
 ---
 

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2721,7 +2721,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-11003 and ST-11007 (merged)
-**Status:** In Progress
+**Status:** In Review (PR #171)
 
 **Acceptance criteria:**
 - [x] Update the skill-powered-agent tutorial and example setup to use a shared filesystem policy or `createModelSafeToolPreset` for model-facing file and directory tools instead of unrestricted factories.

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
-**Last Updated:** 2026-08-06
-**Active Story:** No EP-11 story active; ST-11009 is Ready as a security-guidance follow-on.
+**Last Updated:** 2026-08-07
+**Active Story:** ST-11009 is in progress to align the skill-powered-agent example with the model-safe filesystem path.
 
 ---
 

--- a/planning/features/11-security-boundary-hardening-feature-plan.md
+++ b/planning/features/11-security-boundary-hardening-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-11 through EP-11
 **Status:** In Progress
 **Last Updated:** 2026-08-07
-**Active Story:** ST-11009 is in progress to align the skill-powered-agent example with the model-safe filesystem path.
+**Active Story:** ST-11009 is in review in PR #171 after aligning the skill-powered-agent example with the model-safe filesystem path.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,13 +20,13 @@ None currently.
 
 ## In Progress
 
-- `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance
+None currently.
 
 ---
 
 ## In Review
 
-None currently.
+- `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance (PR #171)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-08-06
+**Last Updated:** 2026-08-07
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,13 +14,13 @@
 
 ## Ready
 
-- `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance
+None currently.
 
 ---
 
 ## In Progress
 
-None currently.
+- `ST-11009` — Harden Skill-Powered Agent Filesystem Guidance
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,31 @@ importers:
         specifier: ^3.5.13
         version: 3.5.26(typescript@5.9.3)
 
+  examples/applications/skill-aware-agent:
+    dependencies:
+      '@agentforge/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@agentforge/skills':
+        specifier: workspace:*
+        version: link:../../../packages/skills
+      '@agentforge/tools':
+        specifier: workspace:*
+        version: link:../../../packages/tools
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.3)(@vitest/ui@2.1.9)
+
   packages/cli:
     dependencies:
       chalk:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'docs-site'
   - 'playground'
   - 'examples/reusable-agents/*'
+  - 'examples/applications/skill-aware-agent'
 allowBuilds:
   better-sqlite3: true
   cpu-features: true


### PR DESCRIPTION
## Story

ST-11009 — Harden Skill-Powered Agent Filesystem Guidance

## What Changed

- Replaced unrestricted model-facing filesystem examples with `createModelSafeToolPreset` configured with an explicit workspace root.
- Kept `SkillRegistry.toActivationTools()` separate so trusted workspace skill-resource loading retains its existing trust policy.
- Added a reusable example helper and focused traversal/outside-root regression coverage.
- Registered the skill-aware-agent example as a workspace project and corrected its stale TypeScript base config so its test, lint, and typecheck commands run.
- Updated the tutorial, example README, story documentation, Kanban tracker, epic tracker, and feature progress metadata.

## Acceptance Criteria Coverage

- Model-facing file and directory tools use the model-safe preset with an explicit root.
- Workspace reads/search remain available while traversal and absolute outside-root paths are rejected.
- Trusted skill resources continue through registry activation tools rather than generic filesystem tools.
- Guidance distinguishes model-exposed tools from trusted local automation and links to `SECURITY.md`.
- Focused example validation and repository-wide validation pass.

## Test Strategy

Test-first automated coverage was selected. The initial test run exposed that the standalone example had no Vitest project include, so an example-local test configuration was added. The focused test covers a valid workspace read, traversal rejection, and absolute outside-root rejection.

No CI workflow file change is required. Workspace registration makes the example installable and available to recursive validation, and its package-local scripts provide focused lint, test, and typecheck commands.

## Validation Performed

- `pnpm --dir examples/applications/skill-aware-agent lint` — passed
- `pnpm --dir examples/applications/skill-aware-agent test` — passed (1 test)
- `pnpm --dir examples/applications/skill-aware-agent typecheck` — passed
- `pnpm test` — passed (231 files passed, 9 skipped; 2,564 tests passed, 110 skipped)
- `pnpm lint` — passed with existing warnings
- `pnpm typecheck` — passed
- `git diff --check` — passed

## Status

All story tasks and validation gates are complete. Ready for review; merge remains reviewer-controlled.
