### PR TITLE
Worker lifecycle: initialize Worker state inside graph execution

### DIFF
--- a/packages/patterns/docs/multi-agent-pattern.md
+++ b/packages/patterns/docs/multi-agent-pattern.md
@@ -154,6 +154,31 @@ The pattern uses `MultiAgentState` with the following channels:
 }
 ```
 
+Each new graph execution initializes `workers` before the Supervisor runs. Worker
+identities, routing skills, and executable tool names come from the topology
+compiled by `createMultiAgentSystem()` or `MultiAgentSystemBuilder`; invocation
+input cannot replace those declarations. Invocation input may set `available`
+and `currentWorkload` for known Workers:
+
+```typescript
+const result = await system.invoke({
+  input: 'Prepare the report',
+  workers: {
+    researcher: {
+      skills: [], // Ignored; the compiled topology supplies routing skills.
+      tools: [], // Ignored; executable tool names belong to the topology.
+      available: false,
+      currentWorkload: 2,
+    },
+  },
+});
+```
+
+Supplying an identity that is not in the compiled Worker topology rejects the
+execution with `WorkerLifecycleError.reason === 'unknown-worker'`. The same
+initialization applies to invoke, stream, batch, and event-streaming execution
+paths.
+
 ### Node Types
 
 #### 1. Supervisor Node

--- a/packages/patterns/src/multi-agent/agent-graph.ts
+++ b/packages/patterns/src/multi-agent/agent-graph.ts
@@ -5,8 +5,8 @@ import { MultiAgentState } from './state.js';
 import type { MultiAgentStateType } from './state.js';
 import type { MultiAgentSystemWithRegistry } from './agent-types.js';
 import type { MultiAgentRouter, MultiAgentSystemConfig } from './types.js';
-import { wrapCompiledSystem } from './agent-runtime.js';
 import { admitWorkerTopology, type WorkerLifecycle } from './worker-lifecycle.js';
+import { createWorkerInitializationNode } from './worker-initialization.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
 
@@ -79,6 +79,10 @@ export function createCompiledMultiAgentSystem(
   const workflow = new StateGraph(MultiAgentState);
   const workerIds: string[] = [];
 
+  workflow.addNode(
+    'initializeWorkers',
+    createWorkerInitializationNode(lifecycle.workerCapabilities)
+  );
   workflow.addNode('supervisor', createSupervisorNode({ ...supervisor, maxIterations, verbose }));
 
   for (const workerConfig of lifecycle.topology) {
@@ -105,7 +109,9 @@ export function createCompiledMultiAgentSystem(
   const aggregatorRouter = createAggregatorRouter();
 
   // @ts-expect-error - LangGraph StateGraph generic mismatch with string node names
-  workflow.setEntryPoint('supervisor');
+  workflow.setEntryPoint('initializeWorkers');
+  // @ts-expect-error - LangGraph StateGraph generic mismatch with string node names
+  workflow.addEdge('initializeWorkers', 'supervisor');
   // @ts-expect-error - LangGraph StateGraph generic mismatch with string node names
   workflow.addConditionalEdges('supervisor', supervisorRouter, ['aggregator', END, ...workerIds]);
 
@@ -117,9 +123,7 @@ export function createCompiledMultiAgentSystem(
   // @ts-expect-error - LangGraph StateGraph generic mismatch with string node names
   workflow.addConditionalEdges('aggregator', aggregatorRouter, [END]);
 
-  const compiled = workflow.compile(
+  return workflow.compile(
     checkpointer ? { checkpointer } : undefined
   ) as unknown as MultiAgentSystemWithRegistry;
-
-  return wrapCompiledSystem(compiled, lifecycle.workerCapabilities);
 }

--- a/packages/patterns/src/multi-agent/agent-runtime.ts
+++ b/packages/patterns/src/multi-agent/agent-runtime.ts
@@ -17,29 +17,6 @@ function mergeWorkers(
   };
 }
 
-export function wrapCompiledSystem(
-  system: MultiAgentSystemWithRegistry,
-  workerCapabilities: Readonly<Record<string, WorkerCapabilities>>
-): MultiAgentSystemWithRegistry {
-  const originalInvoke = system.invoke.bind(system);
-  system.invoke = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
-    return originalInvoke(
-      mergeWorkers(input, workerCapabilities) as Parameters<typeof originalInvoke>[0],
-      config as Parameters<typeof originalInvoke>[1]
-    );
-  } as unknown as typeof system.invoke;
-
-  const originalStream = system.stream.bind(system);
-  system.stream = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
-    return originalStream(
-      mergeWorkers(input, workerCapabilities) as Parameters<typeof originalStream>[0],
-      config as Parameters<typeof originalStream>[1]
-    );
-  } as unknown as typeof system.stream;
-
-  return system;
-}
-
 export function registerWorkerCapabilities(
   system: MultiAgentSystemWithRegistry,
   workers: RegisterWorkerInput[]

--- a/packages/patterns/src/multi-agent/state.ts
+++ b/packages/patterns/src/multi-agent/state.ts
@@ -62,13 +62,16 @@ export const MultiAgentStateConfig = {
    */
   workers: {
     schema: z.record(z.string(), WorkerCapabilitiesSchema),
-    reducer: (left: Record<string, WorkerCapabilities>, right: Record<string, WorkerCapabilities>) => ({
-      ...left,
-      ...right,
-    }),
+    reducer: (
+      _left: Record<string, WorkerCapabilities>,
+      right: Record<string, WorkerCapabilities>
+    ) => right,
     default: () => ({}),
     description: 'Available worker agents and their capabilities',
-  } satisfies StateChannelConfig<Record<string, WorkerCapabilities>, Record<string, WorkerCapabilities>>,
+  } satisfies StateChannelConfig<
+    Record<string, WorkerCapabilities>,
+    Record<string, WorkerCapabilities>
+  >,
 
   /**
    * Trusted supervisor task intent

--- a/packages/patterns/src/multi-agent/worker-initialization.ts
+++ b/packages/patterns/src/multi-agent/worker-initialization.ts
@@ -1,6 +1,9 @@
+import { createPatternLogger } from '../shared/deduplication.js';
 import type { WorkerCapabilities } from './schemas.js';
 import type { MultiAgentStateType } from './state.js';
 import { WorkerLifecycleError } from './worker-lifecycle.js';
+
+const logger = createPatternLogger('agentforge:patterns:multi-agent:worker-initialization');
 
 type WorkerStatusInput = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
 
@@ -9,7 +12,7 @@ export function initializeWorkerState(
   invocationWorkers: Readonly<Record<string, WorkerCapabilities>>
 ): MultiAgentStateType['workers'] {
   for (const workerId of Object.keys(invocationWorkers)) {
-    if (!topologyCapabilities[workerId]) {
+    if (!Object.hasOwn(topologyCapabilities, workerId)) {
       throw new WorkerLifecycleError(
         'unknown-worker',
         `Invocation state contains unknown Worker "${workerId}".`
@@ -19,7 +22,9 @@ export function initializeWorkerState(
 
   return Object.fromEntries(
     Object.entries(topologyCapabilities).map(([workerId, capabilities]) => {
-      const status: WorkerStatusInput = invocationWorkers[workerId] ?? capabilities;
+      const status: WorkerStatusInput = Object.hasOwn(invocationWorkers, workerId)
+        ? invocationWorkers[workerId]!
+        : capabilities;
 
       return [
         workerId,
@@ -37,7 +42,19 @@ export function initializeWorkerState(
 export function createWorkerInitializationNode(
   topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>
 ) {
-  return async (state: MultiAgentStateType): Promise<Partial<MultiAgentStateType>> => ({
-    workers: initializeWorkerState(topologyCapabilities, state.workers),
-  });
+  return async (state: MultiAgentStateType): Promise<Partial<MultiAgentStateType>> => {
+    logger.info('Worker initialization started', {
+      workerCount: Object.keys(topologyCapabilities).length,
+      statusOverrideCount: Object.keys(state.workers).length,
+    });
+
+    const workers = initializeWorkerState(topologyCapabilities, state.workers);
+
+    logger.info('Worker initialization complete', {
+      workerCount: Object.keys(workers).length,
+      workerIds: Object.keys(workers),
+    });
+
+    return { workers };
+  };
 }

--- a/packages/patterns/src/multi-agent/worker-initialization.ts
+++ b/packages/patterns/src/multi-agent/worker-initialization.ts
@@ -1,0 +1,43 @@
+import type { WorkerCapabilities } from './schemas.js';
+import type { MultiAgentStateType } from './state.js';
+import { WorkerLifecycleError } from './worker-lifecycle.js';
+
+type WorkerStatusInput = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
+
+export function initializeWorkerState(
+  topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>,
+  invocationWorkers: Readonly<Record<string, WorkerCapabilities>>
+): MultiAgentStateType['workers'] {
+  for (const workerId of Object.keys(invocationWorkers)) {
+    if (!topologyCapabilities[workerId]) {
+      throw new WorkerLifecycleError(
+        'unknown-worker',
+        `Invocation state contains unknown Worker "${workerId}".`
+      );
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(topologyCapabilities).map(([workerId, capabilities]) => {
+      const status: WorkerStatusInput = invocationWorkers[workerId] ?? capabilities;
+
+      return [
+        workerId,
+        {
+          skills: [...capabilities.skills],
+          tools: [...capabilities.tools],
+          available: status.available,
+          currentWorkload: status.currentWorkload,
+        },
+      ];
+    })
+  );
+}
+
+export function createWorkerInitializationNode(
+  topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>
+) {
+  return async (state: MultiAgentStateType): Promise<Partial<MultiAgentStateType>> => ({
+    workers: initializeWorkerState(topologyCapabilities, state.workers),
+  });
+}

--- a/packages/patterns/src/multi-agent/worker-initialization.ts
+++ b/packages/patterns/src/multi-agent/worker-initialization.ts
@@ -48,7 +48,17 @@ export function createWorkerInitializationNode(
       statusOverrideCount: Object.keys(state.workers).length,
     });
 
-    const workers = initializeWorkerState(topologyCapabilities, state.workers);
+    let workers: MultiAgentStateType['workers'];
+    try {
+      workers = initializeWorkerState(topologyCapabilities, state.workers);
+    } catch (error) {
+      logger.error('Worker initialization failed', {
+        error: error instanceof Error ? error.message : String(error),
+        invocationWorkerIds: Object.keys(state.workers),
+        topologyWorkerIds: Object.keys(topologyCapabilities),
+      });
+      throw error;
+    }
 
     logger.info('Worker initialization complete', {
       workerCount: Object.keys(workers).length,

--- a/packages/patterns/tests/multi-agent/agent-execution-initialization.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-execution-initialization.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMultiAgentSystem,
+  MultiAgentSystemBuilder,
+  WorkerLifecycleError,
+} from '../../src/multi-agent/agent.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
+
+function createSystem() {
+  const searchTool = { name: 'search' } as unknown as NonNullable<WorkerConfig['tools']>[number];
+
+  return createMultiAgentSystem({
+    supervisor: { strategy: 'round-robin' },
+    workers: [
+      {
+        id: 'researcher',
+        capabilities: {
+          skills: ['research'],
+          tools: ['stale-declaration'],
+          available: true,
+          currentWorkload: 0,
+        },
+        tools: [searchTool],
+      },
+    ],
+    maxIterations: 0,
+  });
+}
+
+function invocationWorkers(available: boolean, currentWorkload: number) {
+  return {
+    researcher: {
+      skills: ['caller-skill'],
+      tools: ['caller-tool'],
+      available,
+      currentWorkload,
+    },
+  };
+}
+
+describe('Multi-Agent Worker execution initialization', () => {
+  it('uses topology-owned capabilities and invocation-owned status', async () => {
+    const system = createSystem();
+
+    const result = (await system.invoke({
+      input: 'test',
+      workers: invocationWorkers(false, 7),
+    })) as MultiAgentStateType;
+
+    expect(result.workers).toEqual({
+      researcher: {
+        skills: ['research'],
+        tools: ['search'],
+        available: false,
+        currentWorkload: 7,
+      },
+    });
+  });
+
+  it('rejects unknown invocation Workers with the lifecycle reason', async () => {
+    const system = createSystem();
+
+    await expect(
+      system.invoke({
+        input: 'test',
+        workers: {
+          intruder: {
+            skills: [],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      })
+    ).rejects.toMatchObject<Partial<WorkerLifecycleError>>({ reason: 'unknown-worker' });
+  });
+
+  it('initializes Worker state through streaming before Supervisor execution', async () => {
+    const chunks = [];
+
+    for await (const chunk of await createSystem().stream({
+      input: 'test',
+      workers: invocationWorkers(false, 3),
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks[0]).toEqual({
+      initializeWorkers: {
+        workers: {
+          researcher: {
+            skills: ['research'],
+            tools: ['search'],
+            available: false,
+            currentWorkload: 3,
+          },
+        },
+      },
+    });
+    expect(chunks[1]).toHaveProperty('supervisor');
+  });
+
+  it('initializes every execution in a batch independently', async () => {
+    const results = (await createSystem().batch([
+      { input: 'first', workers: invocationWorkers(false, 1) },
+      { input: 'second', workers: invocationWorkers(true, 4) },
+    ])) as MultiAgentStateType[];
+
+    expect(results.map((result) => result.workers.researcher)).toEqual([
+      {
+        skills: ['research'],
+        tools: ['search'],
+        available: false,
+        currentWorkload: 1,
+      },
+      {
+        skills: ['research'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 4,
+      },
+    ]);
+  });
+
+  it('exposes equivalent initialized state through event streaming', async () => {
+    const events = [];
+
+    for await (const event of createSystem().streamEvents(
+      { input: 'test', workers: invocationWorkers(false, 5) },
+      { version: 'v2' }
+    )) {
+      events.push(event);
+    }
+
+    const initializationEnd = events.find(
+      (event) => event.event === 'on_chain_end' && event.name === 'initializeWorkers'
+    );
+    expect(initializationEnd?.data.output).toEqual({
+      workers: {
+        researcher: {
+          skills: ['research'],
+          tools: ['search'],
+          available: false,
+          currentWorkload: 5,
+        },
+      },
+    });
+  });
+
+  it('gives builder executions the same initialized Worker state', async () => {
+    const builder = new MultiAgentSystemBuilder({
+      supervisor: { strategy: 'round-robin' },
+      maxIterations: 0,
+    }).registerWorkers([
+      {
+        name: 'researcher',
+        capabilities: ['research'],
+        tools: [{ name: 'search' }],
+      },
+    ]);
+
+    const result = (await builder.build().invoke({
+      input: 'test',
+      workers: invocationWorkers(false, 6),
+    })) as MultiAgentStateType;
+
+    expect(result.workers).toEqual({
+      researcher: {
+        skills: ['research'],
+        tools: ['search'],
+        available: false,
+        currentWorkload: 6,
+      },
+    });
+  });
+
+  it('keeps routing behavior on the initialized compatible Worker record', async () => {
+    const system = createMultiAgentSystem({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'researcher',
+          capabilities: {
+            skills: ['research'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+        {
+          id: 'writer',
+          capabilities: {
+            skills: ['writing'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+      maxIterations: 1,
+    });
+
+    const result = (await system.invoke({
+      input: 'test',
+      workers: {
+        researcher: {
+          skills: ['caller-skill'],
+          tools: ['caller-tool'],
+          available: false,
+          currentWorkload: 0,
+        },
+        writer: {
+          skills: ['caller-skill'],
+          tools: ['caller-tool'],
+          available: true,
+          currentWorkload: 2,
+        },
+      },
+    })) as MultiAgentStateType;
+
+    expect(result.routingHistory[0]?.targetAgent).toBe('writer');
+    expect(result.workers.researcher?.skills).toEqual(['research']);
+    expect(result.workers.writer?.skills).toEqual(['writing']);
+  });
+});

--- a/packages/patterns/tests/multi-agent/agent-execution-initialization.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-execution-initialization.test.ts
@@ -39,6 +39,15 @@ function invocationWorkers(available: boolean, currentWorkload: number) {
   };
 }
 
+function expectedResearcher(available: boolean, currentWorkload: number) {
+  return {
+    skills: ['research'],
+    tools: ['search'],
+    available,
+    currentWorkload,
+  };
+}
+
 describe('Multi-Agent Worker execution initialization', () => {
   it('uses topology-owned capabilities and invocation-owned status', async () => {
     const system = createSystem();
@@ -49,32 +58,30 @@ describe('Multi-Agent Worker execution initialization', () => {
     })) as MultiAgentStateType;
 
     expect(result.workers).toEqual({
-      researcher: {
-        skills: ['research'],
-        tools: ['search'],
-        available: false,
-        currentWorkload: 7,
-      },
+      researcher: expectedResearcher(false, 7),
     });
   });
 
-  it('rejects unknown invocation Workers with the lifecycle reason', async () => {
-    const system = createSystem();
+  it.each(['intruder', 'toString'])(
+    'rejects unknown invocation Worker %j with the lifecycle reason',
+    async (workerId) => {
+      const system = createSystem();
 
-    await expect(
-      system.invoke({
-        input: 'test',
-        workers: {
-          intruder: {
-            skills: [],
-            tools: [],
-            available: true,
-            currentWorkload: 0,
+      await expect(
+        system.invoke({
+          input: 'test',
+          workers: {
+            [workerId]: {
+              skills: [],
+              tools: [],
+              available: true,
+              currentWorkload: 0,
+            },
           },
-        },
-      })
-    ).rejects.toMatchObject<Partial<WorkerLifecycleError>>({ reason: 'unknown-worker' });
-  });
+        })
+      ).rejects.toMatchObject<Partial<WorkerLifecycleError>>({ reason: 'unknown-worker' });
+    }
+  );
 
   it('initializes Worker state through streaming before Supervisor execution', async () => {
     const chunks = [];
@@ -89,12 +96,7 @@ describe('Multi-Agent Worker execution initialization', () => {
     expect(chunks[0]).toEqual({
       initializeWorkers: {
         workers: {
-          researcher: {
-            skills: ['research'],
-            tools: ['search'],
-            available: false,
-            currentWorkload: 3,
-          },
+          researcher: expectedResearcher(false, 3),
         },
       },
     });
@@ -108,18 +110,8 @@ describe('Multi-Agent Worker execution initialization', () => {
     ])) as MultiAgentStateType[];
 
     expect(results.map((result) => result.workers.researcher)).toEqual([
-      {
-        skills: ['research'],
-        tools: ['search'],
-        available: false,
-        currentWorkload: 1,
-      },
-      {
-        skills: ['research'],
-        tools: ['search'],
-        available: true,
-        currentWorkload: 4,
-      },
+      expectedResearcher(false, 1),
+      expectedResearcher(true, 4),
     ]);
   });
 
@@ -138,12 +130,7 @@ describe('Multi-Agent Worker execution initialization', () => {
     );
     expect(initializationEnd?.data.output).toEqual({
       workers: {
-        researcher: {
-          skills: ['research'],
-          tools: ['search'],
-          available: false,
-          currentWorkload: 5,
-        },
+        researcher: expectedResearcher(false, 5),
       },
     });
   });
@@ -166,12 +153,7 @@ describe('Multi-Agent Worker execution initialization', () => {
     })) as MultiAgentStateType;
 
     expect(result.workers).toEqual({
-      researcher: {
-        skills: ['research'],
-        tools: ['search'],
-        available: false,
-        currentWorkload: 6,
-      },
+      researcher: expectedResearcher(false, 6),
     });
   });
 

--- a/packages/patterns/tests/multi-agent/agent-tools.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-tools.test.ts
@@ -1,12 +1,11 @@
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
   createMultiAgentSystem,
   registerWorkers,
   WorkerLifecycleError,
 } from '../../src/multi-agent/agent.js';
-import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
 import type { MultiAgentSystemConfig } from '../../src/multi-agent/types.js';
 
 function createBaseConfig(): MultiAgentSystemConfig {
@@ -146,68 +145,5 @@ describe('Multi-Agent tool mapping and stream registration', () => {
     ).toThrowError(
       expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
     );
-  });
-
-  it('should wrap stream() method when workers are registered', async () => {
-    const system = createMultiAgentSystem(createBaseConfig());
-
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [],
-      },
-    ]);
-
-    const systemWithRegistry = system;
-    expect(systemWithRegistry._originalStream).toBeDefined();
-    expect(typeof systemWithRegistry._originalStream).toBe('function');
-    expect(systemWithRegistry._workerRegistry?.worker1?.skills).toEqual(['skill1']);
-
-    const originalStreamSpy = vi.fn(systemWithRegistry._originalStream);
-    systemWithRegistry._originalStream = originalStreamSpy;
-
-    await system.stream({
-      input: 'test',
-    });
-
-    expect(originalStreamSpy).toHaveBeenCalledTimes(1);
-    const [callArgs] = originalStreamSpy.mock.calls[0] as [Partial<MultiAgentStateType>];
-    expect(callArgs.workers?.worker1?.skills).toEqual(['skill1']);
-  });
-
-  it('should inject registered workers with AgentForge Tools when using stream() method', async () => {
-    const agentforgeTool = toolBuilder()
-      .name('stream-tool')
-      .description('Tool for streaming test')
-      .category(ToolCategory.UTILITY)
-      .schema(z.object({ input: z.string().describe('Input') }))
-      .implement(async ({ input }: { input: string }) => input)
-      .build();
-
-    const system = createMultiAgentSystem(createBaseConfig());
-
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [agentforgeTool],
-      },
-    ]);
-
-    const systemWithRegistry = system;
-    expect(systemWithRegistry._originalStream).toBeDefined();
-    expect(systemWithRegistry._workerRegistry?.worker1?.tools).toEqual(['stream-tool']);
-
-    const originalStreamSpy = vi.fn(systemWithRegistry._originalStream);
-    systemWithRegistry._originalStream = originalStreamSpy;
-
-    await system.stream({
-      input: 'test',
-    });
-
-    expect(originalStreamSpy).toHaveBeenCalledTimes(1);
-    const [callArgs] = originalStreamSpy.mock.calls[0] as [Partial<MultiAgentStateType>];
-    expect(callArgs.workers?.worker1?.tools).toEqual(['stream-tool']);
   });
 });

--- a/packages/patterns/tests/multi-agent/state.test.ts
+++ b/packages/patterns/tests/multi-agent/state.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import {
-  MultiAgentState,
-  MultiAgentStateConfig,
-} from '../../src/multi-agent/state.js';
-import {
-  type AgentMessage,
-  type WorkerCapabilities,
-} from '../../src/multi-agent/schemas.js';
+import { MultiAgentState, MultiAgentStateConfig } from '../../src/multi-agent/state.js';
+import { type AgentMessage, type WorkerCapabilities } from '../../src/multi-agent/schemas.js';
 
 describe('Multi-Agent State', () => {
   describe('State Annotation', () => {
@@ -52,8 +46,26 @@ describe('Multi-Agent State', () => {
       const messagesReducer = MultiAgentStateConfig.messages.reducer;
       expect(messagesReducer).toBeDefined();
       if (messagesReducer) {
-        const left: AgentMessage[] = [{ id: '1', type: 'user_input', from: 'user', to: 'supervisor', content: 'test', timestamp: Date.now() }];
-        const right: AgentMessage[] = [{ id: '2', type: 'task_assignment', from: 'supervisor', to: 'worker-1', content: 'task', timestamp: Date.now() }];
+        const left: AgentMessage[] = [
+          {
+            id: '1',
+            type: 'user_input',
+            from: 'user',
+            to: 'supervisor',
+            content: 'test',
+            timestamp: Date.now(),
+          },
+        ];
+        const right: AgentMessage[] = [
+          {
+            id: '2',
+            type: 'task_assignment',
+            from: 'supervisor',
+            to: 'worker-1',
+            content: 'task',
+            timestamp: Date.now(),
+          },
+        ];
         const result = messagesReducer(left, right);
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('1');
@@ -68,7 +80,7 @@ describe('Multi-Agent State', () => {
       }
     });
 
-    it('should have correct reducer for workers record', () => {
+    it('replaces the workers record instead of retaining stale identities', () => {
       const workersReducer = MultiAgentStateConfig.workers.reducer;
       expect(workersReducer).toBeDefined();
       if (workersReducer) {
@@ -89,9 +101,7 @@ describe('Multi-Agent State', () => {
           },
         };
         const result = workersReducer(left, right);
-        expect(Object.keys(result)).toHaveLength(2);
-        expect(result['worker-1']).toBeDefined();
-        expect(result['worker-2']).toBeDefined();
+        expect(result).toEqual(right);
       }
     });
   });

--- a/packages/patterns/tests/multi-agent/worker-initialization.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-initialization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkerCapabilities } from '../../src/multi-agent/schemas.js';
+import { initializeWorkerState } from '../../src/multi-agent/worker-initialization.js';
+
+describe('Worker state initialization', () => {
+  it('uses initial status when a prototype-named Worker has no invocation override', () => {
+    const worker: WorkerCapabilities = {
+      skills: ['prototype-safety'],
+      tools: [],
+      available: true,
+      currentWorkload: 2,
+    };
+    const topology = Object.fromEntries([['toString', worker]]);
+
+    expect(initializeWorkerState(topology, {})).toEqual({
+      toString: {
+        skills: ['prototype-safety'],
+        tools: [],
+        available: true,
+        currentWorkload: 2,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- initialize Worker state inside the compiled LangGraph before Supervisor execution
- preserve topology-owned Worker identities, routing skills, and executable tool names while accepting invocation-owned availability and workload
- apply replacement semantics, reject unknown Workers with stable lifecycle reasons, and cover invoke, stream, batch, event streaming, builder parity, and routing outcomes
- document Worker-state ownership and initialization behavior

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm test` (236 passed files, 2,604 passed tests; 9 files and 110 tests skipped)
- two-axis Standards and Spec review: no remaining findings

Closes #181
