### PR TITLE
Worker lifecycle: privatize legacy routing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,26 @@ import { createMultiAgentSystem } from '@agentforge/patterns';
 const system = createMultiAgentSystem({
   supervisor: { model: llm, strategy: 'skill-based' },
   workers: [
-    { id: 'tech_support', capabilities: { skills: ['technical'], tools: [], available: true, currentWorkload: 0 } },
-    { id: 'billing_support', capabilities: { skills: ['billing'], tools: [], available: true, currentWorkload: 0 } },
+    {
+      id: 'tech_support',
+      model: llm,
+      capabilities: {
+        skills: ['technical'],
+        tools: [],
+        available: true,
+        currentWorkload: 0,
+      },
+    },
+    {
+      id: 'billing_support',
+      model: llm,
+      capabilities: {
+        skills: ['billing'],
+        tools: [],
+        available: true,
+        currentWorkload: 0,
+      },
+    },
   ],
   aggregator: { model: llm },
 });

--- a/README.md
+++ b/README.md
@@ -138,18 +138,16 @@ const agent = createReflectionAgent({
 ### 4. Multi-Agent
 Coordinate specialized agents
 ```typescript
-import { createMultiAgentSystem, registerWorkers } from '@agentforge/patterns';
+import { createMultiAgentSystem } from '@agentforge/patterns';
 
 const system = createMultiAgentSystem({
   supervisor: { model: llm, strategy: 'skill-based' },
-  workers: [],
+  workers: [
+    { id: 'tech_support', capabilities: { skills: ['technical'], tools: [], available: true, currentWorkload: 0 } },
+    { id: 'billing_support', capabilities: { skills: ['billing'], tools: [], available: true, currentWorkload: 0 } },
+  ],
   aggregator: { model: llm },
 });
-
-registerWorkers(system, [
-  { name: 'tech_support', capabilities: ['technical'], tools: [...] },
-  { name: 'billing_support', capabilities: ['billing'], tools: [...] },
-]);
 ```
 
 See the [Pattern Comparison Guide](./packages/patterns/docs/pattern-comparison.md) to choose the right pattern.

--- a/docs-site/api/patterns.md
+++ b/docs-site/api/patterns.md
@@ -175,7 +175,7 @@ Coordinate multiple specialized agents with a supervisor-worker architecture.
 
 ### MultiAgentSystemBuilder (Recommended)
 
-Builder class for creating multi-agent systems with dynamic worker registration.
+Builder class for admitting a fixed Worker topology before compilation.
 
 ```typescript
 import { MultiAgentSystemBuilder } from '@agentforge/patterns';
@@ -531,4 +531,3 @@ See the [Examples](/examples/react-agent) section for complete working examples 
 ## Type Definitions
 
 All exports include full TypeScript definitions. See the [source code](https://github.com/TVScoundrel/agentforge/tree/main/packages/patterns/src) for complete type information.
-

--- a/docs-site/guide/patterns/multi-agent.md
+++ b/docs-site/guide/patterns/multi-agent.md
@@ -541,7 +541,7 @@ const finalResult = await system.invoke(
 
 ## Multi-Agent System Builder
 
-Use the builder pattern for dynamic worker registration:
+Use the builder pattern to construct the fixed Worker topology before compilation:
 
 ```typescript
 import { MultiAgentSystemBuilder } from '@agentforge/patterns';
@@ -1272,4 +1272,3 @@ Parallel routing is fully backward compatible. Existing systems continue to work
 - [AutoGen Paper](https://arxiv.org/abs/2308.08155) - Microsoft's multi-agent framework
 - [MetaGPT Paper](https://arxiv.org/abs/2308.00352) - Multi-agent collaboration
 - [Examples](/examples/multi-agent) - Working code examples
-

--- a/docs-site/guide/patterns/multi-agent.md
+++ b/docs-site/guide/patterns/multi-agent.md
@@ -554,7 +554,7 @@ const builder = new MultiAgentSystemBuilder({
   aggregator: { model }
 });
 
-// Register workers dynamically
+// Admit Workers before compilation
 builder.registerWorkers([
   {
     name: 'researcher',

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -430,7 +430,7 @@ import {
 - `createMultiAgentSystem(config)` - Create a complete Multi-Agent system
 - `MultiAgentSystemBuilder` - Builder for creating Multi-Agent systems with workers
 - `createWorkersRegistry(workers)` - Construct detached, normalized Worker registry records containing declared capabilities and invocation status without admitting Workers or creating graph topology
-- `registerWorkers(system, workers)` - Update worker capabilities in state (Note: does not add worker nodes to compiled graphs; use builder or pass workers to createMultiAgentSystem)
+- `registerWorkers(system, workers)` - Deprecated adapter that updates routing skills for known Workers; supplied tools must match the compiled executable tool set
 
 **Configuration**:
 ```typescript

--- a/packages/patterns/docs/multi-agent-pattern.md
+++ b/packages/patterns/docs/multi-agent-pattern.md
@@ -542,7 +542,7 @@ const system = createMultiAgentSystem({
 
 ### MultiAgentSystemBuilder (Recommended)
 
-Builder class for creating multi-agent systems with dynamic worker registration.
+Builder class for admitting a fixed Worker topology before compilation.
 
 ```typescript
 class MultiAgentSystemBuilder {
@@ -679,9 +679,12 @@ const system = createMultiAgentSystem({
 
 ### registerWorkers() (Deprecated)
 
-> **DEPRECATED**: This function only updates worker capabilities in the state, but does not add worker nodes to the graph. Use `MultiAgentSystemBuilder` instead for proper dynamic worker registration.
+> **DEPRECATED**: This function updates routing skills for known Workers only. Use `MultiAgentSystemBuilder` to admit Workers before compilation.
 
-Registers workers with the multi-agent system. This function has a fundamental limitation: it can only update the worker capabilities in the state, but cannot add new nodes to the compiled graph (LangGraph graphs are immutable after compilation).
+Updates routing skills through the Worker lifecycle privately associated with a
+compiled Multi-Agent System. It cannot add Worker identities or change executable
+tools after compilation. When `tools` are supplied, their normalized names must
+match the compiled executable tool set; ordering does not matter.
 
 ```typescript
 function registerWorkers(
@@ -691,21 +694,21 @@ function registerWorkers(
 ```
 
 **Limitations**:
-- Does NOT add worker nodes to the graph
-- Only updates worker capabilities in state
-- Workers must already exist as nodes in the graph
-- Can update capabilities of existing workers
+- Does not add Worker nodes to the graph
+- Workers must already exist in the compiled Worker topology
+- Updates routing skills only; Worker status remains execution-owned
+- Treats supplied tools as assertions about the compiled executable tool set
 
 **Recommended Alternative**: Use `MultiAgentSystemBuilder` instead:
 
 ```typescript
-// ❌ Old way (deprecated)
-const system = createMultiAgentSystem({ workers: [] });
-registerWorkers(system, [worker1, worker2]); // Only updates state, no nodes added!
+// ❌ Deprecated compatibility update for an already-compiled Worker
+const system = createMultiAgentSystem({ ...config, workers: [worker1] });
+registerWorkers(system, [{ name: worker1.id, capabilities: ['new-routing-skill'] }]);
 
 // ✅ New way (recommended)
 const builder = new MultiAgentSystemBuilder({ supervisor, aggregator });
-builder.registerWorkers([worker1, worker2]); // Properly adds nodes
+builder.registerWorkers([worker1, worker2]); // Admits Workers before compilation
 const system = builder.build();
 ```
 
@@ -1223,9 +1226,9 @@ const parallelWorkflow = new StateGraph({ channels: MultiAgentState })
   .addEdge('aggregator', END);
 ```
 
-### Dynamic Worker Registration
+### Worker Topology Construction
 
-Use `MultiAgentSystemBuilder` for dynamic worker registration:
+Use `MultiAgentSystemBuilder` to construct the fixed Worker topology incrementally:
 
 ```typescript
 const builder = new MultiAgentSystemBuilder({

--- a/packages/patterns/src/multi-agent/agent-graph.ts
+++ b/packages/patterns/src/multi-agent/agent-graph.ts
@@ -5,7 +5,11 @@ import { MultiAgentState } from './state.js';
 import type { MultiAgentStateType } from './state.js';
 import type { MultiAgentSystemWithRegistry } from './agent-types.js';
 import type { MultiAgentRouter, MultiAgentSystemConfig } from './types.js';
-import { admitWorkerTopology, type WorkerLifecycle } from './worker-lifecycle.js';
+import {
+  admitWorkerTopology,
+  associateWorkerLifecycle,
+  type WorkerLifecycle,
+} from './worker-lifecycle.js';
 import { createWorkerInitializationNode } from './worker-initialization.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
@@ -123,7 +127,9 @@ export function createCompiledMultiAgentSystem(
   // @ts-expect-error - LangGraph StateGraph generic mismatch with string node names
   workflow.addConditionalEdges('aggregator', aggregatorRouter, [END]);
 
-  return workflow.compile(
+  const system = workflow.compile(
     checkpointer ? { checkpointer } : undefined
   ) as unknown as MultiAgentSystemWithRegistry;
+  associateWorkerLifecycle(system, lifecycle);
+  return system;
 }

--- a/packages/patterns/src/multi-agent/agent-runtime.ts
+++ b/packages/patterns/src/multi-agent/agent-runtime.ts
@@ -1,55 +1,15 @@
-import type { RunnableConfig } from '@langchain/core/runnables';
-import type { WorkerCapabilities } from './schemas.js';
-import type { MultiAgentStateType } from './state.js';
 import type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-types.js';
-import { toWorkerCapabilities } from './agent-workers.js';
-
-function mergeWorkers(
-  input: Partial<MultiAgentStateType>,
-  workerCapabilities: Readonly<Record<string, WorkerCapabilities>>
-): Partial<MultiAgentStateType> {
-  return {
-    ...input,
-    workers: {
-      ...workerCapabilities,
-      ...(input.workers || {}),
-    },
-  };
-}
+import { resolveWorkerLifecycle } from './worker-lifecycle.js';
 
 export function registerWorkerCapabilities(
   system: MultiAgentSystemWithRegistry,
   workers: RegisterWorkerInput[]
 ): void {
-  if (!system._workerRegistry) {
-    system._workerRegistry = {};
-  }
-
-  for (const worker of workers) {
-    system._workerRegistry[worker.name] = toWorkerCapabilities(worker);
-  }
-
-  if (!system._originalInvoke) {
-    system._originalInvoke = system.invoke.bind(system);
-    system.invoke = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
-      return system._originalInvoke!(
-        mergeWorkers(input, system._workerRegistry || {}) as Parameters<
-          NonNullable<typeof system._originalInvoke>
-        >[0],
-        config as Parameters<NonNullable<typeof system._originalInvoke>>[1]
-      );
-    } as unknown as typeof system.invoke;
-  }
-
-  if (!system._originalStream) {
-    system._originalStream = system.stream.bind(system);
-    system.stream = async function (input: Partial<MultiAgentStateType>, config?: RunnableConfig) {
-      return system._originalStream!(
-        mergeWorkers(input, system._workerRegistry || {}) as Parameters<
-          NonNullable<typeof system._originalStream>
-        >[0],
-        config as Parameters<NonNullable<typeof system._originalStream>>[1]
-      );
-    } as unknown as typeof system.stream;
-  }
+  resolveWorkerLifecycle(system).updateRoutingSkills(
+    workers.map((worker) => ({
+      id: worker.name,
+      skills: worker.capabilities,
+      ...(worker.tools === undefined ? {} : { tools: worker.tools }),
+    }))
+  );
 }

--- a/packages/patterns/src/multi-agent/agent-runtime.ts
+++ b/packages/patterns/src/multi-agent/agent-runtime.ts
@@ -9,7 +9,7 @@ export function registerWorkerCapabilities(
     workers.map((worker) => ({
       id: worker.name,
       skills: worker.capabilities,
-      ...(worker.tools === undefined ? {} : { tools: worker.tools }),
+      ...(worker.tools === undefined ? {} : { assertedTools: worker.tools }),
     }))
   );
 }

--- a/packages/patterns/src/multi-agent/agent-types.ts
+++ b/packages/patterns/src/multi-agent/agent-types.ts
@@ -1,6 +1,4 @@
-import type { RunnableConfig } from '@langchain/core/runnables';
 import type { CompiledStateGraph } from '@langchain/langgraph';
-import type { WorkerCapabilities } from './schemas.js';
 import type { MultiAgentStateType } from './state.js';
 import type { WorkerConfig } from './types.js';
 
@@ -16,15 +14,4 @@ export interface BuilderWorkerInput extends RegisterWorkerInput {
   model?: WorkerConfig['model'];
 }
 
-export interface MultiAgentSystemWithRegistry
-  extends CompiledStateGraph<MultiAgentStateType, unknown> {
-  _workerRegistry?: Record<string, WorkerCapabilities>;
-  _originalInvoke?: (
-    input: Partial<MultiAgentStateType>,
-    config?: RunnableConfig,
-  ) => ReturnType<MultiAgentSystemWithRegistry['invoke']>;
-  _originalStream?: (
-    input: Partial<MultiAgentStateType>,
-    config?: RunnableConfig,
-  ) => ReturnType<MultiAgentSystemWithRegistry['stream']>;
-}
+export type MultiAgentSystemWithRegistry = CompiledStateGraph<MultiAgentStateType, unknown>;

--- a/packages/patterns/src/multi-agent/agent-workers.ts
+++ b/packages/patterns/src/multi-agent/agent-workers.ts
@@ -1,16 +1,5 @@
-import type { WorkerCapabilities } from './schemas.js';
-import type { BuilderWorkerInput, RegisterWorkerInput } from './agent-types.js';
+import type { BuilderWorkerInput } from './agent-types.js';
 import type { WorkerConfig } from './types.js';
-import { normalizeWorkerToolNames } from './worker-lifecycle.js';
-
-export function toWorkerCapabilities(worker: RegisterWorkerInput): WorkerCapabilities {
-  return {
-    skills: worker.capabilities,
-    tools: [...normalizeWorkerToolNames(worker.name, worker.tools)],
-    available: true,
-    currentWorkload: 0,
-  };
-}
 
 export function toWorkerConfig(
   worker: BuilderWorkerInput,

--- a/packages/patterns/src/multi-agent/agent.ts
+++ b/packages/patterns/src/multi-agent/agent.ts
@@ -19,6 +19,7 @@ export type { MultiAgentSystemWithRegistry, RegisterWorkerInput } from './agent-
 export { WorkerLifecycleError, type WorkerLifecycleErrorReason } from './worker-lifecycle.js';
 
 const logger = createPatternLogger('agentforge:patterns:multi-agent:system');
+const systemsWarnedAboutLegacyRegistration = new WeakSet<object>();
 
 /**
  * Create a multi-agent coordination system
@@ -114,13 +115,13 @@ export function createMultiAgentSystem(
 /**
  * Register workers with a compiled multi-agent system
  *
- * **Important**: This function only registers worker *capabilities* in the state.
- * It does NOT add worker nodes to the graph (which is impossible after compilation).
+ * **Important**: This function only updates routing skills for known Workers.
+ * It does NOT add Worker nodes or change executable tools after compilation.
  *
  * This means:
- * - Workers must already exist as nodes in the compiled graph
- * - This function only updates their capabilities in the state
- * - For true dynamic worker registration, use `MultiAgentSystemBuilder` instead
+ * - Workers must already exist in the compiled Worker topology
+ * - Supplied tools, when present, must match the compiled executable tool set
+ * - Use `MultiAgentSystemBuilder` to admit Workers before compilation
  *
  * **Recommended**: Use `MultiAgentSystemBuilder` for a cleaner approach:
  * ```typescript
@@ -142,11 +143,14 @@ export function registerWorkers(
   system: MultiAgentSystemWithRegistry,
   workers: RegisterWorkerInput[]
 ): void {
-  logger.warn(
-    '[AgentForge] registerWorkers() on a compiled system only updates worker capabilities in state.\n' +
-      'It does NOT add worker nodes to the graph. Use MultiAgentSystemBuilder for proper worker registration.\n' +
-      'See: https://github.com/TVScoundrel/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
-  );
+  if (!systemsWarnedAboutLegacyRegistration.has(system)) {
+    systemsWarnedAboutLegacyRegistration.add(system);
+    logger.warn(
+      '[AgentForge] registerWorkers() on a compiled system only updates routing skills for known Workers.\n' +
+        'It does NOT add Worker nodes or change compiled tools. Use MultiAgentSystemBuilder before compilation.\n' +
+        'See: https://github.com/TVScoundrel/agentforge/blob/main/packages/patterns/docs/multi-agent-pattern.md'
+    );
+  }
   registerWorkerCapabilities(system, workers);
 }
 

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -22,7 +22,16 @@ export class WorkerLifecycleError extends Error {
 export interface WorkerLifecycle {
   readonly topology: readonly WorkerConfig[];
   readonly captureWorkerSnapshot: () => Readonly<Record<string, WorkerCapabilities>>;
+  readonly updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
 }
+
+export interface WorkerRoutingSkillUpdate {
+  readonly id: string;
+  readonly skills: readonly string[];
+  readonly tools?: readonly unknown[];
+}
+
+const workerLifecycles = new WeakMap<object, WorkerLifecycle>();
 
 type ToolLike = {
   metadata?: { name?: unknown };
@@ -152,14 +161,72 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
 
   validateIdentities(workers);
   const topology = Object.freeze(workers.map(admitWorker));
-  const workerCapabilities = Object.freeze(
+  let workerCapabilities = Object.freeze(
     Object.fromEntries(topology.map((worker) => [worker.id, worker.capabilities]))
   );
 
   return Object.freeze({
     topology,
     captureWorkerSnapshot: () => workerCapabilities,
+    updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => {
+      validateIdentities(updates);
+
+      const replacements = updates.map((update) => {
+        const current = workerCapabilities[update.id];
+        if (!Object.hasOwn(workerCapabilities, update.id) || !current) {
+          throw new WorkerLifecycleError(
+            'unknown-worker',
+            `Cannot update unknown Worker "${update.id}" after compilation.`
+          );
+        }
+
+        if (update.tools !== undefined) {
+          const assertedTools = [...normalizeWorkerToolNames(update.id, update.tools)].sort();
+          const executableTools = [...current.tools].sort();
+          if (
+            assertedTools.length !== executableTools.length ||
+            assertedTools.some((toolName, index) => toolName !== executableTools[index])
+          ) {
+            throw new WorkerLifecycleError(
+              'invalid-tool',
+              `Worker "${update.id}" tools do not match its compiled executable tools.`
+            );
+          }
+        }
+
+        return [
+          update.id,
+          asCompatibleWorkerCapabilities(
+            Object.freeze({
+              ...current,
+              skills: Object.freeze([...update.skills]),
+            })
+          ),
+        ] as const;
+      });
+
+      workerCapabilities = Object.freeze({
+        ...workerCapabilities,
+        ...Object.fromEntries(replacements),
+      });
+    },
   });
+}
+
+export function associateWorkerLifecycle(system: object, lifecycle: WorkerLifecycle): void {
+  workerLifecycles.set(system, lifecycle);
+}
+
+export function resolveWorkerLifecycle(system: object): WorkerLifecycle {
+  const lifecycle = workerLifecycles.get(system);
+  if (!lifecycle) {
+    throw new WorkerLifecycleError(
+      'unsupported-system',
+      'The compiled graph was not created by the Worker lifecycle.'
+    );
+  }
+
+  return lifecycle;
 }
 
 export function createWorkerRegistryData(

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -28,7 +28,7 @@ export interface WorkerLifecycle {
 export interface WorkerRoutingSkillUpdate {
   readonly id: string;
   readonly skills: readonly string[];
-  readonly tools?: readonly unknown[];
+  readonly assertedTools?: readonly unknown[];
 }
 
 const workerLifecycles = new WeakMap<object, WorkerLifecycle>();
@@ -180,8 +180,10 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
           );
         }
 
-        if (update.tools !== undefined) {
-          const assertedTools = [...normalizeWorkerToolNames(update.id, update.tools)].sort();
+        if (update.assertedTools !== undefined) {
+          const assertedTools = [
+            ...normalizeWorkerToolNames(update.id, update.assertedTools),
+          ].sort();
           const executableTools = [...current.tools].sort();
           if (
             assertedTools.length !== executableTools.length ||

--- a/packages/patterns/tests/multi-agent/agent-register-workers.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-register-workers.test.ts
@@ -1,12 +1,30 @@
-import { describe, expect, it } from 'vitest';
-import { createMultiAgentSystem, registerWorkers } from '../../src/multi-agent/agent.js';
+import { StateGraph } from '@langchain/langgraph';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createMultiAgentSystem,
+  registerWorkers,
+  WorkerLifecycleError,
+} from '../../src/multi-agent/agent.js';
+import type { MultiAgentSystemWithRegistry } from '../../src/multi-agent/agent-types.js';
+import { MultiAgentState } from '../../src/multi-agent/state.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
 import type { MultiAgentSystemConfig } from '../../src/multi-agent/types.js';
+
+const mockedLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('../../src/shared/deduplication.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/shared/deduplication.js')>()),
+  createPatternLogger: () => mockedLogger,
+}));
 
 function createBaseConfig(): MultiAgentSystemConfig {
   return {
-    supervisor: {
-      strategy: 'round-robin',
-    },
+    supervisor: { strategy: 'round-robin' },
     workers: [
       {
         id: 'initial',
@@ -18,66 +36,145 @@ function createBaseConfig(): MultiAgentSystemConfig {
         },
       },
     ],
+    maxIterations: 0,
   };
 }
 
+async function workerState(system: MultiAgentSystemWithRegistry) {
+  const result = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+  return result.workers;
+}
+
 describe('Multi-Agent worker registration', () => {
-  it('should create workers registry', () => {
+  it('updates routing skills for a known Worker in subsequent executions', async () => {
     const system = createMultiAgentSystem(createBaseConfig());
 
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [{ name: 'tool1' }],
-      },
-      {
-        name: 'worker2',
-        capabilities: ['skill2'],
-        tools: [{ name: 'tool2' }],
-      },
-    ]);
+    registerWorkers(system, [{ name: 'initial', capabilities: ['updated'] }]);
 
-    expect(system._workerRegistry).toEqual({
-      worker1: {
-        skills: ['skill1'],
-        tools: ['tool1'],
-        available: true,
-        currentWorkload: 0,
-      },
-      worker2: {
-        skills: ['skill2'],
-        tools: ['tool2'],
+    expect(await workerState(system)).toEqual({
+      initial: {
+        skills: ['updated'],
+        tools: [],
         available: true,
         currentWorkload: 0,
       },
     });
   });
 
-  it('should handle empty workers array', () => {
+  it('uses updated routing skills for subsequent routing decisions', async () => {
+    const system = createMultiAgentSystem({
+      supervisor: { strategy: 'skill-based' },
+      workers: [
+        {
+          id: 'initial',
+          capabilities: {
+            skills: ['research'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+        {
+          id: 'writer',
+          capabilities: {
+            skills: ['write'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
+      maxIterations: 1,
+    });
+
+    registerWorkers(system, [{ name: 'initial', capabilities: ['write'] }]);
+    const result = (await system.invoke({ input: 'write the report' })) as MultiAgentStateType;
+
+    expect(result.routingHistory[0]?.targetAgent).toBe('initial');
+  });
+
+  it('accepts an empty compatibility update without changing Worker state', async () => {
     const system = createMultiAgentSystem(createBaseConfig());
+
     registerWorkers(system, []);
-    expect(system._workerRegistry).toEqual({});
+
+    expect((await workerState(system)).initial?.skills).toEqual(['initial']);
   });
 
-  it('should handle single worker', () => {
+  it('rejects registration for an unknown Worker', () => {
     const system = createMultiAgentSystem(createBaseConfig());
 
-    registerWorkers(system, [
-      {
-        name: 'solo',
-        capabilities: ['everything'],
-        tools: [{ name: 'all' }],
-      },
-    ]);
+    expect(() =>
+      registerWorkers(system, [{ name: 'unknown', capabilities: ['impossible'] }])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'unknown-worker' })
+    );
+  });
 
-    expect(system._workerRegistry).toEqual({
-      solo: {
-        skills: ['everything'],
-        tools: ['all'],
-        available: true,
-        currentWorkload: 0,
-      },
+  it('rejects a compiled graph without an associated Worker lifecycle', () => {
+    const workflow = new StateGraph(MultiAgentState);
+    const system = workflow.compile() as unknown as MultiAgentSystemWithRegistry;
+
+    expect(() =>
+      registerWorkers(system, [{ name: 'initial', capabilities: ['updated'] }])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'unsupported-system' })
+    );
+  });
+
+  it('does not replace compiled graph execution methods', () => {
+    const system = createMultiAgentSystem(createBaseConfig());
+    const invoke = system.invoke;
+    const stream = system.stream;
+
+    registerWorkers(system, [{ name: 'initial', capabilities: ['updated'] }]);
+
+    expect(system.invoke).toBe(invoke);
+    expect(system.stream).toBe(stream);
+  });
+
+  it('applies a registration batch atomically', async () => {
+    const baseConfig = createBaseConfig();
+    const system = createMultiAgentSystem({
+      ...baseConfig,
+      workers: [
+        ...baseConfig.workers,
+        {
+          id: 'second',
+          capabilities: {
+            skills: ['second'],
+            tools: [],
+            available: true,
+            currentWorkload: 0,
+          },
+        },
+      ],
     });
+
+    expect(() =>
+      registerWorkers(system, [
+        { name: 'initial', capabilities: ['must-not-publish'] },
+        { name: 'unknown', capabilities: ['invalid'] },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'unknown-worker' })
+    );
+
+    expect(await workerState(system)).toMatchObject({
+      initial: { skills: ['initial'] },
+      second: { skills: ['second'] },
+    });
+  });
+
+  it('emits one deprecation warning per Multi-Agent System', () => {
+    mockedLogger.warn.mockClear();
+    const first = createMultiAgentSystem(createBaseConfig());
+    const second = createMultiAgentSystem(createBaseConfig());
+
+    registerWorkers(first, []);
+    registerWorkers(first, []);
+    registerWorkers(second, []);
+
+    expect(mockedLogger.warn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/patterns/tests/multi-agent/agent-tools.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-tools.test.ts
@@ -6,29 +6,44 @@ import {
   registerWorkers,
   WorkerLifecycleError,
 } from '../../src/multi-agent/agent.js';
-import type { MultiAgentSystemConfig } from '../../src/multi-agent/types.js';
+import type { MultiAgentStateType } from '../../src/multi-agent/state.js';
+import type { WorkerConfig } from '../../src/multi-agent/types.js';
 
-function createBaseConfig(): MultiAgentSystemConfig {
-  return {
-    supervisor: {
-      strategy: 'round-robin',
-    },
+function createSystem(tools: WorkerConfig['tools'] = []) {
+  return createMultiAgentSystem({
+    supervisor: { strategy: 'round-robin' },
     workers: [
       {
-        id: 'initial',
+        id: 'worker1',
         capabilities: {
           skills: ['initial'],
           tools: [],
           available: true,
           currentWorkload: 0,
         },
+        tools,
       },
     ],
-  };
+    maxIterations: 0,
+  });
 }
 
-describe('Multi-Agent tool mapping and stream registration', () => {
-  it('should correctly extract tool names from AgentForge Tools in registerWorkers', () => {
+async function registeredWorker(tools: WorkerConfig['tools'], assertedTools = tools) {
+  const system = createSystem(tools);
+  registerWorkers(system, [
+    {
+      name: 'worker1',
+      capabilities: ['updated'],
+      tools: assertedTools,
+    },
+  ]);
+
+  const result = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+  return result.workers.worker1;
+}
+
+describe('Multi-Agent legacy tool assertions', () => {
+  it('accepts matching AgentForge tool names', async () => {
     const agentforgeTool1 = toolBuilder()
       .name('agentforge-tool-1')
       .description('First AgentForge tool')
@@ -36,7 +51,6 @@ describe('Multi-Agent tool mapping and stream registration', () => {
       .schema(z.object({ input: z.string().describe('Input') }))
       .implement(async ({ input }) => input)
       .build();
-
     const agentforgeTool2 = toolBuilder()
       .name('agentforge-tool-2')
       .description('Second AgentForge tool')
@@ -45,84 +59,42 @@ describe('Multi-Agent tool mapping and stream registration', () => {
       .implement(async ({ input }) => input)
       .build();
 
-    const system = createMultiAgentSystem(createBaseConfig());
-
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [agentforgeTool1, agentforgeTool2],
-      },
-    ]);
-
-    expect(system._workerRegistry).toEqual({
-      worker1: {
-        skills: ['skill1'],
-        tools: ['agentforge-tool-1', 'agentforge-tool-2'],
-        available: true,
-        currentWorkload: 0,
-      },
+    expect(await registeredWorker([agentforgeTool1, agentforgeTool2])).toMatchObject({
+      skills: ['updated'],
+      tools: ['agentforge-tool-1', 'agentforge-tool-2'],
     });
   });
 
-  it('should correctly extract tool names from LangChain tools in registerWorkers', () => {
-    const system = createMultiAgentSystem(createBaseConfig());
+  it('treats compiled tool names as an unordered set', async () => {
+    const compiledTools = [{ name: 'first' }, { name: 'second' }] as WorkerConfig['tools'];
+    const assertedTools = [{ name: ' second ' }, { name: 'first' }] as WorkerConfig['tools'];
 
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [{ name: 'langchain-tool-1' }, { name: 'langchain-tool-2' }],
-      },
-    ]);
-
-    expect(system._workerRegistry).toEqual({
-      worker1: {
-        skills: ['skill1'],
-        tools: ['langchain-tool-1', 'langchain-tool-2'],
-        available: true,
-        currentWorkload: 0,
-      },
+    expect(await registeredWorker(compiledTools, assertedTools)).toMatchObject({
+      skills: ['updated'],
+      tools: ['first', 'second'],
     });
   });
 
-  it('should handle mixed AgentForge and LangChain tools in registerWorkers', () => {
-    const agentforgeTool = toolBuilder()
-      .name('agentforge-tool')
-      .description('AgentForge tool')
-      .category(ToolCategory.UTILITY)
-      .schema(z.object({ input: z.string().describe('Input') }))
-      .implement(async ({ input }) => input)
-      .build();
+  it('rejects a tool set that differs from compiled executable tools', () => {
+    const system = createSystem([{ name: 'search' }] as WorkerConfig['tools']);
 
-    const system = createMultiAgentSystem(createBaseConfig());
-
-    registerWorkers(system, [
-      {
-        name: 'worker1',
-        capabilities: ['skill1'],
-        tools: [agentforgeTool, { name: 'langchain-tool' }],
-      },
-    ]);
-
-    expect(system._workerRegistry).toEqual({
-      worker1: {
-        skills: ['skill1'],
-        tools: ['agentforge-tool', 'langchain-tool'],
-        available: true,
-        currentWorkload: 0,
-      },
-    });
+    expect(() =>
+      registerWorkers(system, [
+        { name: 'worker1', capabilities: ['updated'], tools: [{ name: 'write' }] },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
+    );
   });
 
   it('rejects tools without a name through lifecycle validation', () => {
-    const system = createMultiAgentSystem(createBaseConfig());
+    const system = createSystem();
 
     expect(() =>
       registerWorkers(system, [
         {
           name: 'worker1',
-          capabilities: ['skill1'],
+          capabilities: ['updated'],
           tools: [{}],
         },
       ])
@@ -132,13 +104,13 @@ describe('Multi-Agent tool mapping and stream registration', () => {
   });
 
   it('rejects duplicate normalized tool names through lifecycle validation', () => {
-    const system = createMultiAgentSystem(createBaseConfig());
+    const system = createSystem([{ name: 'search' }] as WorkerConfig['tools']);
 
     expect(() =>
       registerWorkers(system, [
         {
           name: 'worker1',
-          capabilities: ['skill1'],
+          capabilities: ['updated'],
           tools: [{ name: 'search' }, { name: ' search ' }],
         },
       ])


### PR DESCRIPTION
Closes #183

## Summary

- privately associate compiled Multi-Agent Systems with their Worker lifecycle through a WeakMap
- update routing skills atomically for known Workers without patching graph execution methods
- validate compiled tool assertions and reject unknown Workers or unsupported graphs with stable lifecycle reasons
- replace implementation-field tests with observable execution and routing coverage
- align documentation with the fixed Worker topology

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint:ci`
- `git diff --check`

## Review

Two-axis code review completed: 0 remaining Standards findings; 0 Spec findings.