### PR TITLE
refactor(patterns): publish deprecated Worker updates through lifecycle

### DIFF
--- a/packages/patterns/src/multi-agent/agent-runtime.ts
+++ b/packages/patterns/src/multi-agent/agent-runtime.ts
@@ -5,7 +5,7 @@ export function registerWorkerCapabilities(
   system: MultiAgentSystemWithRegistry,
   workers: RegisterWorkerInput[]
 ): void {
-  resolveWorkerLifecycle(system).updateRoutingSkills(
+  resolveWorkerLifecycle(system).publishRoutingSkills(
     workers.map((worker) => ({
       id: worker.name,
       skills: worker.capabilities,


### PR DESCRIPTION
Closes #199

Part of #195.

## Summary

- route deprecated Worker registration through the explicit lifecycle publication operation
- retain the superseded internal update operation for the later contraction ticket
- preserve the existing public compatibility behavior and package exports

## Validation

- pnpm test (2632 passed, 110 skipped)
- pnpm --filter @agentforge/patterns typecheck
- pnpm --filter @agentforge/patterns lint (0 errors, 2 pre-existing warnings)
- pnpm --filter @agentforge/patterns build
- focused Worker lifecycle, registration, tool-assertion, and checkpoint tests (49 passed)
- two-axis standards/spec review (0 findings on each axis)