### PR TITLE
Worker lifecycle: preserve snapshots across checkpoints and resume

### DIFF
--- a/packages/patterns/src/multi-agent/agent-graph.ts
+++ b/packages/patterns/src/multi-agent/agent-graph.ts
@@ -81,7 +81,7 @@ export function createCompiledMultiAgentSystem(
 
   workflow.addNode(
     'initializeWorkers',
-    createWorkerInitializationNode(lifecycle.workerCapabilities)
+    createWorkerInitializationNode(lifecycle.captureWorkerCapabilities)
   );
   workflow.addNode('supervisor', createSupervisorNode({ ...supervisor, maxIterations, verbose }));
 

--- a/packages/patterns/src/multi-agent/agent-graph.ts
+++ b/packages/patterns/src/multi-agent/agent-graph.ts
@@ -81,7 +81,7 @@ export function createCompiledMultiAgentSystem(
 
   workflow.addNode(
     'initializeWorkers',
-    createWorkerInitializationNode(lifecycle.captureWorkerCapabilities)
+    createWorkerInitializationNode(lifecycle.captureWorkerSnapshot)
   );
   workflow.addNode('supervisor', createSupervisorNode({ ...supervisor, maxIterations, verbose }));
 

--- a/packages/patterns/src/multi-agent/worker-initialization.ts
+++ b/packages/patterns/src/multi-agent/worker-initialization.ts
@@ -6,7 +6,7 @@ import { WorkerLifecycleError } from './worker-lifecycle.js';
 const logger = createPatternLogger('agentforge:patterns:multi-agent:worker-initialization');
 
 type WorkerStatusInput = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
-type CaptureWorkerCapabilities = () => Readonly<Record<string, WorkerCapabilities>>;
+type CaptureWorkerSnapshot = () => Readonly<Record<string, WorkerCapabilities>>;
 
 export function initializeWorkerState(
   topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>,
@@ -40,11 +40,9 @@ export function initializeWorkerState(
   );
 }
 
-export function createWorkerInitializationNode(
-  captureWorkerCapabilities: CaptureWorkerCapabilities
-) {
+export function createWorkerInitializationNode(captureWorkerSnapshot: CaptureWorkerSnapshot) {
   return async (state: MultiAgentStateType): Promise<Partial<MultiAgentStateType>> => {
-    const topologyCapabilities = captureWorkerCapabilities();
+    const topologyCapabilities = captureWorkerSnapshot();
 
     logger.info('Worker initialization started', {
       workerCount: Object.keys(topologyCapabilities).length,

--- a/packages/patterns/src/multi-agent/worker-initialization.ts
+++ b/packages/patterns/src/multi-agent/worker-initialization.ts
@@ -6,6 +6,7 @@ import { WorkerLifecycleError } from './worker-lifecycle.js';
 const logger = createPatternLogger('agentforge:patterns:multi-agent:worker-initialization');
 
 type WorkerStatusInput = Pick<WorkerCapabilities, 'available' | 'currentWorkload'>;
+type CaptureWorkerCapabilities = () => Readonly<Record<string, WorkerCapabilities>>;
 
 export function initializeWorkerState(
   topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>,
@@ -40,9 +41,11 @@ export function initializeWorkerState(
 }
 
 export function createWorkerInitializationNode(
-  topologyCapabilities: Readonly<Record<string, WorkerCapabilities>>
+  captureWorkerCapabilities: CaptureWorkerCapabilities
 ) {
   return async (state: MultiAgentStateType): Promise<Partial<MultiAgentStateType>> => {
+    const topologyCapabilities = captureWorkerCapabilities();
+
     logger.info('Worker initialization started', {
       workerCount: Object.keys(topologyCapabilities).length,
       statusOverrideCount: Object.keys(state.workers).length,

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -21,7 +21,7 @@ export class WorkerLifecycleError extends Error {
 
 export interface WorkerLifecycle {
   readonly topology: readonly WorkerConfig[];
-  readonly captureWorkerCapabilities: () => Readonly<Record<string, WorkerCapabilities>>;
+  readonly captureWorkerSnapshot: () => Readonly<Record<string, WorkerCapabilities>>;
 }
 
 type ToolLike = {
@@ -158,7 +158,7 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
 
   return Object.freeze({
     topology,
-    captureWorkerCapabilities: () => workerCapabilities,
+    captureWorkerSnapshot: () => workerCapabilities,
   });
 }
 

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -21,7 +21,7 @@ export class WorkerLifecycleError extends Error {
 
 export interface WorkerLifecycle {
   readonly topology: readonly WorkerConfig[];
-  readonly workerCapabilities: Readonly<Record<string, WorkerCapabilities>>;
+  readonly captureWorkerCapabilities: () => Readonly<Record<string, WorkerCapabilities>>;
 }
 
 type ToolLike = {
@@ -156,7 +156,10 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
     Object.fromEntries(topology.map((worker) => [worker.id, worker.capabilities]))
   );
 
-  return Object.freeze({ topology, workerCapabilities });
+  return Object.freeze({
+    topology,
+    captureWorkerCapabilities: () => workerCapabilities,
+  });
 }
 
 export function createWorkerRegistryData(

--- a/packages/patterns/tests/multi-agent/agent-checkpoint-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-checkpoint-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { Command, END, MemorySaver, StateGraph, interrupt } from '@langchain/langgraph';
+import { describe, expect, it, vi } from 'vitest';
+import { createMultiAgentSystem } from '../../src/multi-agent/agent.js';
+import type { WorkerCapabilities } from '../../src/multi-agent/schemas.js';
+import { MultiAgentState, type MultiAgentStateType } from '../../src/multi-agent/state.js';
+import { createWorkerInitializationNode } from '../../src/multi-agent/worker-initialization.js';
+
+function workerCapabilities(
+  skills: readonly string[],
+  available = true,
+  currentWorkload = 0
+): Readonly<Record<string, WorkerCapabilities>> {
+  return Object.freeze({
+    researcher: Object.freeze({
+      skills: Object.freeze([...skills]),
+      tools: Object.freeze(['search']),
+      available,
+      currentWorkload,
+    }),
+  });
+}
+
+function createCheckpointedSystem(checkpointer: MemorySaver) {
+  return createMultiAgentSystem({
+    supervisor: { strategy: 'round-robin' },
+    workers: [
+      {
+        id: 'researcher',
+        capabilities: {
+          skills: ['research'],
+          tools: ['search'],
+          available: true,
+          currentWorkload: 0,
+        },
+        tools: [{ name: 'search' }],
+      },
+    ],
+    maxIterations: 0,
+    checkpointer,
+  });
+}
+
+describe('Multi-Agent Worker checkpoint lifecycle', () => {
+  it('preserves checkpointed Worker status across executions in one thread', async () => {
+    const system = createCheckpointedSystem(new MemorySaver());
+    const config = { configurable: { thread_id: 'status-persistence' } };
+
+    await system.invoke(
+      {
+        input: 'first',
+        workers: {
+          researcher: {
+            skills: ['caller-owned'],
+            tools: ['caller-owned'],
+            available: false,
+            currentWorkload: 4,
+          },
+        },
+      },
+      config
+    );
+    const result = (await system.invoke({ input: 'second' }, config)) as MultiAgentStateType;
+
+    expect(result.workers.researcher).toEqual({
+      skills: ['research'],
+      tools: ['search'],
+      available: false,
+      currentWorkload: 4,
+    });
+  });
+
+  it('resumes with the captured Worker snapshot and initializes the next execution afresh', async () => {
+    let currentCapabilities = workerCapabilities(['research'], false, 3);
+    const captureWorkerCapabilities = vi.fn(() => currentCapabilities);
+    const workflow = new StateGraph(MultiAgentState);
+
+    workflow.addNode(
+      'initializeWorkers',
+      createWorkerInitializationNode(captureWorkerCapabilities)
+    );
+    workflow.addNode('interruptingWorker', async (state: MultiAgentStateType) => {
+      const response = interrupt<string, string>('continue?');
+      return { response, workers: state.workers };
+    });
+    workflow.setEntryPoint('initializeWorkers');
+    workflow.addEdge('initializeWorkers', 'interruptingWorker');
+    workflow.addEdge('interruptingWorker', END);
+
+    const graph = workflow.compile({ checkpointer: new MemorySaver() });
+    const interruptedConfig = { configurable: { thread_id: 'interrupted' } };
+    const interrupted = await graph.invoke({ input: 'first' }, interruptedConfig);
+
+    expect(interrupted).toHaveProperty('__interrupt__');
+    expect(interrupted.workers.researcher).toMatchObject({
+      skills: ['research'],
+      available: false,
+      currentWorkload: 3,
+    });
+    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+
+    currentCapabilities = workerCapabilities(['updated-research'], true, 0);
+    const resumed = await graph.invoke(new Command({ resume: 'approved' }), interruptedConfig);
+
+    expect(resumed.workers.researcher).toMatchObject({
+      skills: ['research'],
+      available: false,
+      currentWorkload: 3,
+    });
+    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+
+    const later = await graph.invoke({ input: 'later' }, interruptedConfig);
+
+    expect(later.workers.researcher).toMatchObject({
+      skills: ['updated-research'],
+      available: false,
+      currentWorkload: 3,
+    });
+    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves a failure thrown while resuming an interrupted execution', async () => {
+    const cause = new Error('resume cause');
+    const failure = new Error('resume failure', { cause });
+    const captureWorkerCapabilities = vi.fn(() => workerCapabilities(['research']));
+    const workflow = new StateGraph(MultiAgentState);
+
+    workflow.addNode(
+      'initializeWorkers',
+      createWorkerInitializationNode(captureWorkerCapabilities)
+    );
+    workflow.addNode('interruptingWorker', async () => {
+      interrupt('continue?');
+      throw failure;
+    });
+    workflow.setEntryPoint('initializeWorkers');
+    workflow.addEdge('initializeWorkers', 'interruptingWorker');
+    workflow.addEdge('interruptingWorker', END);
+
+    const graph = workflow.compile({ checkpointer: new MemorySaver() });
+    const config = { configurable: { thread_id: 'resume-failure' } };
+
+    await graph.invoke({ input: 'first' }, config);
+
+    await expect(graph.invoke(new Command({ resume: 'approved' }), config)).rejects.toBe(failure);
+    expect(failure.cause).toBe(cause);
+    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/patterns/tests/multi-agent/agent-checkpoint-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-checkpoint-lifecycle.test.ts
@@ -40,6 +40,21 @@ function createCheckpointedSystem(checkpointer: MemorySaver) {
   });
 }
 
+function createInterruptibleGraph(
+  captureWorkerSnapshot: () => Readonly<Record<string, WorkerCapabilities>>,
+  interruptingWorker: (state: MultiAgentStateType) => Promise<Partial<MultiAgentStateType>>
+) {
+  const workflow = new StateGraph(MultiAgentState);
+
+  workflow.addNode('initializeWorkers', createWorkerInitializationNode(captureWorkerSnapshot));
+  workflow.addNode('interruptingWorker', interruptingWorker);
+  workflow.setEntryPoint('initializeWorkers');
+  workflow.addEdge('initializeWorkers', 'interruptingWorker');
+  workflow.addEdge('interruptingWorker', END);
+
+  return workflow.compile({ checkpointer: new MemorySaver() });
+}
+
 describe('Multi-Agent Worker checkpoint lifecycle', () => {
   it('preserves checkpointed Worker status across executions in one thread', async () => {
     const system = createCheckpointedSystem(new MemorySaver());
@@ -71,22 +86,11 @@ describe('Multi-Agent Worker checkpoint lifecycle', () => {
 
   it('resumes with the captured Worker snapshot and initializes the next execution afresh', async () => {
     let currentCapabilities = workerCapabilities(['research'], false, 3);
-    const captureWorkerCapabilities = vi.fn(() => currentCapabilities);
-    const workflow = new StateGraph(MultiAgentState);
-
-    workflow.addNode(
-      'initializeWorkers',
-      createWorkerInitializationNode(captureWorkerCapabilities)
-    );
-    workflow.addNode('interruptingWorker', async (state: MultiAgentStateType) => {
+    const captureWorkerSnapshot = vi.fn(() => currentCapabilities);
+    const graph = createInterruptibleGraph(captureWorkerSnapshot, async (state) => {
       const response = interrupt<string, string>('continue?');
       return { response, workers: state.workers };
     });
-    workflow.setEntryPoint('initializeWorkers');
-    workflow.addEdge('initializeWorkers', 'interruptingWorker');
-    workflow.addEdge('interruptingWorker', END);
-
-    const graph = workflow.compile({ checkpointer: new MemorySaver() });
     const interruptedConfig = { configurable: { thread_id: 'interrupted' } };
     const interrupted = await graph.invoke({ input: 'first' }, interruptedConfig);
 
@@ -96,7 +100,7 @@ describe('Multi-Agent Worker checkpoint lifecycle', () => {
       available: false,
       currentWorkload: 3,
     });
-    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+    expect(captureWorkerSnapshot).toHaveBeenCalledTimes(1);
 
     currentCapabilities = workerCapabilities(['updated-research'], true, 0);
     const resumed = await graph.invoke(new Command({ resume: 'approved' }), interruptedConfig);
@@ -106,7 +110,7 @@ describe('Multi-Agent Worker checkpoint lifecycle', () => {
       available: false,
       currentWorkload: 3,
     });
-    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+    expect(captureWorkerSnapshot).toHaveBeenCalledTimes(1);
 
     const later = await graph.invoke({ input: 'later' }, interruptedConfig);
 
@@ -115,34 +119,23 @@ describe('Multi-Agent Worker checkpoint lifecycle', () => {
       available: false,
       currentWorkload: 3,
     });
-    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(2);
+    expect(captureWorkerSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it('preserves a failure thrown while resuming an interrupted execution', async () => {
     const cause = new Error('resume cause');
     const failure = new Error('resume failure', { cause });
-    const captureWorkerCapabilities = vi.fn(() => workerCapabilities(['research']));
-    const workflow = new StateGraph(MultiAgentState);
-
-    workflow.addNode(
-      'initializeWorkers',
-      createWorkerInitializationNode(captureWorkerCapabilities)
-    );
-    workflow.addNode('interruptingWorker', async () => {
+    const captureWorkerSnapshot = vi.fn(() => workerCapabilities(['research']));
+    const graph = createInterruptibleGraph(captureWorkerSnapshot, async () => {
       interrupt('continue?');
       throw failure;
     });
-    workflow.setEntryPoint('initializeWorkers');
-    workflow.addEdge('initializeWorkers', 'interruptingWorker');
-    workflow.addEdge('interruptingWorker', END);
-
-    const graph = workflow.compile({ checkpointer: new MemorySaver() });
     const config = { configurable: { thread_id: 'resume-failure' } };
 
     await graph.invoke({ input: 'first' }, config);
 
     await expect(graph.invoke(new Command({ resume: 'approved' }), config)).rejects.toBe(failure);
     expect(failure.cause).toBe(cause);
-    expect(captureWorkerCapabilities).toHaveBeenCalledTimes(1);
+    expect(captureWorkerSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -121,9 +121,9 @@ describe('Worker lifecycle admission', () => {
     expect(Object.isFrozen(admitted.capabilities.skills)).toBe(true);
     expect(Object.isFrozen(admitted.capabilities.tools)).toBe(true);
     expect(Object.isFrozen(admitted.tools)).toBe(true);
-    expect(lifecycle.captureWorkerCapabilities()).toEqual({
+    expect(lifecycle.captureWorkerSnapshot()).toEqual({
       researcher: admitted.capabilities,
     });
-    expect(Object.isFrozen(lifecycle.captureWorkerCapabilities())).toBe(true);
+    expect(Object.isFrozen(lifecycle.captureWorkerSnapshot())).toBe(true);
   });
 });

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -121,5 +121,9 @@ describe('Worker lifecycle admission', () => {
     expect(Object.isFrozen(admitted.capabilities.skills)).toBe(true);
     expect(Object.isFrozen(admitted.capabilities.tools)).toBe(true);
     expect(Object.isFrozen(admitted.tools)).toBe(true);
+    expect(lifecycle.captureWorkerCapabilities()).toEqual({
+      researcher: admitted.capabilities,
+    });
+    expect(Object.isFrozen(lifecycle.captureWorkerCapabilities())).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- capture an immutable Worker lifecycle snapshot when each new graph execution enters initialization
- preserve checkpointed Worker availability and workload across subsequent executions on the same thread
- verify LangGraph 1.1.2 interrupt/resume entry-point behavior and preserve resume failure identity

## Validation

- pnpm test (2607 passed, 110 skipped)
- pnpm typecheck
- pnpm lint:ci
- targeted Prettier checks for changed files
- two-axis code review: no remaining Standards or Spec findings

Closes #182