### PR TITLE
Worker lifecycle: finish legacy tool migration

### DIFF
--- a/docs-site/api/patterns.md
+++ b/docs-site/api/patterns.md
@@ -295,7 +295,8 @@ interface WorkerCapabilities {
 
 **build(): CompiledStateGraph**
 
-Compiles the system into an executable graph. After calling `build()`, the system is immutable.
+Compiles the system into an executable graph. After calling `build()`, Worker
+identities and executable tools are fixed and Workers cannot be added.
 
 ### createMultiAgentSystem()
 
@@ -342,6 +343,30 @@ interface MultiAgentSystemConfig {
   verbose?: boolean;
 }
 ```
+
+### registerWorkers(system, workers) (Deprecated)
+
+The standalone `registerWorkers(system, workers)` function is a compatibility
+adapter for Workers already present in a compiled Multi-Agent System. It may
+update their routing skills for later executions, but it cannot add Worker nodes
+or replace executable tools. When `tools` are supplied, they are normalized and
+checked as an unordered assertion of the Worker's compiled executable tool set.
+
+```typescript
+import { registerWorkers } from '@agentforge/patterns';
+
+registerWorkers(system, [
+  {
+    name: 'researcher',
+    capabilities: ['research', 'source-validation'],
+    tools: [webSearch], // Must match the tool set compiled for researcher
+  },
+]);
+```
+
+Recompile a new Multi-Agent System to add a Worker or change executable tools.
+Use this deprecated adapter only when a known Worker's routing skills must change
+for subsequent executions.
 
 ## Custom Patterns
 

--- a/docs-site/examples/multi-agent.md
+++ b/docs-site/examples/multi-agent.md
@@ -12,6 +12,10 @@ The Multi-Agent pattern:
 
 ## Complete Example
 
+This example admits every Worker before `build()`. The resulting Worker
+identities and executable tools are fixed for the lifetime of the compiled
+Multi-Agent System.
+
 ```typescript
 import { MultiAgentSystemBuilder } from '@agentforge/patterns';
 import { ChatOpenAI } from '@langchain/openai';
@@ -155,7 +159,7 @@ Best for:
 
 - **Specialization** - Each agent has expertise
 - **Coordination** - Smart task routing
-- **Scalability** - Add more agents easily
+- **Scalability** - Recompile a topology with additional Workers as needs grow
 - **Flexibility** - Sequential, parallel, or custom workflows
 - **Efficiency** - Parallel execution when possible
 
@@ -264,4 +268,3 @@ agentInvocations.inc({ agent_name: 'researcher' });
 
 - [Custom Patterns](/tutorials/advanced-patterns) - Create your own patterns
 - [Production Deployment](/tutorials/production-deployment) - Deploy multi-agent systems
-

--- a/docs-site/guide/patterns/multi-agent.md
+++ b/docs-site/guide/patterns/multi-agent.md
@@ -36,6 +36,12 @@ Not sure which pattern to use? See the [Agent Patterns Overview](/guide/concepts
 
 ## Basic Usage
 
+Worker identities and executable tools form a fixed Worker topology when the
+Multi-Agent System is compiled. Use the factory directly or the builder shown
+later in this guide to admit every Worker before compilation. The deprecated
+compiled-system registration adapter cannot add Worker nodes or change tools;
+it can only update routing skills for known Workers in later executions.
+
 ```typescript
 import { createMultiAgentSystem } from '@agentforge/patterns';
 import { ChatOpenAI } from '@langchain/openai';
@@ -1062,7 +1068,7 @@ const llmBased = createMultiAgentSystem({
 | Complexity | High | Low |
 | Specialization | High (per agent) | Medium |
 | Coordination | Required | Not needed |
-| Scalability | High (add agents) | Limited |
+| Scalability | High (recompile with additional Workers) | Limited |
 | Latency | Higher (coordination) | Lower |
 | Token usage | Higher | Lower |
 | Best for | Complex, multi-domain | Simple, single-domain |

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -84,7 +84,7 @@ The Multi-Agent pattern coordinates multiple specialized agents for complex task
 - Flexible routing strategies (LLM-based, skill-based, rule-based, round-robin, load-balanced)
 - Parallel execution support
 - Intelligent result aggregation
-- Dynamic worker registration
+- Fixed Worker topology construction before compilation
 - **22+ tests** - Comprehensive coverage
 
 ## Installation
@@ -431,6 +431,12 @@ import {
 - `MultiAgentSystemBuilder` - Builder for creating Multi-Agent systems with workers
 - `createWorkersRegistry(workers)` - Construct detached, normalized Worker registry records containing declared capabilities and invocation status without admitting Workers or creating graph topology
 - `registerWorkers(system, workers)` - Deprecated adapter that updates routing skills for known Workers; supplied tools must match the compiled executable tool set
+
+Worker identities and executable tools are fixed when the Multi-Agent System is
+compiled. The builder's `registerWorkers(workers)` method constructs that topology
+before `build()`. The deprecated `registerWorkers(system, workers)` adapter does
+not add executable Worker nodes: it may update routing skills for known Workers,
+and those updates are visible only to later executions.
 
 **Configuration**:
 ```typescript

--- a/packages/patterns/docs/multi-agent-pattern.md
+++ b/packages/patterns/docs/multi-agent-pattern.md
@@ -40,7 +40,7 @@ Input → Supervisor → Worker(s) → Aggregator → Output
 
 ### Using MultiAgentSystemBuilder (Recommended)
 
-The builder pattern allows you to dynamically register workers before compiling the system:
+The builder pattern lets you construct the fixed Worker topology incrementally before compiling the system:
 
 ```typescript
 import { MultiAgentSystemBuilder } from '@agentforge/patterns';
@@ -59,7 +59,7 @@ const builder = new MultiAgentSystemBuilder({
   },
 });
 
-// Register workers dynamically
+// Admit Workers into the topology before compilation
 builder.registerWorkers([
   {
     name: 'math_specialist',
@@ -607,7 +607,10 @@ interface WorkerCapabilities {
 
 #### build(): CompiledStateGraph
 
-Compiles the system into an executable graph. After calling `build()`, the system is immutable and workers cannot be added.
+Compiles the system into an executable graph. After calling `build()`, Worker
+identities and executable tools are fixed and Workers cannot be added. The
+deprecated compatibility adapter may still update routing skills for known
+Workers in later executions.
 
 **Example**:
 
@@ -668,7 +671,19 @@ const system = createMultiAgentSystem({
     model: new ChatOpenAI({ modelName: 'gpt-4' }),
     strategy: 'skill-based',
   },
-  workers: [],
+  workers: [
+    {
+      id: 'researcher',
+      capabilities: {
+        skills: ['research'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 0,
+      },
+      tools: [searchTool],
+      model: llm,
+    },
+  ],
   aggregator: {
     model: new ChatOpenAI({ modelName: 'gpt-4' }),
   },
@@ -730,20 +745,15 @@ interface WorkerConfig {
 registerWorkers(system, [
   {
     name: 'researcher',
-    description: 'Conducts research and gathers information',
-    capabilities: ['research', 'data_collection'],
-    tools: [searchTool, fetchTool],
-    systemPrompt: 'You are a research specialist.',
-  },
-  {
-    name: 'analyst',
-    description: 'Analyzes data and identifies patterns',
-    capabilities: ['analysis', 'statistics'],
-    tools: [analyzeTool, validateTool],
-    systemPrompt: 'You are a data analyst.',
+    capabilities: ['research', 'source-validation'],
+    tools: [searchTool], // Assertion: must match the compiled tool set
   },
 ]);
 ```
+
+This compatibility call changes routing metadata for later executions only. It
+does not add a Worker node or replace the Worker's executable tools, model,
+prompt, or implementation.
 
 ### createWorkersRegistry() (Deprecated)
 
@@ -1246,7 +1256,10 @@ builder.registerWorkers([worker3Config]);
 const system = builder.build();
 ```
 
-**Important**: Workers must be registered BEFORE calling `build()`. Once the system is compiled, it's immutable and workers cannot be added.
+**Important**: Workers must be registered BEFORE calling `build()`. Once the
+system is compiled, Worker identities and executable tools are fixed and Workers
+cannot be added. Routing-skill compatibility updates for known Workers may still
+affect later executions.
 
 ### Worker Priority
 
@@ -1376,7 +1389,19 @@ const system = createMultiAgentSystem({
     model: llm,
     strategy: 'skill-based',
   },
-  workers: [],
+  workers: [
+    {
+      id: 'researcher',
+      capabilities: {
+        skills: ['research'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 0,
+      },
+      tools: [searchTool],
+      model: llm,
+    },
+  ],
   aggregator: { model: llm },
   verbose: true, // Enable logging
 });

--- a/packages/patterns/tests/multi-agent/agent-tools.test.ts
+++ b/packages/patterns/tests/multi-agent/agent-tools.test.ts
@@ -118,4 +118,43 @@ describe('Multi-Agent legacy tool assertions', () => {
       expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
     );
   });
+
+  it('preserves the observable Worker snapshot after a failed tool assertion', async () => {
+    const system = createMultiAgentSystem({
+      supervisor: { strategy: 'round-robin' },
+      workers: [
+        {
+          id: 'worker1',
+          capabilities: {
+            skills: ['initial'],
+            tools: [],
+            available: false,
+            currentWorkload: 3,
+          },
+          tools: [{ name: 'search' }],
+        },
+      ],
+      maxIterations: 0,
+    });
+
+    expect(() =>
+      registerWorkers(system, [
+        {
+          name: 'worker1',
+          capabilities: ['must-not-publish'],
+          tools: [{ name: 'write' }],
+        },
+      ])
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkerLifecycleError>>({ reason: 'invalid-tool' })
+    );
+
+    const result = (await system.invoke({ input: 'test' })) as MultiAgentStateType;
+    expect(result.workers.worker1).toEqual({
+      skills: ['initial'],
+      tools: ['search'],
+      available: false,
+      currentWorkload: 3,
+    });
+  });
 });


### PR DESCRIPTION
Closes #185

## Summary
- document fixed Worker identities and executable tools across package and docs-site guides
- clarify that deprecated registration only updates known-Worker routing skills for later executions
- add black-box coverage proving failed tool assertions preserve the observable Worker snapshot
- replace stale empty-topology and dynamic-admission examples

## Validation
- `pnpm --dir packages/patterns typecheck`
- `pnpm exec vitest run --config packages/patterns/vitest.config.ts` (354 tests)
- `pnpm release:validate` (2,617 passed, 110 skipped)
- `pnpm --dir docs-site build`
- `git diff --check`