### PR TITLE
refactor(patterns): add Worker routing-skill publication

### DIFF
--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -25,6 +25,7 @@ export interface WorkerLifecycle {
   readonly captureSnapshot: (
     statusOverrides: Readonly<Record<string, WorkerStatus>>
   ) => Record<string, WorkerCapabilities>;
+  readonly publishRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
   readonly updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
 }
 
@@ -168,6 +169,53 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
     Object.fromEntries(topology.map((worker) => [worker.id, worker.capabilities]))
   );
 
+  const publishRoutingSkills = (updates: readonly WorkerRoutingSkillUpdate[]): void => {
+    if (updates.length === 0) {
+      return;
+    }
+
+    validateIdentities(updates);
+
+    const replacements = updates.map((update) => {
+      const current = workerCapabilities[update.id];
+      if (!Object.hasOwn(workerCapabilities, update.id) || !current) {
+        throw new WorkerLifecycleError(
+          'unknown-worker',
+          `Cannot update unknown Worker "${update.id}" after compilation.`
+        );
+      }
+
+      if (update.assertedTools !== undefined) {
+        const assertedTools = [...normalizeWorkerToolNames(update.id, update.assertedTools)].sort();
+        const executableTools = [...current.tools].sort();
+        if (
+          assertedTools.length !== executableTools.length ||
+          assertedTools.some((toolName, index) => toolName !== executableTools[index])
+        ) {
+          throw new WorkerLifecycleError(
+            'invalid-tool',
+            `Worker "${update.id}" tools do not match its compiled executable tools.`
+          );
+        }
+      }
+
+      return [
+        update.id,
+        asCompatibleWorkerCapabilities(
+          Object.freeze({
+            ...current,
+            skills: Object.freeze([...update.skills]),
+          })
+        ),
+      ] as const;
+    });
+
+    workerCapabilities = Object.freeze({
+      ...workerCapabilities,
+      ...Object.fromEntries(replacements),
+    });
+  };
+
   return Object.freeze({
     topology,
     captureWorkerSnapshot: () => workerCapabilities,
@@ -201,54 +249,8 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
         })
       );
     },
-    updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => {
-      if (updates.length === 0) {
-        return;
-      }
-
-      validateIdentities(updates);
-
-      const replacements = updates.map((update) => {
-        const current = workerCapabilities[update.id];
-        if (!Object.hasOwn(workerCapabilities, update.id) || !current) {
-          throw new WorkerLifecycleError(
-            'unknown-worker',
-            `Cannot update unknown Worker "${update.id}" after compilation.`
-          );
-        }
-
-        if (update.assertedTools !== undefined) {
-          const assertedTools = [
-            ...normalizeWorkerToolNames(update.id, update.assertedTools),
-          ].sort();
-          const executableTools = [...current.tools].sort();
-          if (
-            assertedTools.length !== executableTools.length ||
-            assertedTools.some((toolName, index) => toolName !== executableTools[index])
-          ) {
-            throw new WorkerLifecycleError(
-              'invalid-tool',
-              `Worker "${update.id}" tools do not match its compiled executable tools.`
-            );
-          }
-        }
-
-        return [
-          update.id,
-          asCompatibleWorkerCapabilities(
-            Object.freeze({
-              ...current,
-              skills: Object.freeze([...update.skills]),
-            })
-          ),
-        ] as const;
-      });
-
-      workerCapabilities = Object.freeze({
-        ...workerCapabilities,
-        ...Object.fromEntries(replacements),
-      });
-    },
+    publishRoutingSkills,
+    updateRoutingSkills: publishRoutingSkills,
   });
 }
 

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -237,124 +237,72 @@ describe('Worker lifecycle snapshot capture', () => {
   });
 });
 
