### PR TITLE
ST-09099: Normalize Default Node Metrics Namespaces

### DIFF
--- a/docs/st09099-default-node-metrics-namespaces.md
+++ b/docs/st09099-default-node-metrics-namespaces.md
@@ -1,0 +1,13 @@
+# ST-09099: Normalize Default Node Metrics Namespaces
+
+## Outcome
+
+`withMetrics(...)` now sends unqualified metric suffixes to collectors it creates itself. The collector namespace supplies the node name, so default metrics are emitted as `<node>.invocations`, `<node>.success`, `<node>.errors`, and `<node>.duration`.
+
+Callers that provide a shared collector continue to receive node-qualified suffixes, preserving distinguishability between multiple instrumented nodes under one collector namespace.
+
+## Validation and decisions
+
+- Test-first regression coverage was added in `packages/core/tests/langgraph/observability/default-node-instrumentation.test.ts`; the test failed before the production change with duplicated `my-node.my-node.*` output at the collector boundary.
+- Existing metrics coverage continues to verify shared-collector naming, synchronous/asynchronous results, error identity and rethrow, duration tracking, and disabled tracking options.
+- No CI or validation automation change is required; the existing core test, typecheck, lint, baseline, and workspace test commands cover this behavior.

--- a/packages/core/src/langgraph/observability/metrics/node-instrumentation.ts
+++ b/packages/core/src/langgraph/observability/metrics/node-instrumentation.ts
@@ -11,19 +11,22 @@ export function withMetrics<State>(
     trackDuration = true,
     trackErrors = true,
     trackInvocations = true,
-    metrics = createMetrics(name),
+    metrics: providedMetrics,
   } = options;
+  const metrics = providedMetrics ?? createMetrics(name);
+  const metricSuffix = (suffix: string): string =>
+    providedMetrics ? `${name}.${suffix}` : suffix;
 
   return async (state: State): Promise<State | Partial<State>> => {
-    if (trackInvocations) metrics.increment(`${name}.invocations`);
-    const timer = trackDuration ? metrics.startTimer(`${name}.duration`) : null;
+    if (trackInvocations) metrics.increment(metricSuffix('invocations'));
+    const timer = trackDuration ? metrics.startTimer(metricSuffix('duration')) : null;
 
     try {
       const result = await Promise.resolve(node(state));
-      metrics.increment(`${name}.success`);
+      metrics.increment(metricSuffix('success'));
       return result;
     } catch (error) {
-      if (trackErrors) metrics.increment(`${name}.errors`);
+      if (trackErrors) metrics.increment(metricSuffix('errors'));
       throw error;
     } finally {
       timer?.end();

--- a/packages/core/tests/langgraph/observability/default-node-instrumentation.test.ts
+++ b/packages/core/tests/langgraph/observability/default-node-instrumentation.test.ts
@@ -37,8 +37,10 @@ describe('withMetrics default collector', () => {
     await expect(metricNode({ count: 0 })).resolves.toEqual({ count: 1 });
 
     expect(createMetricsMock).toHaveBeenCalledWith('my-node');
-    expect(metricsMock.increment).toHaveBeenCalledWith('invocations');
-    expect(metricsMock.increment).toHaveBeenCalledWith('success');
+    expect(metricsMock.increment).toHaveBeenCalledTimes(2);
+    expect(metricsMock.increment).toHaveBeenNthCalledWith(1, 'invocations');
+    expect(metricsMock.increment).toHaveBeenNthCalledWith(2, 'success');
+    expect(metricsMock.startTimer).toHaveBeenCalledTimes(1);
     expect(metricsMock.startTimer).toHaveBeenCalledWith('duration');
   });
 
@@ -50,6 +52,10 @@ describe('withMetrics default collector', () => {
 
     await expect(metricNode({ count: 0 })).rejects.toBe(error);
 
-    expect(metricsMock.increment).toHaveBeenCalledWith('errors');
+    expect(metricsMock.increment).toHaveBeenCalledTimes(2);
+    expect(metricsMock.increment).toHaveBeenNthCalledWith(1, 'invocations');
+    expect(metricsMock.increment).toHaveBeenNthCalledWith(2, 'errors');
+    expect(metricsMock.startTimer).toHaveBeenCalledTimes(1);
+    expect(metricsMock.startTimer).toHaveBeenCalledWith('duration');
   });
 });

