### PR TITLE
refactor(patterns): add Worker lifecycle snapshot capture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,3 +28,6 @@ _Avoid_: Dynamic worker registration
 
 **Worker lifecycle**:
 The period from admitting a Worker into a Worker topology through making its capabilities available during execution.
+
+**Worker lifecycle snapshot**:
+The invocation-specific view of the Worker topology: fixed Worker identity, executable tools, and declared capabilities combined with the availability and workload captured for that execution. A resumed execution retains its original snapshot.

--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -22,6 +22,9 @@ export class WorkerLifecycleError extends Error {
 export interface WorkerLifecycle {
   readonly topology: readonly WorkerConfig[];
   readonly captureWorkerSnapshot: () => Readonly<Record<string, WorkerCapabilities>>;
+  readonly captureSnapshot: (
+    statusOverrides: Readonly<Record<string, WorkerStatus>>
+  ) => Record<string, WorkerCapabilities>;
   readonly updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
 }
 
@@ -168,6 +171,36 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
   return Object.freeze({
     topology,
     captureWorkerSnapshot: () => workerCapabilities,
+    captureSnapshot: (statusOverrides: Readonly<Record<string, WorkerStatus>>) => {
+      const publishedCapabilities = workerCapabilities;
+
+      for (const workerId of Object.keys(statusOverrides)) {
+        if (!Object.hasOwn(publishedCapabilities, workerId)) {
+          throw new WorkerLifecycleError(
+            'unknown-worker',
+            `Invocation state contains unknown Worker "${workerId}".`
+          );
+        }
+      }
+
+      return Object.fromEntries(
+        Object.entries(publishedCapabilities).map(([workerId, capabilities]) => {
+          const status = Object.hasOwn(statusOverrides, workerId)
+            ? statusOverrides[workerId]!
+            : capabilities;
+
+          return [
+            workerId,
+            {
+              skills: [...capabilities.skills],
+              tools: [...capabilities.tools],
+              available: status.available,
+              currentWorkload: status.currentWorkload,
+            },
+          ];
+        })
+      );
+    },
     updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => {
       if (updates.length === 0) {
         return;

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -128,6 +128,115 @@ describe('Worker lifecycle admission', () => {
   });
 });
 
+describe('Worker lifecycle snapshot capture', () => {
+  it('uses invocation-owned status while retaining every admitted Worker', () => {
+    const lifecycle = admitWorkerTopology([
+      worker(),
+      worker({
+        id: 'writer',
+        capabilities: {
+          skills: ['writing'],
+          tools: [],
+          available: false,
+          currentWorkload: 4,
+        },
+      }),
+    ]);
+
+    expect(
+      lifecycle.captureSnapshot({
+        researcher: {
+          skills: ['caller-skill'],
+          tools: ['caller-tool'],
+          available: false,
+          currentWorkload: 7,
+        },
+      })
+    ).toEqual({
+      researcher: {
+        skills: ['research'],
+        tools: [],
+        available: false,
+        currentWorkload: 7,
+      },
+      writer: {
+        skills: ['writing'],
+        tools: [],
+        available: false,
+        currentWorkload: 4,
+      },
+    });
+  });
+
+  it.each(['intruder', 'toString'])(
+    'rejects an override for unknown Worker %j with the lifecycle reason',
+    (workerId) => {
+      const lifecycle = admitWorkerTopology([worker()]);
+
+      expectLifecycleReason(
+        () =>
+          lifecycle.captureSnapshot({
+            [workerId]: { available: true, currentWorkload: 0 },
+          }),
+        'unknown-worker'
+      );
+    }
+  );
+
+  it('returns mutable records detached from lifecycle and caller-owned collections', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+    const callerSkills = ['caller-skill'];
+    const callerTools = ['caller-tool'];
+    const override = {
+      skills: callerSkills,
+      tools: callerTools,
+      available: false,
+      currentWorkload: 6,
+    };
+
+    const snapshot = lifecycle.captureSnapshot({ researcher: override });
+    const captured = snapshot.researcher!;
+
+    callerSkills.push('late-caller-skill');
+    callerTools.push('late-caller-tool');
+    override.available = true;
+    override.currentWorkload = 99;
+    captured.skills.push('snapshot-skill');
+    captured.tools.push('snapshot-tool');
+    captured.available = true;
+    captured.currentWorkload = 12;
+
+    expect(Object.isFrozen(snapshot)).toBe(false);
+    expect(Object.isFrozen(captured)).toBe(false);
+    expect(Object.isFrozen(captured.skills)).toBe(false);
+    expect(Object.isFrozen(captured.tools)).toBe(false);
+    expect(lifecycle.captureSnapshot({ researcher: override })).toEqual({
+      researcher: {
+        skills: ['research'],
+        tools: [],
+        available: true,
+        currentWorkload: 99,
+      },
+    });
+    expect(lifecycle.topology[0]?.capabilities).toEqual({
+      skills: ['research'],
+      tools: [],
+      available: true,
+      currentWorkload: 1,
+    });
+  });
+
+  it('keeps an earlier snapshot isolated from a later routing-skill publication', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+    const earlier = lifecycle.captureSnapshot({});
+
+    lifecycle.updateRoutingSkills([{ id: 'researcher', skills: ['analysis'] }]);
+
+    expect(earlier.researcher?.skills).toEqual(['research']);
+    expect(lifecycle.captureSnapshot({}).researcher?.skills).toEqual(['analysis']);
+  });
+});
+
 describe('Worker lifecycle routing-skill updates', () => {
   it('publishes one immutable multi-Worker snapshot without changing Worker status', () => {
     const lifecycle = admitWorkerTopology([


### PR DESCRIPTION
Closes #196

Parent: #195

## Summary
- add synchronous lifecycle-owned snapshot capture beside the existing initialization callback
- preserve topology-owned identity, skills, and executable tools while applying invocation-owned status
- return mutable detached graph records isolated from caller data and later routing-skill publications
- document the Worker lifecycle snapshot domain term

## Validation
- pnpm test (2,622 passed, 110 skipped)
- pnpm --filter @agentforge/patterns lint (0 errors; 2 pre-existing warnings)
- pnpm --filter @agentforge/patterns build
- pnpm --dir packages/patterns typecheck
- two-axis standards/spec review: no findings