### PR TITLE
Worker lifecycle: route builder admission through the lifecycle

### DIFF
--- a/packages/patterns/src/multi-agent/agent-builder.ts
+++ b/packages/patterns/src/multi-agent/agent-builder.ts
@@ -2,17 +2,19 @@ import { createCompiledMultiAgentSystem } from './agent-graph.js';
 import type { BuilderWorkerInput } from './agent-types.js';
 import { toWorkerConfig } from './agent-workers.js';
 import type { MultiAgentSystemConfig, WorkerConfig } from './types.js';
+import { admitWorkerTopology, type WorkerLifecycle } from './worker-lifecycle.js';
 
 export class MultiAgentSystemBuilder {
   private config: MultiAgentSystemConfig;
-  private additionalWorkers: WorkerConfig[] = [];
+  private lifecycle: WorkerLifecycle | undefined;
   private compiled = false;
 
   constructor(config: Omit<MultiAgentSystemConfig, 'workers'> & { workers?: WorkerConfig[] }) {
     this.config = {
       ...config,
-      workers: config.workers || [],
+      workers: [],
     };
+    this.lifecycle = config.workers?.length ? admitWorkerTopology(config.workers) : undefined;
   }
 
   registerWorkers(workers: BuilderWorkerInput[]): this {
@@ -20,9 +22,17 @@ export class MultiAgentSystemBuilder {
       throw new Error('Cannot register workers after the system has been compiled');
     }
 
-    for (const worker of workers) {
-      this.additionalWorkers.push(toWorkerConfig(worker, this.config.supervisor.model));
+    if (workers.length === 0) {
+      return this;
     }
+
+    const existingWorkers = this.lifecycle?.topology ?? [];
+    const pendingWorkers = workers.map((worker) =>
+      toWorkerConfig(worker, this.config.supervisor.model)
+    );
+    const lifecycle = admitWorkerTopology([...existingWorkers, ...pendingWorkers]);
+
+    this.lifecycle = lifecycle;
 
     return this;
   }
@@ -32,17 +42,17 @@ export class MultiAgentSystemBuilder {
       throw new Error('System has already been compiled');
     }
 
-    const allWorkers = [...this.config.workers, ...this.additionalWorkers];
+    const lifecycle = this.lifecycle ?? admitWorkerTopology([]);
 
-    if (allWorkers.length === 0) {
-      throw new Error('At least one worker must be registered before building the system');
-    }
-
+    const system = createCompiledMultiAgentSystem(
+      {
+        ...this.config,
+        workers: [...lifecycle.topology],
+      },
+      lifecycle
+    );
     this.compiled = true;
 
-    return createCompiledMultiAgentSystem({
-      ...this.config,
-      workers: allWorkers,
-    });
+    return system;
   }
 }

