### PR TITLE
Centralize Skill activation in Agent Skill access

### DIFF
--- a/docs-site/guide/agent-skills.md
+++ b/docs-site/guide/agent-skills.md
@@ -122,7 +122,9 @@ Runtime (agent decides):
   7. Agent follows skill instructions using its existing tools
 ```
 
-## Activation Tools
+## Agent Skill Access Tools
+
+Agent Skill access covers both instructions and supporting resources. Skill activation is the narrower operation that makes a trusted Agent Skill's instructions available for active work.
 
 ### `activate-skill`
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -20,7 +20,7 @@ yarn add @agentforge/skills
 
 ## Overview
 
-`@agentforge/skills` provides the skill discovery, registration, activation, and trust policy engine for AgentForge agents. It implements the [Agent Skills Specification](https://agentskills.io) for composable, modular agent capabilities.
+`@agentforge/skills` provides Agent Skill discovery, registration, access, and trust policy enforcement for AgentForge agents. Within Agent Skill access, Skill activation loads trusted instructions while resource access loads supporting files. It implements the [Agent Skills Specification](https://agentskills.io) for composable, modular agent capabilities.
 
 Full source code and API will be available after ST-07002 (Move Skills Source Files). See the [AgentForge docs](https://tvscoundrel.github.io/agentforge/) for usage guides and tutorials.
 

--- a/packages/skills/src/activation-activate-tool.ts
+++ b/packages/skills/src/activation-activate-tool.ts
@@ -1,14 +1,10 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { ToolBuilder, ToolCategory } from '@agentforge/core';
 import type { Tool } from '@agentforge/core';
 import type { z } from 'zod';
 import type { SkillRegistry } from './registry.js';
-import { SkillRegistryEvent } from './types.js';
-import { extractBody } from './activation-content.js';
+import { AgentSkillAccess } from './agent-skill-access.js';
 import { activateSkillSchema } from './activation-schemas.js';
-import { activationLogger, buildMissingSkillMessage } from './activation-shared.js';
-import { evaluateSkillActivationPolicy } from './trust.js';
+import { formatMissingSkillMessage } from './activation-shared.js';
 
 /**
  * Create the `activate-skill` tool bound to a registry instance.
@@ -22,6 +18,8 @@ import { evaluateSkillActivationPolicy } from './trust.js';
 export function createActivateSkillTool(
   registry: SkillRegistry,
 ): Tool<z.infer<typeof activateSkillSchema>, string> {
+  const access = new AgentSkillAccess(registry);
+
   return new ToolBuilder<z.infer<typeof activateSkillSchema>, string>()
     .name('activate-skill')
     .description(
@@ -34,63 +32,17 @@ export function createActivateSkillTool(
     .tags(['skill', 'activation', 'agent-skills'])
     .schema(activateSkillSchema)
     .implement(async ({ name }) => {
-      const skill = registry.get(name);
+      const result = await access.activate(name);
 
-      if (!skill) {
-        const { availableCount, errorMessage } = buildMissingSkillMessage(registry, name);
-        activationLogger.warn('Skill activation failed — not found', { name, availableCount });
-        return errorMessage;
-      }
-
-      const policyDecision = evaluateSkillActivationPolicy(skill.trustLevel);
-      if (!policyDecision.allowed) {
-        activationLogger.warn('Skill activation blocked — trust policy', {
-          name,
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-          message: policyDecision.message,
-        });
-
-        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
-          name: skill.metadata.name,
-          resourcePath: 'SKILL.md',
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-          message: policyDecision.message,
-        });
-
-        return policyDecision.message;
-      }
-
-      const skillMdPath = resolve(skill.skillPath, 'SKILL.md');
-      try {
-        const content = readFileSync(skillMdPath, 'utf-8');
-        const body = extractBody(content);
-
-        activationLogger.info('Skill activated', {
-          name: skill.metadata.name,
-          skillPath: skill.skillPath,
-          bodyLength: body.length,
-          trustLevel: skill.trustLevel,
-          activationReason: policyDecision.reason,
-        });
-
-        registry.emitEvent(SkillRegistryEvent.SKILL_ACTIVATED, {
-          name: skill.metadata.name,
-          skillPath: skill.skillPath,
-          bodyLength: body.length,
-          trustLevel: skill.trustLevel,
-        });
-
-        return body;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        activationLogger.error('Skill activation failed — read error', {
-          name,
-          skillPath: skill.skillPath,
-          error: message,
-        });
-        return `Failed to read skill "${name}" instructions: ${message}`;
+      switch (result.kind) {
+        case 'success':
+          return result.body;
+        case 'skill-not-found':
+          return formatMissingSkillMessage(result.name, result.availableNames);
+        case 'access-denied':
+          return result.message;
+        case 'read-failure':
+          return `Failed to read skill "${result.name}" instructions: ${result.error}`;
       }
     })
     .build();

--- a/packages/skills/src/activation-shared.ts
+++ b/packages/skills/src/activation-shared.ts
@@ -5,17 +5,21 @@ export const activationLogger = createLogger('agentforge:skills:activation', {
   level: LogLevel.INFO,
 });
 
+export function formatMissingSkillMessage(name: string, availableNames: string[]): string {
+  const suggestion = availableNames.length > 0
+    ? ` Available skills: ${availableNames.join(', ')}`
+    : ' No skills are currently registered.';
+
+  return `Skill "${name}" not found.${suggestion}`;
+}
+
 export function buildMissingSkillMessage(registry: SkillRegistry, name: string): {
   availableCount: number;
   errorMessage: string;
 } {
   const availableNames = registry.getNames();
-  const suggestion = availableNames.length > 0
-    ? ` Available skills: ${availableNames.join(', ')}`
-    : ' No skills are currently registered.';
-
   return {
     availableCount: availableNames.length,
-    errorMessage: `Skill "${name}" not found.${suggestion}`,
+    errorMessage: formatMissingSkillMessage(name, availableNames),
   };
 }

--- a/packages/skills/src/activation.ts
+++ b/packages/skills/src/activation.ts
@@ -1,9 +1,9 @@
 /**
- * Skill Activation Tools
+ * Agent Skill Access Tools
  *
  * Provides `activate-skill` and `read-skill-resource` tools built with
- * the AgentForge tool builder API. These tools enable agents to load
- * skill instructions on demand and access skill resources at runtime.
+ * the AgentForge tool builder API. Skill activation makes trusted Agent
+ * Skill instructions available; resource access loads supporting files.
  *
  * @see https://agentskills.io/specification
  *

--- a/packages/skills/src/agent-skill-access.ts
+++ b/packages/skills/src/agent-skill-access.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SkillRegistry } from './registry.js';
+import { SkillRegistryEvent } from './types.js';
+import type { TrustPolicyReason } from './types.js';
+import { extractBody } from './activation-content.js';
+import { activationLogger } from './activation-shared.js';
+import { evaluateSkillActivationPolicy } from './trust.js';
+
+export type SkillActivationResult =
+  | { kind: 'success'; body: string }
+  | { kind: 'skill-not-found'; name: string; availableNames: string[] }
+  | { kind: 'access-denied'; reason: TrustPolicyReason; message: string }
+  | { kind: 'read-failure'; name: string; error: string };
+
+/** Package-internal owner of Agent Skill lookup, policy, reads, and audit signals. */
+export class AgentSkillAccess {
+  constructor(private readonly registry: SkillRegistry) {}
+
+  async activate(name: string): Promise<SkillActivationResult> {
+    const skill = this.registry.get(name);
+    if (!skill) {
+      const availableNames = this.registry.getNames();
+      activationLogger.warn('Skill activation failed — not found', {
+        name,
+        availableCount: availableNames.length,
+      });
+      return { kind: 'skill-not-found', name, availableNames };
+    }
+
+    const policyDecision = evaluateSkillActivationPolicy(skill.trustLevel);
+    if (!policyDecision.allowed) {
+      activationLogger.warn('Skill activation blocked — trust policy', {
+        name,
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      });
+
+      this.registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+        name: skill.metadata.name,
+        resourcePath: 'SKILL.md',
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      });
+
+      return {
+        kind: 'access-denied',
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      };
+    }
+
+    let body: string;
+    try {
+      const content = readFileSync(resolve(skill.skillPath, 'SKILL.md'), 'utf-8');
+      body = extractBody(content);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      activationLogger.error('Skill activation failed — read error', {
+        name,
+        skillPath: skill.skillPath,
+        error: message,
+      });
+      return { kind: 'read-failure', name, error: message };
+    }
+
+    activationLogger.info('Skill activated', {
+      name: skill.metadata.name,
+      skillPath: skill.skillPath,
+      bodyLength: body.length,
+      trustLevel: skill.trustLevel,
+      activationReason: policyDecision.reason,
+    });
+
+    this.registry.emitEvent(SkillRegistryEvent.SKILL_ACTIVATED, {
+      name: skill.metadata.name,
+      skillPath: skill.skillPath,
+      bodyLength: body.length,
+      trustLevel: skill.trustLevel,
+    });
+
+    return { kind: 'success', body };
+  }
+}

--- a/packages/skills/tests/activation/activate-skill.suite.ts
+++ b/packages/skills/tests/activation/activate-skill.suite.ts
@@ -78,10 +78,11 @@ describe('activate-skill tool', () => {
     expect(await tool.invoke({ name: 'trusted-skill' })).toBe('Trusted body');
 
     const blocked = await tool.invoke({ name: 'community-skill' });
-    expect(blocked).toContain('blocked');
-    expect(blocked).toContain('untrusted');
-    expect(blocked).toContain('trusted');
-    expect(blocked).not.toContain('Untrusted body');
+    expect(blocked).toBe(
+      'Skill activation blocked — skill root is untrusted. ' +
+      'Untrusted skills remain discoverable, but their full SKILL.md bodies are blocked by default. ' +
+      "Promote the skill root to 'trusted' or 'workspace' trust level after review to allow activation.",
+    );
     expect(deniedEvents).toHaveLength(1);
     expect(deniedEvents[0]).toEqual(expect.objectContaining({
       name: 'community-skill',
@@ -97,15 +98,14 @@ describe('activate-skill tool', () => {
     const populatedRegistry = new SkillRegistry({ skillRoots: [{ path: tempDir, trust: 'workspace' }] });
     const populatedTool = createActivateSkillTool(populatedRegistry);
     const populatedResult = await populatedTool.invoke({ name: 'non-existent' });
-    expect(populatedResult).toContain('Skill "non-existent" not found');
-    expect(populatedResult).toContain('code-review');
+    expect(populatedResult).toBe('Skill "non-existent" not found. Available skills: code-review');
 
     const emptyRoot = createTempDir();
     tempDirs.push(emptyRoot);
     const emptyRegistry = new SkillRegistry({ skillRoots: [emptyRoot] });
     const emptyTool = createActivateSkillTool(emptyRegistry);
     const emptyResult = await emptyTool.invoke({ name: 'anything' });
-    expect(emptyResult).toContain('No skills are currently registered');
+    expect(emptyResult).toBe('Skill "anything" not found. No skills are currently registered.');
   });
 
   it('emits activation events and read errors correctly', async () => {

--- a/packages/skills/tests/agent-skill-access.test.ts
+++ b/packages/skills/tests/agent-skill-access.test.ts
@@ -1,0 +1,151 @@
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentSkillAccess } from '../src/agent-skill-access.js';
+import { activationLogger } from '../src/activation-shared.js';
+import { SkillRegistry } from '../src/registry.js';
+import { SkillRegistryEvent, TrustPolicyReason } from '../src/types.js';
+import { cleanupTempDirs, createSkillFixture, createTempDir } from './activation/shared.js';
+
+describe('AgentSkillAccess', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanupTempDirs([tempDir]);
+  });
+
+  it('activates a trusted Agent Skill and publishes the existing registry event', async () => {
+    createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\n# Code Review\n\nReview code for quality.'
+    );
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const activated = vi.fn();
+    const info = vi.spyOn(activationLogger, 'info');
+    registry.on(SkillRegistryEvent.SKILL_ACTIVATED, activated);
+
+    const result = await new AgentSkillAccess(registry).activate('code-review');
+
+    expect(result).toEqual({
+      kind: 'success',
+      body: '# Code Review\n\nReview code for quality.',
+    });
+    expect(activated).toHaveBeenCalledWith({
+      name: 'code-review',
+      skillPath: expect.any(String),
+      bodyLength: 39,
+      trustLevel: 'workspace',
+    });
+    expect(info).toHaveBeenCalledWith(
+      'Skill activated',
+      expect.objectContaining({
+        name: 'code-review',
+        bodyLength: 39,
+        trustLevel: 'workspace',
+        activationReason: TrustPolicyReason.WORKSPACE_SKILL_ACTIVATION,
+      })
+    );
+  });
+
+  it('denies activation at the Skill trust policy seam and publishes the existing registry event', async () => {
+    createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nUntrusted instructions'
+    );
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'untrusted' }],
+    });
+    const denied = vi.fn();
+    const warn = vi.spyOn(activationLogger, 'warn');
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, denied);
+
+    const result = await new AgentSkillAccess(registry).activate('community-skill');
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      message: expect.stringContaining('Skill activation blocked'),
+    });
+    expect(denied).toHaveBeenCalledWith({
+      name: 'community-skill',
+      resourcePath: 'SKILL.md',
+      trustLevel: 'untrusted',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      message: expect.stringContaining('Skill activation blocked'),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Skill activation blocked — trust policy',
+      expect.objectContaining({
+        name: 'community-skill',
+        trustLevel: 'untrusted',
+        reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      })
+    );
+  });
+
+  it('normalizes a missing Agent Skill without throwing', async () => {
+    createSkillFixture(
+      tempDir,
+      'available-skill',
+      'name: available-skill\ndescription: Available skill',
+      '\nAvailable instructions'
+    );
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const warn = vi.spyOn(activationLogger, 'warn');
+
+    const result = await new AgentSkillAccess(registry).activate('missing-skill');
+
+    expect(result).toEqual({
+      kind: 'skill-not-found',
+      name: 'missing-skill',
+      availableNames: ['available-skill'],
+    });
+    expect(warn).toHaveBeenCalledWith('Skill activation failed — not found', {
+      name: 'missing-skill',
+      availableCount: 1,
+    });
+  });
+
+  it('normalizes an instruction read failure without throwing', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'broken-skill',
+      'name: broken-skill\ndescription: Broken skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'workspace' }],
+    });
+    const error = vi.spyOn(activationLogger, 'error');
+    rmSync(join(skillDir, 'SKILL.md'));
+
+    const result = await new AgentSkillAccess(registry).activate('broken-skill');
+
+    expect(result).toEqual({
+      kind: 'read-failure',
+      name: 'broken-skill',
+      error: expect.any(String),
+    });
+    expect(error).toHaveBeenCalledWith(
+      'Skill activation failed — read error',
+      expect.objectContaining({
+        name: 'broken-skill',
+        skillPath: skillDir,
+        error: expect.any(String),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Closes #209

## Summary
- add a package-internal asynchronous Agent Skill access abstraction for activation
- centralize lookup, instruction reads, trust enforcement, logging, and registry event publication
- preserve the public activation Tool contract through discriminated-result translation
- add access-seam and exact Tool contract coverage, plus terminology updates

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint:ci`
- focused activation and conformance suites after review fix

## Formatting note
- changed files pass `git diff --check`; new files pass targeted Prettier checks
- repository-wide `pnpm format:check` remains red on pre-existing formatting drift outside this ticket