### PR TITLE
Normalize Worker registry helper lifecycle rules

### DIFF
--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -418,6 +418,7 @@ import {
 ```typescript
 import {
   createMultiAgentSystem,
+  createWorkersRegistry,
   registerWorkers,
   createSupervisorNode,
   createWorkerNode,
@@ -428,6 +429,7 @@ import {
 **Main API**:
 - `createMultiAgentSystem(config)` - Create a complete Multi-Agent system
 - `MultiAgentSystemBuilder` - Builder for creating Multi-Agent systems with workers
+- `createWorkersRegistry(workers)` - Construct detached, normalized Worker registry records containing declared capabilities and invocation status without admitting Workers or creating graph topology
 - `registerWorkers(system, workers)` - Update worker capabilities in state (Note: does not add worker nodes to compiled graphs; use builder or pass workers to createMultiAgentSystem)
 
 **Configuration**:
@@ -540,4 +542,3 @@ pnpm typecheck
 ## License
 
 MIT © 2026 Tom Van Schoor
-

--- a/packages/patterns/docs/multi-agent-pattern.md
+++ b/packages/patterns/docs/multi-agent-pattern.md
@@ -717,6 +717,33 @@ registerWorkers(system, [
 ]);
 ```
 
+### createWorkersRegistry() (Deprecated)
+
+Constructs immutable Worker registry records for callers that need the existing
+combined data shape: declared capabilities (`skills` and `tools`) plus invocation
+status (`available` and `currentWorkload`). It normalizes those records and
+Worker identities using the same rules as lifecycle admission, but it does not
+admit a Worker, create graph topology, associate data with a compiled Multi-Agent
+System, or mutate lifecycle state. Empty input is valid for this data helper.
+
+Use `createMultiAgentSystem()` or `MultiAgentSystemBuilder` when the Workers
+must be executable. Use `registerWorkers()` only for compatible capability
+updates to Workers already present in a compiled topology.
+
+```typescript
+const registry = createWorkersRegistry([
+  {
+    id: 'researcher',
+    capabilities: {
+      skills: ['research'],
+      tools: ['search'],
+      available: true,
+      currentWorkload: 0,
+    },
+  },
+]);
+```
+
 ### createSupervisorNode()
 
 Creates a supervisor node for custom workflows.

--- a/packages/patterns/src/index.ts
+++ b/packages/patterns/src/index.ts
@@ -179,6 +179,7 @@ export {
 
   // Agent creation
   createMultiAgentSystem,
+  createWorkersRegistry,
   registerWorkers,
   MultiAgentSystemBuilder,
   WorkerLifecycleError,

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -12,7 +12,7 @@ import { registerWorkerCapabilities } from './agent-runtime.js';
 import type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-types.js';
 import type { WorkerCapabilities } from './schemas.js';
 import type { MultiAgentSystemConfig } from './types.js';
-import { admitWorkerTopology } from './worker-lifecycle.js';
+import { admitWorkerTopology, createWorkerRegistryData } from './worker-lifecycle.js';
 
 export { MultiAgentSystemBuilder } from './agent-builder.js';
 export type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-types.js';
@@ -151,18 +151,20 @@ export function registerWorkers(
 }
 
 /**
- * Helper function to create workers registry for initial state
+ * Construct detached Worker registry records for initial state data.
  *
- * @deprecated Use registerWorkers(system, workers) instead
- * @param workers - Worker configurations with id and capabilities
- * @returns Workers registry for initial state
+ * This helper applies Worker lifecycle normalization without admitting Workers,
+ * creating graph topology, or associating the result with a compiled system.
+ * Empty input is therefore valid. Use the factory or builder when Workers must
+ * be admitted into an executable Multi-Agent System.
+ *
+ * @deprecated Prefer the factory or builder for Worker admission. This helper
+ * remains available for callers that only need compatible registry data.
+ * @param workers - Worker identities and combined capability/status records
+ * @returns An immutable, detached Worker registry
  */
 export function createWorkersRegistry(
-  workers: Array<{ id: string; capabilities: WorkerCapabilities }>
+  workers: readonly { id: string; capabilities: WorkerCapabilities }[]
 ) {
-  const registry: Record<string, WorkerCapabilities> = {};
-  for (const worker of workers) {
-    registry[worker.id] = worker.capabilities;
-  }
-  return registry;
+  return createWorkerRegistryData(workers);
 }

--- a/packages/patterns/src/multi-agent/index.ts
+++ b/packages/patterns/src/multi-agent/index.ts
@@ -70,6 +70,7 @@ export {
 // Export agent creation
 export {
   createMultiAgentSystem,
+  createWorkersRegistry,
   registerWorkers,
   MultiAgentSystemBuilder,
   WorkerLifecycleError,

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -62,8 +62,15 @@ export function normalizeWorkerToolNames(
 
 type WorkerIdentity = Pick<WorkerConfig, 'id'>;
 type WorkerRegistryInput = WorkerIdentity & { capabilities: WorkerCapabilities };
-type WorkerDeclaredCapabilities = Pick<WorkerCapabilities, 'skills' | 'tools'>;
-type WorkerStatus = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
+type WorkerDeclaredCapabilities = {
+  readonly skills: readonly string[];
+  readonly tools: readonly string[];
+};
+type WorkerStatus = {
+  readonly available: boolean;
+  readonly currentWorkload: number;
+};
+type WorkerRegistryRecord = WorkerDeclaredCapabilities & WorkerStatus;
 
 function validateIdentities(workers: readonly WorkerIdentity[]): void {
   for (const worker of workers) {
@@ -95,7 +102,7 @@ function normalizeWorkerDeclaredCapabilities(
   return {
     skills: Object.freeze([...capabilities.skills]),
     tools: normalizeWorkerToolNames(workerId, tools),
-  } as WorkerDeclaredCapabilities;
+  };
 }
 
 function normalizeWorkerStatus(capabilities: WorkerCapabilities): WorkerStatus {
@@ -109,15 +116,21 @@ function normalizeWorkerRegistryRecord(
   workerId: string,
   capabilities: WorkerCapabilities,
   tools: readonly unknown[] | undefined
-): WorkerCapabilities {
+): WorkerRegistryRecord {
   return Object.freeze({
     ...normalizeWorkerDeclaredCapabilities(workerId, capabilities, tools),
     ...normalizeWorkerStatus(capabilities),
-  }) as WorkerCapabilities;
+  });
+}
+
+function asCompatibleWorkerCapabilities(record: WorkerRegistryRecord): WorkerCapabilities {
+  return record as WorkerCapabilities;
 }
 
 function admitWorker(worker: WorkerConfig): WorkerConfig {
-  const capabilities = normalizeWorkerRegistryRecord(worker.id, worker.capabilities, worker.tools);
+  const capabilities = asCompatibleWorkerCapabilities(
+    normalizeWorkerRegistryRecord(worker.id, worker.capabilities, worker.tools)
+  );
   const tools = worker.tools
     ? (Object.freeze([...worker.tools]) as WorkerConfig['tools'])
     : undefined;
@@ -155,10 +168,12 @@ export function createWorkerRegistryData(
     Object.fromEntries(
       workers.map((worker) => [
         worker.id,
-        normalizeWorkerRegistryRecord(
-          worker.id,
-          worker.capabilities,
-          worker.capabilities.tools.map((name) => ({ name }))
+        asCompatibleWorkerCapabilities(
+          normalizeWorkerRegistryRecord(
+            worker.id,
+            worker.capabilities,
+            worker.capabilities.tools.map((name) => ({ name }))
+          )
         ),
       ])
     )

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -60,7 +60,12 @@ export function normalizeWorkerToolNames(
   return Object.freeze(toolNames);
 }
 
-function validateIdentities(workers: readonly WorkerConfig[]): void {
+type WorkerIdentity = Pick<WorkerConfig, 'id'>;
+type WorkerRegistryInput = WorkerIdentity & { capabilities: WorkerCapabilities };
+type WorkerDeclaredCapabilities = Pick<WorkerCapabilities, 'skills' | 'tools'>;
+type WorkerStatus = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
+
+function validateIdentities(workers: readonly WorkerIdentity[]): void {
   for (const worker of workers) {
     if (!worker.id || worker.id.trim() !== worker.id || worker.id.includes(',')) {
       throw new WorkerLifecycleError(
@@ -75,22 +80,44 @@ function validateIdentities(workers: readonly WorkerConfig[]): void {
     if (identities.has(worker.id)) {
       throw new WorkerLifecycleError(
         'duplicate-identity',
-        `Worker identity "${worker.id}" appears more than once in the topology.`
+        `Worker identity "${worker.id}" appears more than once in the Worker batch.`
       );
     }
     identities.add(worker.id);
   }
 }
 
-function admitWorker(worker: WorkerConfig): WorkerConfig {
-  const toolNames = normalizeWorkerToolNames(worker.id, worker.tools);
+function normalizeWorkerDeclaredCapabilities(
+  workerId: string,
+  capabilities: WorkerCapabilities,
+  tools: readonly unknown[] | undefined
+): WorkerDeclaredCapabilities {
+  return {
+    skills: Object.freeze([...capabilities.skills]),
+    tools: normalizeWorkerToolNames(workerId, tools),
+  } as WorkerDeclaredCapabilities;
+}
 
-  const capabilities = Object.freeze({
-    skills: Object.freeze([...worker.capabilities.skills]),
-    tools: toolNames,
-    available: worker.capabilities.available,
-    currentWorkload: worker.capabilities.currentWorkload,
+function normalizeWorkerStatus(capabilities: WorkerCapabilities): WorkerStatus {
+  return {
+    available: capabilities.available,
+    currentWorkload: capabilities.currentWorkload,
+  };
+}
+
+function normalizeWorkerRegistryRecord(
+  workerId: string,
+  capabilities: WorkerCapabilities,
+  tools: readonly unknown[] | undefined
+): WorkerCapabilities {
+  return Object.freeze({
+    ...normalizeWorkerDeclaredCapabilities(workerId, capabilities, tools),
+    ...normalizeWorkerStatus(capabilities),
   }) as WorkerCapabilities;
+}
+
+function admitWorker(worker: WorkerConfig): WorkerConfig {
+  const capabilities = normalizeWorkerRegistryRecord(worker.id, worker.capabilities, worker.tools);
   const tools = worker.tools
     ? (Object.freeze([...worker.tools]) as WorkerConfig['tools'])
     : undefined;
@@ -117,4 +144,23 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
   );
 
   return Object.freeze({ topology, workerCapabilities });
+}
+
+export function createWorkerRegistryData(
+  workers: readonly WorkerRegistryInput[]
+): Readonly<Record<string, WorkerCapabilities>> {
+  validateIdentities(workers);
+
+  return Object.freeze(
+    Object.fromEntries(
+      workers.map((worker) => [
+        worker.id,
+        normalizeWorkerRegistryRecord(
+          worker.id,
+          worker.capabilities,
+          worker.capabilities.tools.map((name) => ({ name }))
+        ),
+      ])
+    )
+  );
 }

--- a/packages/patterns/tests/multi-agent/agent-workers-registry.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-workers-registry.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMultiAgentSystem,
+  createWorkersRegistry,
+  WorkerLifecycleError,
+} from '../../src/index.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
+
+describe('Worker capability registry construction', () => {
+  it('matches factory admission normalization', async () => {
+    const registry = createWorkersRegistry([
+      {
+        id: 'researcher',
+        capabilities: {
+          skills: ['research'],
+          tools: [' search '],
+          available: true,
+          currentWorkload: 2,
+        },
+      },
+    ]);
+    const executableTool = { name: ' search ' } as unknown as NonNullable<
+      WorkerConfig['tools']
+    >[number];
+    const system = createMultiAgentSystem({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'researcher',
+          capabilities: {
+            skills: ['research'],
+            tools: ['ignored-declaration'],
+            available: true,
+            currentWorkload: 2,
+          },
+          tools: [executableTool],
+        },
+      ],
+    });
+
+    const state = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+
+    expect(registry).toEqual(state.workers);
+  });
+
+  it.each([
+    {
+      name: 'invalid Worker identities',
+      workers: [
+        {
+          id: ' padded',
+          capabilities: {
+            skills: [],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+      reason: 'invalid-identity',
+    },
+    {
+      name: 'duplicate Worker identities',
+      workers: [
+        {
+          id: 'duplicate',
+          capabilities: {
+            skills: [],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+        {
+          id: 'duplicate',
+          capabilities: {
+            skills: [],
+            tools: [],
+            available: false,
+            currentWorkload: 1,
+          },
+        },
+      ],
+      reason: 'duplicate-identity',
+    },
+    {
+      name: 'nameless tools',
+      workers: [
+        {
+          id: 'worker',
+          capabilities: {
+            skills: [],
+            tools: ['   '],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+      reason: 'invalid-tool',
+    },
+    {
+      name: 'duplicate normalized tool names',
+      workers: [
+        {
+          id: 'worker',
+          capabilities: {
+            skills: [],
+            tools: ['search', ' search '],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+      reason: 'invalid-tool',
+    },
+  ] as const)('rejects $name with the lifecycle reason', ({ workers, reason }) => {
+    expect(() => createWorkersRegistry(workers)).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason })
+    );
+  });
+
+  it('returns an immutable snapshot detached from caller-owned capability data', () => {
+    const skills = ['research'];
+    const tools = [' search '];
+    const capabilities = {
+      skills,
+      tools,
+      available: true,
+      currentWorkload: 2,
+    };
+
+    const registry = createWorkersRegistry([{ id: 'researcher', capabilities }]);
+
+    skills.push('late-skill');
+    tools.push('late-tool');
+    capabilities.available = false;
+    capabilities.currentWorkload = 99;
+
+    expect(registry).toEqual({
+      researcher: {
+        skills: ['research'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 2,
+      },
+    });
+    expect(Object.isFrozen(registry)).toBe(true);
+    expect(Object.isFrozen(registry.researcher)).toBe(true);
+    expect(Object.isFrozen(registry.researcher?.skills)).toBe(true);
+    expect(Object.isFrozen(registry.researcher?.tools)).toBe(true);
+  });
+
+  it('accepts empty input without creating a Multi-Agent System', () => {
+    expect(createWorkersRegistry([])).toEqual({});
+  });
+
+  it('returns records detached from compiled Worker lifecycle state', async () => {
+    const sharedSkills = ['research'];
+    const sharedCapabilities = {
+      skills: sharedSkills,
+      tools: [' search '],
+      available: true,
+      currentWorkload: 0,
+    };
+    const system = createMultiAgentSystem({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'researcher',
+          capabilities: sharedCapabilities,
+          tools: [
+            { name: ' search ' } as unknown as NonNullable<WorkerConfig['tools']>[number],
+          ],
+        },
+      ],
+    });
+
+    const registry = createWorkersRegistry([{ id: 'researcher', capabilities: sharedCapabilities }]);
+
+    const state = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+
+    expect(registry.researcher).toEqual({
+      skills: ['research'],
+      tools: ['search'],
+      available: true,
+      currentWorkload: 0,
+    });
+    expect(registry.researcher).toEqual(state.workers.researcher);
+    expect(registry.researcher).not.toBe(state.workers.researcher);
+    expect(registry.researcher?.skills).not.toBe(state.workers.researcher?.skills);
+    expect(registry.researcher?.tools).not.toBe(state.workers.researcher?.tools);
+  });
+});


### PR DESCRIPTION
## Summary

- share Worker identity, declared capability, status, and tool-name normalization with lifecycle admission
- keep registry construction immutable and detached from compiled Worker lifecycle state
- expose and document the compatibility helper through the package entry point

## Validation

- pnpm test (2597 passed, 110 skipped)
- pnpm --filter @agentforge/patterns typecheck
- pnpm --filter @agentforge/patterns lint (2 pre-existing warnings, 0 errors)
- pnpm --filter @agentforge/patterns build

Closes #180