--- a/packages/core/tests/langgraph/observability/default-node-instrumentation.test.ts
+++ b/packages/core/tests/langgraph/observability/default-node-instrumentation.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Metrics } from '../../../src/langgraph/observability/metrics/contracts.js';
+
+const { createMetricsMock, metricsMock } = vi.hoisted(() => {
+  const metrics: Metrics = {
+    increment: vi.fn(),
+    decrement: vi.fn(),
+    gauge: vi.fn(),
+    histogram: vi.fn(),
+    startTimer: vi.fn(() => ({ end: vi.fn() })),
+    getMetrics: vi.fn(() => []),
+    clear: vi.fn(),
+  };
+
+  return {
+    createMetricsMock: vi.fn(() => metrics),
+    metricsMock: metrics,
+  };
+});
+
+vi.mock('../../../src/langgraph/observability/metrics/collector.js', () => ({
+  createMetrics: createMetricsMock,
+}));
+
+import { withMetrics } from '../../../src/langgraph/observability/metrics/node-instrumentation.js';
+
+describe('withMetrics default collector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses unqualified suffixes with the node namespace supplied by the collector', async () => {
+    const metricNode = withMetrics((state: { count: number }) => ({ count: state.count + 1 }), {
+      name: 'my-node',
+    });
+
+    await expect(metricNode({ count: 0 })).resolves.toEqual({ count: 1 });
+
+    expect(createMetricsMock).toHaveBeenCalledWith('my-node');
+    expect(metricsMock.increment).toHaveBeenCalledWith('invocations');
+    expect(metricsMock.increment).toHaveBeenCalledWith('success');
+    expect(metricsMock.startTimer).toHaveBeenCalledWith('duration');
+  });
+
+  it('uses an unqualified error suffix and rethrows the original error', async () => {
+    const error = new Error('Test error');
+    const metricNode = withMetrics(() => {
+      throw error;
+    }, { name: 'error-node' });
+
+    await expect(metricNode({ count: 0 })).rejects.toBe(error);
+
+    expect(metricsMock.increment).toHaveBeenCalledWith('errors');
+  });
+});

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -4067,8 +4067,10 @@ Implementation notes:
 - [x] Add or update story documentation at `docs/st09099-default-node-metrics-namespaces.md` (or document why not required)
 - [x] Assess CI/validation impact and update automation if required, or record why no CI change is needed
   - No CI change required; existing core and workspace validation commands cover the changed source and tests.
