### PR TITLE
refactor(patterns): complete the Worker lifecycle contraction

### DIFF
--- a/packages/patterns/src/multi-agent/worker-lifecycle.ts
+++ b/packages/patterns/src/multi-agent/worker-lifecycle.ts
@@ -25,7 +25,6 @@ export interface WorkerLifecycle {
     statusOverrides: Readonly<Record<string, WorkerStatus>>
   ) => Record<string, WorkerCapabilities>;
   readonly publishRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
-  readonly updateRoutingSkills: (updates: readonly WorkerRoutingSkillUpdate[]) => void;
 }
 
 export interface WorkerRoutingSkillUpdate {
@@ -248,7 +247,6 @@ export function admitWorkerTopology(workers: readonly WorkerConfig[]): WorkerLif
       );
     },
     publishRoutingSkills,
-    updateRoutingSkills: publishRoutingSkills,
   });
 }
 

--- a/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
+++ b/packages/patterns/tests/multi-agent/worker-lifecycle.test.ts
@@ -34,6 +34,16 @@ function expectLifecycleReason(action: () => unknown, reason: WorkerLifecycleErr
 }
 
 describe('Worker lifecycle admission', () => {
+  it('exposes only topology, snapshot capture, and routing-skill publication', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+
+    expect(Object.keys(lifecycle).sort()).toEqual([
+      'captureSnapshot',
+      'publishRoutingSkills',
+      'topology',
+    ]);
+  });
+
   it('rejects an empty Worker topology', () => {
     expectLifecycleReason(() => admitWorkerTopology([]), 'empty-topology');
   });
@@ -249,7 +259,7 @@ describe('Worker lifecycle snapshot capture', () => {
     const lifecycle = admitWorkerTopology([worker()]);
     const earlier = lifecycle.captureSnapshot({});
 
-    lifecycle.updateRoutingSkills([{ id: 'researcher', skills: ['analysis'] }]);
+    lifecycle.publishRoutingSkills([{ id: 'researcher', skills: ['analysis'] }]);
 
     expect(earlier.researcher?.skills).toEqual(['research']);
     expect(lifecycle.captureSnapshot({}).researcher?.skills).toEqual(['analysis']);
@@ -257,66 +267,60 @@ describe('Worker lifecycle snapshot capture', () => {
 });
 
 describe('Worker lifecycle routing-skill operations', () => {
-  it.each(['publishRoutingSkills', 'updateRoutingSkills'] as const)(
-    '%s atomically publishes one multi-Worker replacement',
-    (operation) => {
-      const lifecycle = admitWorkerTopology([
-        worker({ tools: [{ name: 'search' }] }),
-        worker({
-          id: 'writer',
-          capabilities: {
-            skills: ['writing'],
-            tools: [],
-            available: false,
-            currentWorkload: 4,
-          },
-        }),
-      ]);
-      const previousLifecycleSnapshot = lifecycle.captureSnapshot({});
-      const researcherSkills = ['analysis'];
-      const writerSkills = ['editing'];
-
-      lifecycle[operation]([
-        { id: 'researcher', skills: researcherSkills, assertedTools: [{ name: 'search' }] },
-        { id: 'writer', skills: writerSkills },
-      ]);
-      researcherSkills.push('caller-mutation');
-      writerSkills.push('caller-mutation');
-
-      const currentLifecycleSnapshot = lifecycle.captureSnapshot({});
-      expect(currentLifecycleSnapshot).not.toBe(previousLifecycleSnapshot);
-      expect(previousLifecycleSnapshot).toMatchObject({
-        researcher: { skills: ['research'] },
-        writer: { skills: ['writing'] },
-      });
-      expect(currentLifecycleSnapshot).toEqual({
-        researcher: {
-          skills: ['analysis'],
-          tools: ['search'],
-          available: true,
-          currentWorkload: 1,
-        },
-        writer: {
-          skills: ['editing'],
+  it('atomically publishes one multi-Worker replacement', () => {
+    const lifecycle = admitWorkerTopology([
+      worker({ tools: [{ name: 'search' }] }),
+      worker({
+        id: 'writer',
+        capabilities: {
+          skills: ['writing'],
           tools: [],
           available: false,
           currentWorkload: 4,
         },
-      });
-    }
-  );
+      }),
+    ]);
+    const previousLifecycleSnapshot = lifecycle.captureSnapshot({});
+    const researcherSkills = ['analysis'];
+    const writerSkills = ['editing'];
 
-  it.each(['publishRoutingSkills', 'updateRoutingSkills'] as const)(
-    '%s preserves published capabilities when its batch is empty',
-    (operation) => {
-      const lifecycle = admitWorkerTopology([worker()]);
-      const baselineLifecycleSnapshot = lifecycle.captureSnapshot({});
+    lifecycle.publishRoutingSkills([
+      { id: 'researcher', skills: researcherSkills, assertedTools: [{ name: 'search' }] },
+      { id: 'writer', skills: writerSkills },
+    ]);
+    researcherSkills.push('caller-mutation');
+    writerSkills.push('caller-mutation');
 
-      lifecycle[operation]([]);
+    const currentLifecycleSnapshot = lifecycle.captureSnapshot({});
+    expect(currentLifecycleSnapshot).not.toBe(previousLifecycleSnapshot);
+    expect(previousLifecycleSnapshot).toMatchObject({
+      researcher: { skills: ['research'] },
+      writer: { skills: ['writing'] },
+    });
+    expect(currentLifecycleSnapshot).toEqual({
+      researcher: {
+        skills: ['analysis'],
+        tools: ['search'],
+        available: true,
+        currentWorkload: 1,
+      },
+      writer: {
+        skills: ['editing'],
+        tools: [],
+        available: false,
+        currentWorkload: 4,
+      },
+    });
+  });
 
-      expect(lifecycle.captureSnapshot({})).toEqual(baselineLifecycleSnapshot);
-    }
-  );
+  it('preserves published capabilities when its batch is empty', () => {
+    const lifecycle = admitWorkerTopology([worker()]);
+    const baselineLifecycleSnapshot = lifecycle.captureSnapshot({});
+
+    lifecycle.publishRoutingSkills([]);
+
+    expect(lifecycle.captureSnapshot({})).toEqual(baselineLifecycleSnapshot);
+  });
 
   it('validates every publication identity before detecting duplicates', () => {
     const lifecycle = admitWorkerTopology([worker()]);


### PR DESCRIPTION
Closes #201

Parent specification: #195

## Summary

- remove the superseded `updateRoutingSkills` lifecycle operation
- retain atomic routing-skill publication as the sole deprecated-registration update path
- add exact three-member lifecycle contract coverage and migrate focused tests

## Validation

- focused lifecycle and compatibility matrix: 82 tests passed
- complete patterns suite: 368 tests passed
- patterns type-check: passed
- patterns lint: passed with two existing unrelated warnings
- patterns build: passed
- package-root declaration/export inspection: passed