--- a/packages/patterns/src/multi-agent/agent-workers.ts
+++ b/packages/patterns/src/multi-agent/agent-workers.ts
@@ -18,7 +18,12 @@ export function toWorkerConfig(
 ): WorkerConfig {
   return {
     id: worker.name,
-    capabilities: toWorkerCapabilities(worker),
+    capabilities: {
+      skills: worker.capabilities,
+      tools: [],
+      available: true,
+      currentWorkload: 0,
+    },
     model: worker.model || fallbackModel,
     tools: worker.tools,
     systemPrompt: worker.systemPrompt,

--- a/packages/patterns/tests/multi-agent/agent-builder.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-builder.test.ts
@@ -1,10 +1,131 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { describe, expect, it } from 'vitest';
+import { StateGraph } from '@langchain/langgraph';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { MultiAgentSystemBuilder } from '../../src/multi-agent/agent.js';
+import {
+  createMultiAgentSystem,
+  MultiAgentSystemBuilder,
+  WorkerLifecycleError,
+} from '../../src/multi-agent/agent.js';
 import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
 
 describe('MultiAgentSystemBuilder', () => {
+  it('keeps registration atomic when a Worker batch fails admission', async () => {
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'existing',
+          capabilities: {
+            skills: ['accepted'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+    });
+
+    expect(() =>
+      builder.registerWorkers([
+        { name: 'partial', capabilities: ['must-not-be-admitted'] },
+        { name: 'existing', capabilities: ['duplicate'] },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({
+        reason: 'duplicate-identity',
+      })
+    );
+
+    builder.registerWorkers([{ name: 'retry', capabilities: ['accepted'] }]);
+    const result = (await builder.build().invoke({ input: 'test' })) as MultiAgentStateType;
+
+    expect(Object.keys(result.workers)).toEqual(['existing', 'retry']);
+  });
+
+  it('uses factory lifecycle validation when building without Workers', () => {
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+    });
+
+    expect(() => builder.build()).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({
+        reason: 'empty-topology',
+      })
+    );
+  });
+
+  it('matches factory admission and observable execution behavior', async () => {
+    const factorySkills = ['research'];
+    const builderSkills = ['research'];
+    const tool = { name: ' search ' } as unknown as NonNullable<WorkerConfig['tools']>[number];
+    const factory = createMultiAgentSystem({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'researcher',
+          capabilities: {
+            skills: factorySkills,
+            tools: ['stale-declaration'],
+            available: true,
+            currentWorkload: 0,
+          },
+          tools: [tool],
+        },
+      ],
+    });
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+    });
+    builder.registerWorkers([{ name: 'researcher', capabilities: builderSkills, tools: [tool] }]);
+
+    factorySkills.push('late-factory-skill');
+    builderSkills.push('late-builder-skill');
+
+    const factoryResult = (await factory.invoke({ input: 'test' })) as MultiAgentStateType;
+    const builderResult = (await builder.build().invoke({ input: 'test' })) as MultiAgentStateType;
+
+    expect(builderResult.workers).toEqual(factoryResult.workers);
+    expect(builderResult.workers.researcher.tools).toEqual(['search']);
+    expect(builderResult.status).toBe(factoryResult.status);
+    expect(builderResult.completedTasks[0]).toMatchObject({
+      workerId: factoryResult.completedTasks[0]?.workerId,
+      success: factoryResult.completedTasks[0]?.success,
+      error: factoryResult.completedTasks[0]?.error,
+    });
+  });
+
+  it('remains retryable with admitted Workers after compilation fails', () => {
+    const failure = new Error('compiler failure');
+    const compile = vi.spyOn(StateGraph.prototype, 'compile').mockImplementationOnce(() => {
+      throw failure;
+    });
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+    }).registerWorkers([{ name: 'worker', capabilities: ['accepted'] }]);
+
+    try {
+      expect(() => builder.build()).toThrow(failure);
+      expect(builder.build()).toBeDefined();
+    } finally {
+      compile.mockRestore();
+    }
+  });
+
+  it('seals registration and building after successful compilation', () => {
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+    }).registerWorkers([{ name: 'worker', capabilities: [] }]);
+
+    builder.build();
+
+    expect(() => builder.registerWorkers([{ name: 'late', capabilities: [] }])).toThrow(
+      'Cannot register workers after the system has been compiled'
+    );
+    expect(() => builder.build()).toThrow('System has already been compiled');
+  });
+
   it('should correctly extract tool names from AgentForge Tools in MultiAgentSystemBuilder', async () => {
     const agentforgeTool1 = toolBuilder()
       .name('builder-tool-1')


### PR DESCRIPTION
Closes #179

## Summary
- route constructor and incremental builder Workers through shared lifecycle admission
- validate registration batches atomically and preserve admitted state across failures
- seal the builder only after successful LangGraph compilation
- remove the builder's duplicate tool-normalization path

## Validation
- pnpm --filter @agentforge/patterns typecheck
- pnpm --filter @agentforge/patterns lint (0 errors; 2 pre-existing warnings)
- pnpm test (233 files passed, 9 skipped; 2,589 tests passed, 110 skipped)
- two-axis code review: no Standards findings; no Spec findings