### PR TITLE
Worker lifecycle: validate admission through the factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 Issues and specs are tracked in GitHub Issues for `TVScoundrel/agentforge`. See `docs/agents/issue-tracker.md`.
 
+### Ticket delivery
+
+Deliver every ticket through a feature-branch pull request that references the ticket. Ticket implementation is complete only when the branch is pushed and the pull request URL exists.
+
 ### Triage labels
 
 Use the five default triage labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.

--- a/packages/patterns/src/index.ts
+++ b/packages/patterns/src/index.ts
@@ -19,16 +19,16 @@ export {
   type ToolCall,
   type ToolResult,
   type ScratchpadEntry,
-  
+
   // Types
   type ReActAgentConfig,
   type ReActAgentOptions,
   type ReActBuilderOptions,
   type StopConditionFn,
-  
+
   // Prompts
   DEFAULT_REACT_SYSTEM_PROMPT,
-  
+
   // Agent creation
   createReActAgent,
   ReActAgentBuilder,
@@ -181,6 +181,8 @@ export {
   createMultiAgentSystem,
   registerWorkers,
   MultiAgentSystemBuilder,
+  WorkerLifecycleError,
+  type WorkerLifecycleErrorReason,
 } from './multi-agent/index.js';
 
 // Shared utilities

--- a/packages/patterns/src/multi-agent/agent-graph.ts
+++ b/packages/patterns/src/multi-agent/agent-graph.ts
@@ -1,12 +1,12 @@
 import { END, StateGraph } from '@langchain/langgraph';
 import { createPatternLogger } from '../shared/deduplication.js';
 import { createAggregatorNode, createSupervisorNode, createWorkerNode } from './nodes.js';
-import type { WorkerCapabilities } from './schemas.js';
 import { MultiAgentState } from './state.js';
 import type { MultiAgentStateType } from './state.js';
 import type { MultiAgentSystemWithRegistry } from './agent-types.js';
 import type { MultiAgentRouter, MultiAgentSystemConfig } from './types.js';
 import { wrapCompiledSystem } from './agent-runtime.js';
+import { admitWorkerTopology, type WorkerLifecycle } from './worker-lifecycle.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
 
@@ -30,7 +30,7 @@ function createSupervisorRouter(): MultiAgentRouter {
 
     if (state.currentAgent && state.currentAgent !== 'supervisor') {
       if (state.currentAgent.includes(',')) {
-        const agents = state.currentAgent.split(',').map(agent => agent.trim());
+        const agents = state.currentAgent.split(',').map((agent) => agent.trim());
         logger.info('Supervisor router: parallel routing', {
           agents,
           count: agents.length,
@@ -72,35 +72,24 @@ function createAggregatorRouter(): MultiAgentRouter {
 
 export function createCompiledMultiAgentSystem(
   config: MultiAgentSystemConfig,
+  lifecycle: WorkerLifecycle = admitWorkerTopology(config.workers)
 ): MultiAgentSystemWithRegistry {
-  const {
-    supervisor,
-    workers,
-    aggregator,
-    maxIterations = 10,
-    verbose = false,
-    checkpointer,
-  } = config;
+  const { supervisor, aggregator, maxIterations = 10, verbose = false, checkpointer } = config;
 
   const workflow = new StateGraph(MultiAgentState);
   const workerIds: string[] = [];
-  const workerCapabilities: Record<string, WorkerCapabilities> = {};
 
-  workflow.addNode(
-    'supervisor',
-    createSupervisorNode({ ...supervisor, maxIterations, verbose }),
-  );
+  workflow.addNode('supervisor', createSupervisorNode({ ...supervisor, maxIterations, verbose }));
 
-  for (const workerConfig of workers) {
+  for (const workerConfig of lifecycle.topology) {
     workflow.addNode(
       workerConfig.id,
       createWorkerNode({
         ...workerConfig,
         verbose,
-      }),
+      })
     );
     workerIds.push(workerConfig.id);
-    workerCapabilities[workerConfig.id] = workerConfig.capabilities;
   }
 
   workflow.addNode(
@@ -108,7 +97,7 @@ export function createCompiledMultiAgentSystem(
     createAggregatorNode({
       ...aggregator,
       verbose,
-    }),
+    })
   );
 
   const supervisorRouter = createSupervisorRouter();
@@ -129,8 +118,8 @@ export function createCompiledMultiAgentSystem(
   workflow.addConditionalEdges('aggregator', aggregatorRouter, [END]);
 
   const compiled = workflow.compile(
-    checkpointer ? { checkpointer } : undefined,
+    checkpointer ? { checkpointer } : undefined
   ) as unknown as MultiAgentSystemWithRegistry;
 
-  return wrapCompiledSystem(compiled, workerCapabilities);
+  return wrapCompiledSystem(compiled, lifecycle.workerCapabilities);
 }

--- a/packages/patterns/src/multi-agent/agent-runtime.ts
+++ b/packages/patterns/src/multi-agent/agent-runtime.ts
@@ -6,7 +6,7 @@ import { toWorkerCapabilities } from './agent-workers.js';
 
 function mergeWorkers(
   input: Partial<MultiAgentStateType>,
-  workerCapabilities: Record<string, WorkerCapabilities>,
+  workerCapabilities: Readonly<Record<string, WorkerCapabilities>>
 ): Partial<MultiAgentStateType> {
   return {
     ...input,
@@ -19,36 +19,30 @@ function mergeWorkers(
 
 export function wrapCompiledSystem(
   system: MultiAgentSystemWithRegistry,
-  workerCapabilities: Record<string, WorkerCapabilities>,
+  workerCapabilities: Readonly<Record<string, WorkerCapabilities>>
 ): MultiAgentSystemWithRegistry {
   const originalInvoke = system.invoke.bind(system);
-  system.invoke = (async function (
-    input: Partial<MultiAgentStateType>,
-    config?: RunnableConfig,
-  ) {
+  system.invoke = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
     return originalInvoke(
       mergeWorkers(input, workerCapabilities) as Parameters<typeof originalInvoke>[0],
-      config as Parameters<typeof originalInvoke>[1],
+      config as Parameters<typeof originalInvoke>[1]
     );
-  }) as unknown as typeof system.invoke;
+  } as unknown as typeof system.invoke;
 
   const originalStream = system.stream.bind(system);
-  system.stream = (async function (
-    input: Partial<MultiAgentStateType>,
-    config?: RunnableConfig,
-  ) {
+  system.stream = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
     return originalStream(
       mergeWorkers(input, workerCapabilities) as Parameters<typeof originalStream>[0],
-      config as Parameters<typeof originalStream>[1],
+      config as Parameters<typeof originalStream>[1]
     );
-  }) as unknown as typeof system.stream;
+  } as unknown as typeof system.stream;
 
   return system;
 }
 
 export function registerWorkerCapabilities(
   system: MultiAgentSystemWithRegistry,
-  workers: RegisterWorkerInput[],
+  workers: RegisterWorkerInput[]
 ): void {
   if (!system._workerRegistry) {
     system._workerRegistry = {};
@@ -60,31 +54,25 @@ export function registerWorkerCapabilities(
 
   if (!system._originalInvoke) {
     system._originalInvoke = system.invoke.bind(system);
-    system.invoke = (async function (
-      input: Partial<MultiAgentStateType>,
-      config?: RunnableConfig,
-    ) {
+    system.invoke = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
       return system._originalInvoke!(
         mergeWorkers(input, system._workerRegistry || {}) as Parameters<
           NonNullable<typeof system._originalInvoke>
         >[0],
-        config as Parameters<NonNullable<typeof system._originalInvoke>>[1],
+        config as Parameters<NonNullable<typeof system._originalInvoke>>[1]
       );
-    }) as unknown as typeof system.invoke;
+    } as unknown as typeof system.invoke;
   }
 
   if (!system._originalStream) {
     system._originalStream = system.stream.bind(system);
-    system.stream = (async function (
-      input: Partial<MultiAgentStateType>,
-      config?: RunnableConfig,
-    ) {
+    system.stream = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
       return system._originalStream!(
         mergeWorkers(input, system._workerRegistry || {}) as Parameters<
           NonNullable<typeof system._originalStream>
         >[0],
-        config as Parameters<NonNullable<typeof system._originalStream>>[1],
+        config as Parameters<NonNullable<typeof system._originalStream>>[1]
       );
-    }) as unknown as typeof system.stream;
+    } as unknown as typeof system.stream;
   }
 }

--- a/packages/patterns/src/multi-agent/agent-workers.ts
+++ b/packages/patterns/src/multi-agent/agent-workers.ts
@@ -1,34 +1,12 @@
 import type { WorkerCapabilities } from './schemas.js';
 import type { BuilderWorkerInput, RegisterWorkerInput } from './agent-types.js';
 import type { WorkerConfig } from './types.js';
-
-type ToolLike = {
-  metadata?: { name?: string };
-  name?: string;
-};
-
-export function getToolName(tool: unknown): string {
-  if (!tool || typeof tool !== 'object') {
-    return 'unknown';
-  }
-
-  const candidate = tool as ToolLike;
-
-  if (typeof candidate.metadata?.name === 'string') {
-    return candidate.metadata.name;
-  }
-
-  if (typeof candidate.name === 'string') {
-    return candidate.name;
-  }
-
-  return 'unknown';
-}
+import { normalizeWorkerToolNames } from './worker-lifecycle.js';
 
 export function toWorkerCapabilities(worker: RegisterWorkerInput): WorkerCapabilities {
   return {
     skills: worker.capabilities,
-    tools: worker.tools?.map(tool => getToolName(tool)) || [],
+    tools: [...normalizeWorkerToolNames(worker.name, worker.tools)],
     available: true,
     currentWorkload: 0,
   };
@@ -36,7 +14,7 @@ export function toWorkerCapabilities(worker: RegisterWorkerInput): WorkerCapabil
 
 export function toWorkerConfig(
   worker: BuilderWorkerInput,
-  fallbackModel: WorkerConfig['model'],
+  fallbackModel: WorkerConfig['model']
 ): WorkerConfig {
   return {
     id: worker.name,

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -12,9 +12,11 @@ import { registerWorkerCapabilities } from './agent-runtime.js';
 import type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-types.js';
 import type { WorkerCapabilities } from './schemas.js';
 import type { MultiAgentSystemConfig } from './types.js';
+import { admitWorkerTopology } from './worker-lifecycle.js';
 
 export { MultiAgentSystemBuilder } from './agent-builder.js';
 export type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-types.js';
+export { WorkerLifecycleError, type WorkerLifecycleErrorReason } from './worker-lifecycle.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
 
@@ -102,8 +104,11 @@ const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
  * );
  * ```
  */
-export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAgentSystemWithRegistry {
-  return createCompiledMultiAgentSystem(config);
+export function createMultiAgentSystem(
+  config: MultiAgentSystemConfig
+): MultiAgentSystemWithRegistry {
+  const lifecycle = admitWorkerTopology(config.workers);
+  return createCompiledMultiAgentSystem(config, lifecycle);
 }
 
 /**
@@ -135,12 +140,12 @@ export function createMultiAgentSystem(config: MultiAgentSystemConfig): MultiAge
  */
 export function registerWorkers(
   system: MultiAgentSystemWithRegistry,
-  workers: RegisterWorkerInput[],
+  workers: RegisterWorkerInput[]
 ): void {
   logger.warn(
     '[AgentForge] registerWorkers() on a compiled system only updates worker capabilities in state.\n' +
-    'It does NOT add worker nodes to the graph. Use MultiAgentSystemBuilder for proper worker registration.\n' +
-    'See: https://github.com/TVScoundrel/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
+      'It does NOT add worker nodes to the graph. Use MultiAgentSystemBuilder for proper worker registration.\n' +
+      'See: https://github.com/TVScoundrel/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
   );
   registerWorkerCapabilities(system, workers);
 }
@@ -152,7 +157,9 @@ export function registerWorkers(
  * @param workers - Worker configurations with id and capabilities
  * @returns Workers registry for initial state
  */
-export function createWorkersRegistry(workers: Array<{ id: string; capabilities: WorkerCapabilities }>) {
+export function createWorkersRegistry(
+  workers: Array<{ id: string; capabilities: WorkerCapabilities }>
+) {
   const registry: Record<string, WorkerCapabilities> = {};
   for (const worker of workers) {
     registry[worker.id] = worker.capabilities;

--- a/packages/patterns/src/multi-agent/index.ts
+++ b/packages/patterns/src/multi-agent/index.ts
@@ -8,11 +8,7 @@
  */
 
 // Export state and schemas
-export {
-  MultiAgentState,
-  MultiAgentStateConfig,
-  type MultiAgentStateType,
-} from './state.js';
+export { MultiAgentState, MultiAgentStateConfig, type MultiAgentStateType } from './state.js';
 
 export {
   AgentRoleSchema,
@@ -61,10 +57,7 @@ export {
 } from './routing.js';
 
 // Export utilities
-export {
-  isReActAgent,
-  wrapReActAgent,
-} from './utils.js';
+export { isReActAgent, wrapReActAgent } from './utils.js';
 
 // Export node creators
 export {
@@ -79,4 +72,6 @@ export {
   createMultiAgentSystem,
   registerWorkers,
   MultiAgentSystemBuilder,
+  WorkerLifecycleError,
+  type WorkerLifecycleErrorReason,
 } from './agent.js';

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -1,0 +1,120 @@
+import type { WorkerCapabilities } from './schemas.js';
+import type { WorkerConfig } from './types.js';
+
+export type WorkerLifecycleErrorReason =
+  | 'empty-topology'
+  | 'invalid-identity'
+  | 'duplicate-identity'
+  | 'unknown-worker'
+  | 'invalid-tool'
+  | 'unsupported-system';
+
+export class WorkerLifecycleError extends Error {
+  readonly reason: WorkerLifecycleErrorReason;
+
+  constructor(reason: WorkerLifecycleErrorReason, message: string) {
+    super(message);
+    this.name = 'WorkerLifecycleError';
+    this.reason = reason;
+  }
+}
+
+export interface WorkerLifecycle {
+  readonly topology: readonly WorkerConfig[];
+  readonly workerCapabilities: Readonly<Record<string, WorkerCapabilities>>;
+}
+
+type ToolLike = {
+  metadata?: { name?: unknown };
+  name?: unknown;
+};
+
+function normalizeToolName(tool: unknown, workerId: string, index: number): string {
+  const candidate = tool && typeof tool === 'object' ? (tool as ToolLike) : undefined;
+  const rawName = candidate?.metadata?.name ?? candidate?.name;
+  const name = typeof rawName === 'string' ? rawName.trim() : '';
+
+  if (!name) {
+    throw new WorkerLifecycleError(
+      'invalid-tool',
+      `Worker "${workerId}" has a nameless tool at index ${index}.`
+    );
+  }
+
+  return name;
+}
+
+export function normalizeWorkerToolNames(
+  workerId: string,
+  tools: readonly unknown[] | undefined
+): readonly string[] {
+  const toolNames = (tools ?? []).map((tool, index) => normalizeToolName(tool, workerId, index));
+  const uniqueToolNames = new Set(toolNames);
+  if (uniqueToolNames.size !== toolNames.length) {
+    throw new WorkerLifecycleError(
+      'invalid-tool',
+      `Worker "${workerId}" has duplicate normalized tool names.`
+    );
+  }
+
+  return Object.freeze(toolNames);
+}
+
+function validateIdentities(workers: readonly WorkerConfig[]): void {
+  for (const worker of workers) {
+    if (!worker.id || worker.id.trim() !== worker.id || worker.id.includes(',')) {
+      throw new WorkerLifecycleError(
+        'invalid-identity',
+        `Worker identity "${worker.id}" must be non-empty, trimmed, and comma-free.`
+      );
+    }
+  }
+
+  const identities = new Set<string>();
+  for (const worker of workers) {
+    if (identities.has(worker.id)) {
+      throw new WorkerLifecycleError(
+        'duplicate-identity',
+        `Worker identity "${worker.id}" appears more than once in the topology.`
+      );
+    }
+    identities.add(worker.id);
+  }
+}
+
+function admitWorker(worker: WorkerConfig): WorkerConfig {
+  const toolNames = normalizeWorkerToolNames(worker.id, worker.tools);
+
+  const capabilities = Object.freeze({
+    skills: Object.freeze([...worker.capabilities.skills]),
+    tools: toolNames,
+    available: worker.capabilities.available,
+    currentWorkload: worker.capabilities.currentWorkload,
+  }) as WorkerCapabilities;
+  const tools = worker.tools
+    ? (Object.freeze([...worker.tools]) as WorkerConfig['tools'])
+    : undefined;
+
+  return Object.freeze({
+    ...worker,
+    capabilities,
+    ...(tools ? { tools } : {}),
+  });
+}
+
+export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLifecycle {
+  if (workers.length === 0) {
+    throw new WorkerLifecycleError(
+      'empty-topology',
+      'A Multi-Agent System requires at least one Worker.'
+    );
+  }
+
+  validateIdentities(workers);
+  const topology = Object.freeze(workers.map(admitWorker));
+  const workerCapabilities = Object.freeze(
+    Object.fromEntries(topology.map((worker) => [worker.id, worker.capabilities]))
+  );
+
+  return Object.freeze({ topology, workerCapabilities });
+}

--- a/packages/patterns/tests/multi-agent/agent-system.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-system.test.ts
@@ -1,7 +1,9 @@
-import { MemorySaver } from '@langchain/langgraph';
-import { describe, expect, it } from 'vitest';
-import { createMultiAgentSystem } from '../../src/multi-agent/agent.js';
+import { MemorySaver, StateGraph } from '@langchain/langgraph';
+import { describe, expect, it, vi } from 'vitest';
+import { createMultiAgentSystem, WorkerLifecycleError } from '../../src/multi-agent/agent.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
 import type { MultiAgentSystemConfig } from '../../src/multi-agent/types.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
 
 describe('Multi-Agent System Factory', () => {
   describe('createMultiAgentSystem', () => {
@@ -37,7 +39,7 @@ describe('Multi-Agent System Factory', () => {
       expect(typeof system.invoke).toBe('function');
     });
 
-    it('should allow empty workers array (workers can be registered later)', () => {
+    it('rejects an empty Worker topology before compilation', () => {
       const config: MultiAgentSystemConfig = {
         supervisor: {
           strategy: 'round-robin',
@@ -45,9 +47,130 @@ describe('Multi-Agent System Factory', () => {
         workers: [],
       };
 
+      expect(() => createMultiAgentSystem(config)).toThrowError(
+        expect.objectContaining<Partial<WorkerLifecycleError>>({
+          reason: 'empty-topology',
+        })
+      );
+    });
+
+    it('delegates Worker validation to lifecycle admission', () => {
+      const config: MultiAgentSystemConfig = {
+        supervisor: { strategy: 'round-robin' },
+        workers: [
+          {
+            id: 'worker,other',
+            capabilities: {
+              skills: [],
+              tools: [],
+              available: true,
+              currentWorkload: 0,
+            },
+          },
+        ],
+      };
+
+      expect(() => createMultiAgentSystem(config)).toThrowError(
+        expect.objectContaining<Partial<WorkerLifecycleError>>({
+          reason: 'invalid-identity',
+        })
+      );
+    });
+
+    it('executes with the canonical Worker snapshot after caller configuration changes', async () => {
+      const skills = ['research'];
+      const tool = { name: ' search ' } as unknown as NonNullable<WorkerConfig['tools']>[number];
+      const config: MultiAgentSystemConfig = {
+        supervisor: { strategy: 'round-robin' },
+        workers: [
+          {
+            id: 'researcher',
+            capabilities: {
+              skills,
+              tools: ['stale-declaration'],
+              available: true,
+              currentWorkload: 0,
+            },
+            tools: [tool],
+          },
+        ],
+      };
       const system = createMultiAgentSystem(config);
-      expect(system).toBeDefined();
-      expect(typeof system.invoke).toBe('function');
+
+      skills.push('late-skill');
+      config.workers[0]!.capabilities.available = false;
+      config.workers[0]!.tools!.push({ name: 'late-tool' } as unknown as NonNullable<
+        WorkerConfig['tools']
+      >[number]);
+
+      const result = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+
+      expect(result.workers.researcher).toMatchObject({
+        skills: ['research'],
+        tools: ['search'],
+        available: true,
+      });
+    });
+
+    it('preserves LangGraph compilation failure identity and cause', () => {
+      const cause = new Error('compiler cause');
+      const failure = new Error('compiler failure', { cause });
+      const compile = vi.spyOn(StateGraph.prototype, 'compile').mockImplementationOnce(() => {
+        throw failure;
+      });
+      const config: MultiAgentSystemConfig = {
+        supervisor: { strategy: 'round-robin' },
+        workers: [
+          {
+            id: 'worker',
+            capabilities: {
+              skills: [],
+              tools: [],
+              available: true,
+              currentWorkload: 0,
+            },
+          },
+        ],
+      };
+
+      let thrown: unknown;
+      try {
+        createMultiAgentSystem(config);
+      } catch (error) {
+        thrown = error;
+      } finally {
+        compile.mockRestore();
+      }
+
+      expect(thrown).toBe(failure);
+      expect((thrown as Error).cause).toBe(cause);
+    });
+
+    it('preserves LangGraph execution failure identity and cause', async () => {
+      const cause = new Error('checkpoint cause');
+      const failure = new Error('checkpoint failure', { cause });
+      const checkpointer = new MemorySaver();
+      vi.spyOn(checkpointer, 'getTuple').mockRejectedValueOnce(failure);
+      const system = createMultiAgentSystem({
+        supervisor: { strategy: 'round-robin' },
+        workers: [
+          {
+            id: 'worker',
+            capabilities: {
+              skills: [],
+              tools: [],
+              available: true,
+              currentWorkload: 0,
+            },
+          },
+        ],
+        checkpointer,
+      });
+
+      await expect(
+        system.invoke({ input: 'test' }, { configurable: { thread_id: 'failure-test' } })
+      ).rejects.toBe(failure);
+      expect(failure.cause).toBe(cause);
     });
 
     it('should create system with aggregator', () => {

--- a/packages/patterns/tests/multi-agent/agent-tools.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-tools.test.ts
@@ -1,7 +1,11 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { createMultiAgentSystem, registerWorkers } from '../../src/multi-agent/agent.js';
+import {
+  createMultiAgentSystem,
+  registerWorkers,
+  WorkerLifecycleError,
+} from '../../src/multi-agent/agent.js';
 import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
 import type { MultiAgentSystemConfig } from '../../src/multi-agent/types.js';
 
@@ -112,25 +116,36 @@ describe('Multi-Agent tool mapping and stream registration', () => {
     });
   });
 
-  it('should handle tools without name or metadata gracefully', () => {
+  it('rejects tools without a name through lifecycle validation', () => {
     const system = createMultiAgentSystem(createBaseConfig());
 
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [{}],
-      },
-    ]);
+    expect(() =>
+      registerWorkers(system, [
+        {
+          name: 'worker1',
+          capabilities: ['skill1'],
+          tools: [{}],
+        },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
+    );
+  });
 
-    expect(system._workerRegistry).toEqual({
-      worker1: {
-        skills: ['skill1'],
-        tools: ['unknown'],
-        available: true,
-        currentWorkload: 0,
-      },
-    });
+  it('rejects duplicate normalized tool names through lifecycle validation', () => {
+    const system = createMultiAgentSystem(createBaseConfig());
+
+    expect(() =>
+      registerWorkers(system, [
+        {
+          name: 'worker1',
+          capabilities: ['skill1'],
+          tools: [{ name: 'search' }, { name: ' search ' }],
+        },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
+    );
   });
 
   it('should wrap stream() method when workers are registered', async () => {

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -1,0 +1,122 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { CompiledStateGraph } from '@langchain/langgraph';
+import { describe, expect, it } from 'vitest';
+import {
+  WorkerLifecycleError,
+  admitWorkerTopology,
+} from '../../src/multi-agent/worker-lifecycle.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
+
+function worker(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
+  return {
+    id: 'researcher',
+    capabilities: {
+      skills: ['research'],
+      tools: ['stale-declaration'],
+      available: true,
+      currentWorkload: 1,
+    },
+    ...overrides,
+  };
+}
+
+function expectLifecycleReason(action: () => unknown, reason: WorkerLifecycleError['reason']) {
+  expect(action).toThrowError(WorkerLifecycleError);
+  try {
+    action();
+  } catch (error) {
+    expect(error).toMatchObject({ reason });
+  }
+}
+
+describe('Worker lifecycle admission', () => {
+  it('rejects an empty Worker topology', () => {
+    expectLifecycleReason(() => admitWorkerTopology([]), 'empty-topology');
+  });
+
+  it.each(['', '  ', ' padded', 'padded ', 'worker,other'])(
+    'rejects the invalid Worker identity %j',
+    (id) => {
+      expectLifecycleReason(() => admitWorkerTopology([worker({ id })]), 'invalid-identity');
+    }
+  );
+
+  it('validates every identity before detecting duplicates', () => {
+    expectLifecycleReason(
+      () =>
+        admitWorkerTopology([
+          worker({ id: 'duplicate' }),
+          worker({ id: 'duplicate' }),
+          worker({ id: '' }),
+        ]),
+      'invalid-identity'
+    );
+  });
+
+  it('rejects duplicate Worker identities after identity validation', () => {
+    expectLifecycleReason(
+      () => admitWorkerTopology([worker({ id: 'duplicate' }), worker({ id: 'duplicate' })]),
+      'duplicate-identity'
+    );
+  });
+
+  it.each([
+    [[{}]],
+    [[{ name: '' }]],
+    [[{ name: '   ' }]],
+    [[{ name: 'search' }, { metadata: { name: ' search ' } }]],
+  ])('rejects nameless and duplicate normalized tools', (tools) => {
+    expectLifecycleReason(
+      () => admitWorkerTopology([worker({ tools: tools as WorkerConfig['tools'] })]),
+      'invalid-tool'
+    );
+  });
+
+  it('creates a canonical immutable snapshot while retaining opaque dependency identity', () => {
+    const model = {} as BaseChatModel;
+    const tool = { metadata: { name: ' search ' } } as unknown as NonNullable<
+      WorkerConfig['tools']
+    >[number];
+    const executeFn = async (): Promise<Partial<MultiAgentStateType>> => ({ status: 'completed' });
+    const agent = {} as CompiledStateGraph<unknown, unknown>;
+    const skills = ['research'];
+    const tools = [tool];
+    const capabilities = {
+      skills,
+      tools: ['caller-declaration'],
+      available: true,
+      currentWorkload: 2,
+    };
+    const configuredWorker = worker({ capabilities, model, tools, executeFn, agent });
+    const workers = [configuredWorker];
+
+    const lifecycle = admitWorkerTopology(workers);
+    const admitted = lifecycle.topology[0]!;
+
+    workers.push(worker({ id: 'late-worker' }));
+    skills.push('late-skill');
+    tools.push({ name: 'late-tool' } as unknown as NonNullable<WorkerConfig['tools']>[number]);
+    capabilities.available = false;
+    capabilities.currentWorkload = 99;
+
+    expect(lifecycle.topology).toHaveLength(1);
+    expect(admitted.capabilities).toEqual({
+      skills: ['research'],
+      tools: ['search'],
+      available: true,
+      currentWorkload: 2,
+    });
+    expect(admitted.tools).toEqual([tool]);
+    expect(admitted.model).toBe(model);
+    expect(admitted.tools?.[0]).toBe(tool);
+    expect(admitted.executeFn).toBe(executeFn);
+    expect(admitted.agent).toBe(agent);
+    expect(Object.isFrozen(lifecycle.topology)).toBe(true);
+    expect(Object.isFrozen(admitted)).toBe(true);
+    expect(Object.isFrozen(admitted.capabilities)).toBe(true);
+    expect(Object.isFrozen(admitted.capabilities.skills)).toBe(true);
+    expect(Object.isFrozen(admitted.capabilities.tools)).toBe(true);
+    expect(Object.isFrozen(admitted.tools)).toBe(true);
+  });
+});

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -22,12 +22,15 @@ function worker(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
 }
 
 function expectLifecycleReason(action: () => unknown, reason: WorkerLifecycleError['reason']) {
-  expect(action).toThrowError(WorkerLifecycleError);
+  let thrown: unknown;
   try {
     action();
   } catch (error) {
-    expect(error).toMatchObject({ reason });
+    thrown = error;
   }
+
+  expect(thrown).toBeInstanceOf(WorkerLifecycleError);
+  expect(thrown).toMatchObject({ reason });
 }
 
 describe('Worker lifecycle admission', () => {


### PR DESCRIPTION
## Summary
- route factory Worker admission through one lifecycle module
- validate and freeze canonical Worker topology snapshots
- export stable lifecycle errors and cover factory/error behavior
- require pull requests for future ticket delivery in AGENTS.md

## Validation
- pnpm --filter @agentforge/patterns lint
- pnpm --filter @agentforge/patterns typecheck
- pnpm --filter @agentforge/patterns build
- pnpm test (2,584 passed; 110 skipped)

Closes #178