-describe('Worker lifecycle routing-skill updates', () => {
-  it('publishes one immutable multi-Worker snapshot without changing Worker status', () => {
-    const lifecycle = admitWorkerTopology([
-      worker(),
-      worker({
-        id: 'writer',
-        capabilities: {
-          skills: ['writing'],
+describe('Worker lifecycle routing-skill operations', () => {
+  it.each(['publishRoutingSkills', 'updateRoutingSkills'] as const)(
+    '%s publishes one immutable multi-Worker replacement',
+    (operation) => {
+      const lifecycle = admitWorkerTopology([
+        worker({ tools: [{ name: 'search' }] }),
+        worker({
+          id: 'writer',
+          capabilities: {
+            skills: ['writing'],
+            tools: [],
+            available: false,
+            currentWorkload: 4,
+          },
+        }),
+      ]);
+      const previous = lifecycle.captureWorkerSnapshot();
+      const researcherSkills = ['analysis'];
+      const writerSkills = ['editing'];
+
+      lifecycle[operation]([
+        { id: 'researcher', skills: researcherSkills, assertedTools: [{ name: 'search' }] },
+        { id: 'writer', skills: writerSkills },
+      ]);
+      researcherSkills.push('caller-mutation');
+      writerSkills.push('caller-mutation');
+
+      const published = lifecycle.captureWorkerSnapshot();
+      expect(published).not.toBe(previous);
+      expect(previous).toMatchObject({
+        researcher: { skills: ['research'] },
+        writer: { skills: ['writing'] },
+      });
+      expect(published).toEqual({
+        researcher: {
+          skills: ['analysis'],
+          tools: ['search'],
+          available: true,
+          currentWorkload: 1,
+        },
+        writer: {
+          skills: ['editing'],
           tools: [],
           available: false,
           currentWorkload: 4,
         },
-      }),
-    ]);
-    const previous = lifecycle.captureWorkerSnapshot();
-    const researcherSkills = ['analysis'];
-    const writerSkills = ['editing'];
+      });
+      expect(Object.isFrozen(published)).toBe(true);
+      expect(Object.isFrozen(published.researcher)).toBe(true);
+      expect(Object.isFrozen(published.researcher?.skills)).toBe(true);
+      expect(Object.isFrozen(published.writer)).toBe(true);
+      expect(Object.isFrozen(published.writer?.skills)).toBe(true);
+    }
+  );
 
-    lifecycle.updateRoutingSkills([
-      { id: 'researcher', skills: researcherSkills },
-      { id: 'writer', skills: writerSkills },
-    ]);
-    researcherSkills.push('caller-mutation');
-    writerSkills.push('caller-mutation');
+  it.each(['publishRoutingSkills', 'updateRoutingSkills'] as const)(
+    '%s preserves the published snapshot when its batch is empty',
+    (operation) => {
+      const lifecycle = admitWorkerTopology([worker()]);
+      const published = lifecycle.captureWorkerSnapshot();
 
-    const published = lifecycle.captureWorkerSnapshot();
-    expect(published).not.toBe(previous);
-    expect(previous).toMatchObject({
-      researcher: { skills: ['research'] },
-      writer: { skills: ['writing'] },
-    });
-    expect(published).toEqual({
-      researcher: {
-        skills: ['analysis'],
-        tools: [],
-        available: true,
-        currentWorkload: 1,
-      },
-      writer: {
-        skills: ['editing'],
-        tools: [],
-        available: false,
-        currentWorkload: 4,
-      },
-    });
-    expect(Object.isFrozen(published)).toBe(true);
-    expect(Object.isFrozen(published.researcher)).toBe(true);
-    expect(Object.isFrozen(published.researcher?.skills)).toBe(true);
-    expect(Object.isFrozen(published.writer)).toBe(true);
-    expect(Object.isFrozen(published.writer?.skills)).toBe(true);
-  });
+      lifecycle[operation]([]);
 
-  it('keeps the published capability snapshot when the update batch is empty', () => {
-    const lifecycle = admitWorkerTopology([worker()]);
-    const published = lifecycle.captureWorkerSnapshot();
-
-    lifecycle.updateRoutingSkills([]);
-
-    expect(lifecycle.captureWorkerSnapshot()).toBe(published);
-  });
-});
-
-describe('Worker lifecycle routing-skill publication', () => {
-  it('publishes one immutable multi-Worker replacement', () => {
-    const lifecycle = admitWorkerTopology([
-      worker({ tools: [{ name: 'search' }] }),
-      worker({
-        id: 'writer',
-        capabilities: {
-          skills: ['writing'],
-          tools: [],
-          available: false,
-          currentWorkload: 4,
-        },
-      }),
-    ]);
-    const previous = lifecycle.captureWorkerSnapshot();
-
-    lifecycle.publishRoutingSkills([
-      { id: 'researcher', skills: ['analysis'], assertedTools: [{ name: 'search' }] },
-      { id: 'writer', skills: ['editing'] },
-    ]);
-
-    const published = lifecycle.captureWorkerSnapshot();
-    expect(published).not.toBe(previous);
-    expect(previous).toMatchObject({
-      researcher: { skills: ['research'] },
-      writer: { skills: ['writing'] },
-    });
-    expect(published).toEqual({
-      researcher: {
-        skills: ['analysis'],
-        tools: ['search'],
-        available: true,
-        currentWorkload: 1,
-      },
-      writer: {
-        skills: ['editing'],
-        tools: [],
-        available: false,
-        currentWorkload: 4,
-      },
-    });
-    expect(Object.isFrozen(published)).toBe(true);
-    expect(Object.isFrozen(published.researcher)).toBe(true);
-    expect(Object.isFrozen(published.researcher?.skills)).toBe(true);
-    expect(Object.isFrozen(published.writer)).toBe(true);
-    expect(Object.isFrozen(published.writer?.skills)).toBe(true);
-  });
-
-  it('preserves the published snapshot when the publication is empty', () => {
-    const lifecycle = admitWorkerTopology([worker()]);
-    const published = lifecycle.captureWorkerSnapshot();
-
-    lifecycle.publishRoutingSkills([]);
-
-    expect(lifecycle.captureWorkerSnapshot()).toBe(published);
-  });
+      expect(lifecycle.captureWorkerSnapshot()).toBe(published);
+    }
+  );
 
   it('validates every publication identity before detecting duplicates', () => {
     const lifecycle = admitWorkerTopology([worker()]);

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -298,3 +298,170 @@ describe('Worker lifecycle routing-skill updates', () => {
     expect(lifecycle.captureWorkerSnapshot()).toBe(published);
   });
 });
+
+describe('Worker lifecycle routing-skill publication', () => {
+  it('publishes one immutable multi-Worker replacement', () => {
+    const lifecycle = admitWorkerTopology([
+      worker({ tools: [{ name: 'search' }] }),
+      worker({
+        id: 'writer',
+        capabilities: {
+          skills: ['writing'],
+          tools: [],
+          available: false,
+          currentWorkload: 4,
+        },
+      }),
+    ]);
+    const previous = lifecycle.captureWorkerSnapshot();
+
+    lifecycle.publishRoutingSkills([
+      { id: 'researcher', skills: ['analysis'], assertedTools: [{ name: 'search' }] },
+      { id: 'writer', skills: ['editing'] },
+    ]);
+
+    const published = lifecycle.captureWorkerSnapshot();
+    expect(published).not.toBe(previous);
+    expect(previous).toMatchObject({
+      researcher: { skills: ['research'] },
+      writer: { skills: ['writing'] },
+    });
+    expect(published).toEqual({
+      researcher: {
+        skills: ['analysis'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 1,
+      },
+      writer: {
+        skills: ['editing'],
+        tools: [],
+        available: false,
+        currentWorkload: 4,
+      },
+    });
+    expect(Object.isFrozen(published)).toBe(true);
+    expect(Object.isFrozen(published.researcher)).toBe(true);
+    expect(Object.isFrozen(published.researcher?.skills)).toBe(true);
+    expect(Object.isFrozen(published.writer)).toBe(true);
+    expect(Object.isFrozen(published.writer?.skills)).toBe(true);
+  });
+
+  it('preserves the published snapshot when the publication is empty', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+    const published = lifecycle.captureWorkerSnapshot();
+
+    lifecycle.publishRoutingSkills([]);
+
+    expect(lifecycle.captureWorkerSnapshot()).toBe(published);
+  });
+
+  it('validates every publication identity before detecting duplicates', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+
+    expectLifecycleReason(
+      () =>
+        lifecycle.publishRoutingSkills([
+          { id: 'researcher', skills: [] },
+          { id: 'researcher', skills: [] },
+          { id: '', skills: [] },
+        ]),
+      'invalid-identity'
+    );
+  });
+
+  it.each([
+    {
+      name: 'duplicate Worker identities',
+      updates: [
+        { id: 'researcher', skills: [] },
+        { id: 'researcher', skills: [] },
+      ],
+      reason: 'duplicate-identity' as const,
+    },
+    {
+      name: 'an unknown Worker',
+      updates: [{ id: 'unknown', skills: [] }],
+      reason: 'unknown-worker' as const,
+    },
+    {
+      name: 'a nameless asserted tool',
+      updates: [{ id: 'researcher', skills: [], assertedTools: [{}] }],
+      reason: 'invalid-tool' as const,
+    },
+    {
+      name: 'duplicate asserted tools',
+      updates: [
+        {
+          id: 'researcher',
+          skills: [],
+          assertedTools: [{ name: 'search' }, { metadata: { name: ' search ' } }],
+        },
+      ],
+      reason: 'invalid-tool' as const,
+    },
+    {
+      name: 'mismatched asserted tools',
+      updates: [{ id: 'researcher', skills: [], assertedTools: [{ name: 'different-tool' }] }],
+      reason: 'invalid-tool' as const,
+    },
+  ])('preserves the lifecycle reason for $name', ({ updates, reason }) => {
+    const lifecycle = admitWorkerTopology([worker({ tools: [{ name: 'search' }] })]);
+
+    expectLifecycleReason(() => lifecycle.publishRoutingSkills(updates), reason);
+  });
+
+  it('publishes nothing when any update in the batch is invalid', () => {
+    const lifecycle = admitWorkerTopology([
+      worker(),
+      worker({
+        id: 'writer',
+        capabilities: {
+          skills: ['writing'],
+          tools: [],
+          available: false,
+          currentWorkload: 4,
+        },
+        tools: [{ name: 'write' }],
+      }),
+    ]);
+    const published = lifecycle.captureWorkerSnapshot();
+
+    expectLifecycleReason(
+      () =>
+        lifecycle.publishRoutingSkills([
+          { id: 'researcher', skills: ['must-not-publish'] },
+          {
+            id: 'writer',
+            skills: ['also-must-not-publish'],
+            assertedTools: [{ name: 'different-tool' }],
+          },
+        ]),
+      'invalid-tool'
+    );
+
+    expect(lifecycle.captureWorkerSnapshot()).toBe(published);
+    expect(lifecycle.captureWorkerSnapshot()).toMatchObject({
+      researcher: { skills: ['research'] },
+      writer: { skills: ['writing'] },
+    });
+  });
+
+  it('isolates earlier lifecycle snapshots from later publications', () => {
+    const lifecycle = admitWorkerTopology([worker({ tools: [{ name: 'search' }] })]);
+    const earlierPublished = lifecycle.captureWorkerSnapshot();
+    const earlierExecution = lifecycle.captureSnapshot({});
+
+    lifecycle.publishRoutingSkills([{ id: 'researcher', skills: ['analysis'] }]);
+
+    expect(earlierPublished.researcher?.skills).toEqual(['research']);
+    expect(earlierExecution.researcher?.skills).toEqual(['research']);
+    expect(lifecycle.captureWorkerSnapshot().researcher).toEqual({
+      skills: ['analysis'],
+      tools: ['search'],
+      available: true,
+      currentWorkload: 1,
+    });
+    expect(lifecycle.captureSnapshot({}).researcher?.skills).toEqual(['analysis']);
+  });
+});


### PR DESCRIPTION
## Summary

- add explicit synchronous routing-skill publication to the internal Worker lifecycle
- preserve the existing update operation as the compatibility path
- validate complete batches before publishing one immutable replacement
- cover error precedence, tool assertions, failure isolation, and snapshot visibility

## Validation

- `pnpm test` (237 files passed, 9 skipped; 2632 tests passed, 110 skipped)
- `pnpm --dir packages/patterns typecheck`
- focused lifecycle and deprecated-registration tests
- ESLint and Prettier checks for changed files

Closes #197