-- [ ] Run full test suite before finalizing the PR and record results
-- [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
+- [x] Run full test suite before finalizing the PR and record results
+  - `pnpm test --run` -> exit `0`; full workspace Vitest run passed.
+- [x] Run lint (`pnpm lint`) before finalizing the PR and record results
+  - `pnpm lint` -> exit `0`; existing warnings only (`0` errors).
 - [ ] Commit completed checklist items and push updates
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -4053,7 +4053,8 @@ Implementation notes:
 
 ### Checklist
 - [x] Create branch `fix/st-09099-default-node-metrics-namespaces` from `main`
-- [ ] Create draft PR with ST-09099 in the title
+- [x] Create draft PR with ST-09099 in the title
+  - PR #176: https://github.com/TVScoundrel/agentforge/pull/176
 - [x] Define test strategy before implementation: cover default-collector naming, shared-collector naming, success/error/duration samples, tracking options, and the first failing regression test
   - Test-first automated coverage: existing shared-collector tests cover success, async results, errors, duration, and disabled tracking; a dedicated mocked default-collector suite asserts that `withMetrics` sends unqualified suffixes to the collector created for the node namespace.
 - [x] Write the failing automated regression test for the duplicated default namespace before production changes
@@ -4071,6 +4072,8 @@ Implementation notes:
   - `pnpm test --run` -> exit `0`; full workspace Vitest run passed.
 - [x] Run lint (`pnpm lint`) before finalizing the PR and record results
   - `pnpm lint` -> exit `0`; existing warnings only (`0` errors).
-- [ ] Commit completed checklist items and push updates
+- [x] Commit completed checklist items and push updates
+  - `88c64d30` `fix(st-09099): normalize default metrics namespaces`
+  - `d9b8497d` `docs(st-09099): record validation and active tracking`
 - [ ] Mark the PR Ready only after all story tasks are complete
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -4075,5 +4075,6 @@ Implementation notes:
 - [x] Commit completed checklist items and push updates
   - `88c64d30` `fix(st-09099): normalize default metrics namespaces`
   - `d9b8497d` `docs(st-09099): record validation and active tracking`
-- [ ] Mark the PR Ready only after all story tasks are complete
+- [x] Mark the PR Ready only after all story tasks are complete
+  - PR #176 marked ready for review: https://github.com/TVScoundrel/agentforge/pull/176
 - [ ] Wait for merge; do not merge directly from local branch

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -4052,16 +4052,21 @@ Implementation notes:
 **Branch:** `fix/st-09099-default-node-metrics-namespaces`
 
 ### Checklist
-- [ ] Create branch `fix/st-09099-default-node-metrics-namespaces` from `main`
+- [x] Create branch `fix/st-09099-default-node-metrics-namespaces` from `main`
 - [ ] Create draft PR with ST-09099 in the title
-- [ ] Define test strategy before implementation: cover default-collector naming, shared-collector naming, success/error/duration samples, tracking options, and the first failing regression test
-- [ ] Write the failing automated regression test for the duplicated default namespace before production changes
-- [ ] Normalize metric suffix selection so default collectors do not repeat the node name while shared collectors retain node-qualified suffixes
-- [ ] Preserve the public API, synchronous/asynchronous results, error identity, duration tracking, and disabled tracking semantics
-- [ ] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
-- [ ] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-- [ ] Add or update story documentation at `docs/st09099-default-node-metrics-namespaces.md` (or document why not required)
-- [ ] Assess CI/validation impact and update automation if required, or record why no CI change is needed
+- [x] Define test strategy before implementation: cover default-collector naming, shared-collector naming, success/error/duration samples, tracking options, and the first failing regression test
+  - Test-first automated coverage: existing shared-collector tests cover success, async results, errors, duration, and disabled tracking; a dedicated mocked default-collector suite asserts that `withMetrics` sends unqualified suffixes to the collector created for the node namespace.
+- [x] Write the failing automated regression test for the duplicated default namespace before production changes
+  - Added `default-node-instrumentation.test.ts`; focused test currently fails because `withMetrics` sends `my-node.invocations`, `my-node.success`, and `my-node.duration` to the default collector.
+- [x] Normalize metric suffix selection so default collectors do not repeat the node name while shared collectors retain node-qualified suffixes
+- [x] Preserve the public API, synchronous/asynchronous results, error identity, duration tracking, and disabled tracking semantics
+- [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
+  - `pnpm --filter @agentforge/core test --run tests/langgraph/observability/default-node-instrumentation.test.ts tests/langgraph/observability/metrics.test.ts` -> 2 files, 11 tests passed.
+- [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
+  - Added default-collector success/error coverage; existing shared-collector tests cover async results, duration, disabled tracking, and error identity.
+- [x] Add or update story documentation at `docs/st09099-default-node-metrics-namespaces.md` (or document why not required)
+- [x] Assess CI/validation impact and update automation if required, or record why no CI change is needed
+  - No CI change required; existing core and workspace validation commands cover the changed source and tests.
 - [ ] Run full test suite before finalizing the PR and record results
 - [ ] Run lint (`pnpm lint`) before finalizing the PR and record results
 - [ ] Commit completed checklist items and push updates

--- a/planning/checklists/epic-09-story-tasks.md
+++ b/planning/checklists/epic-09-story-tasks.md
@@ -4064,7 +4064,7 @@ Implementation notes:
 - [x] Add/update production code until focused tests pass, keeping test evidence in checklist notes and PR body
   - `pnpm --filter @agentforge/core test --run tests/langgraph/observability/default-node-instrumentation.test.ts tests/langgraph/observability/metrics.test.ts` -> 2 files, 11 tests passed.
 - [x] Assess residual test impact; add/update additional automated tests when needed, or document why no further tests are required
-  - Added default-collector success/error coverage; existing shared-collector tests cover async results, duration, disabled tracking, and error identity.
+  - Added default-collector success/error coverage with exact call counts and ordered suffix assertions; existing shared-collector tests cover async results, duration, disabled tracking, and error identity.
 - [x] Add or update story documentation at `docs/st09099-default-node-metrics-namespaces.md` (or document why not required)
 - [x] Assess CI/validation impact and update automation if required, or record why no CI change is needed
   - No CI change required; existing core and workspace validation commands cover the changed source and tests.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2547,7 +2547,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09095
-**Status:** Backlog
+**Status:** In Progress
 
 **Acceptance criteria:**
 - [ ] When `withMetrics(...)` creates its default collector, invocation, success, error, and duration samples use `<node>.invocations`, `<node>.success`, `<node>.errors`, and `<node>.duration` rather than `<node>.<node>.*`.

--- a/planning/epics-and-stories.md
+++ b/planning/epics-and-stories.md
@@ -2547,7 +2547,7 @@
 **Priority:** P2 (Medium)
 **Estimate:** 2 hours
 **Dependencies:** ST-09095
-**Status:** In Progress
+**Status:** In Review
 
 **Acceptance criteria:**
 - [ ] When `withMetrics(...)` creates its default collector, invocation, success, error, and duration samples use `<node>.invocations`, `<node>.success`, `<node>.errors`, and `<node>.duration` rather than `<node>.<node>.*`.

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -2,8 +2,8 @@
 
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
-**Last Updated:** 2026-08-12
-**Active Story:** ST-09098 merged in PR #175; ST-09099 is the next dependency-ready story in Ready.
+**Last Updated:** 2026-08-20
+**Active Story:** ST-09099 is implemented locally on `fix/st-09099-default-node-metrics-namespaces`; remote PR creation is pending push authorization.
 
 ---
 

--- a/planning/features/09-solid-micro-refactors-feature-plan.md
+++ b/planning/features/09-solid-micro-refactors-feature-plan.md
@@ -3,7 +3,7 @@
 **Epic Range:** EP-09 through EP-09
 **Status:** In Progress
 **Last Updated:** 2026-08-20
-**Active Story:** ST-09099 is implemented locally on `fix/st-09099-default-node-metrics-namespaces`; remote PR creation is pending push authorization.
+**Active Story:** ST-09099 is in review in PR #176 from `fix/st-09099-default-node-metrics-namespaces`.
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -5,8 +5,8 @@
 ## Queue Status Summary
 
 - **Ready:** 0 stories
-- **In Progress:** 1 story
-- **In Review:** 0 stories
+- **In Progress:** 0 stories
+- **In Review:** 1 story
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
 
@@ -20,12 +20,13 @@ None currently.
 
 ## In Progress
 
-- `ST-09099` — Normalize Default Node Metrics Namespaces
-  - Depends on: ST-09095 (merged, PR #172)
+None currently.
 
 ## In Review
 
-None currently.
+- `ST-09099` — Normalize Default Node Metrics Namespaces
+  - Depends on: ST-09095 (merged, PR #172)
+  - PR: #176 (draft; local validation complete)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -26,7 +26,7 @@ None currently.
 
 - `ST-09099` — Normalize Default Node Metrics Namespaces
   - Depends on: ST-09095 (merged, PR #172)
-  - PR: #176 (draft; local validation complete)
+  - PR: #176 (ready for review; local validation complete)
 
 ---
 

--- a/planning/kanban-queue.md
+++ b/planning/kanban-queue.md
@@ -1,11 +1,11 @@
 # Kanban Queue: AgentForge
 
-**Last Updated:** 2026-08-10
+**Last Updated:** 2026-08-20
 
 ## Queue Status Summary
 
-- **Ready:** 1 story
-- **In Progress:** 0 stories
+- **Ready:** 0 stories
+- **In Progress:** 1 story
 - **In Review:** 0 stories
 - **Blocked:** 0 stories
 - **Backlog:** 0 stories
@@ -14,14 +14,14 @@
 
 ## Ready
 
-- `ST-09099` — Normalize Default Node Metrics Namespaces
-  - Depends on: ST-09095 (merged, PR #172)
+None currently.
 
 ---
 
 ## In Progress
 
-None currently.
+- `ST-09099` — Normalize Default Node Metrics Namespaces
+  - Depends on: ST-09095 (merged, PR #172)
 
 ## In Review
 


### PR DESCRIPTION
## Story

ST-09099 — Normalize Default Node Metrics Namespaces

## What Changed

- Default collectors created by `withMetrics(...)` now receive unqualified metric suffixes.
- Shared collectors retain node-qualified suffixes for multi-node distinguishability.
- Added test-first default-collector regression coverage and story documentation.

## Acceptance Criteria Coverage

- Default samples use `<node>.invocations`, `<node>.success`, `<node>.errors`, and `<node>.duration`.
- Shared-collector naming, API behavior, async results, error identity/rethrow, duration, tracking defaults, and disabled tracking remain covered.

## Test Strategy

Test-first automated coverage: the default collector test failed before implementation because node-qualified suffixes were passed into the node-namespaced collector; existing shared-collector coverage remains in place.

## Validation Performed

- Focused core metrics tests: 2 files, 11 tests passed.
- `pnpm --filter @agentforge/core typecheck`: passed.
- `pnpm test --run`: passed.
- `pnpm lint`: passed with existing warnings and 0 errors.
- `pnpm lint:explicit-any:baseline`: passed at 45/289.

## Status

Implementation and local validation complete. PR is ready for review; do not merge from this task.
