### PR TITLE
Centralize supporting-resource reads in Agent Skill access

### DIFF
--- a/packages/skills/src/activation-resource-tool.ts
+++ b/packages/skills/src/activation-resource-tool.ts
@@ -1,14 +1,10 @@
-import { readFileSync, realpathSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { ToolBuilder, ToolCategory } from '@agentforge/core';
 import type { Tool } from '@agentforge/core';
 import type { z } from 'zod';
 import type { SkillRegistry } from './registry.js';
-import { evaluateSkillActivationPolicy, evaluateTrustPolicy } from './trust.js';
-import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
-import { resolveResourcePath } from './activation-path.js';
+import { AgentSkillAccess } from './agent-skill-access.js';
 import { readSkillResourceSchema } from './activation-schemas.js';
-import { activationLogger, buildMissingSkillMessage } from './activation-shared.js';
+import { formatMissingSkillMessage } from './activation-shared.js';
 
 /**
  * Create the `read-skill-resource` tool bound to a registry instance.
@@ -20,138 +16,34 @@ import { activationLogger, buildMissingSkillMessage } from './activation-shared.
  * @returns An AgentForge Tool
  */
 export function createReadSkillResourceTool(
-  registry: SkillRegistry,
+  registry: SkillRegistry
 ): Tool<z.infer<typeof readSkillResourceSchema>, string> {
+  const access = new AgentSkillAccess(registry);
+
   return new ToolBuilder<z.infer<typeof readSkillResourceSchema>, string>()
     .name('read-skill-resource')
     .description(
       'Read a resource file from an activated Agent Skill. ' +
-      'Returns the content of a file within the skill directory (e.g., references/, scripts/, assets/). ' +
-      'The path must be relative to the skill root and cannot traverse outside it. ' +
-      'SKILL.md is only readable from workspace or trusted roots.',
+        'Returns the content of a file within the skill directory (e.g., references/, scripts/, assets/). ' +
+        'The path must be relative to the skill root and cannot traverse outside it. ' +
+        'SKILL.md is only readable from workspace or trusted roots.'
     )
     .category(ToolCategory.SKILLS)
     .tags(['skill', 'resource', 'agent-skills'])
     .schema(readSkillResourceSchema)
     .implement(async ({ name, path: resourcePath }) => {
-      const skill = registry.get(name);
+      const result = await access.readResource(name, resourcePath);
 
-      if (!skill) {
-        const { errorMessage } = buildMissingSkillMessage(registry, name);
-        activationLogger.warn('Skill resource load failed — skill not found', { name, resourcePath });
-        return errorMessage;
-      }
-
-      const pathResult = resolveResourcePath(skill.skillPath, resourcePath);
-      if (!pathResult.success) {
-        activationLogger.warn('Skill resource load blocked — path traversal', {
-          name,
-          resourcePath,
-          error: pathResult.error,
-        });
-        return pathResult.error;
-      }
-
-      const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
-      let isSkillInstructions = pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
-      if (!isSkillInstructions) {
-        try {
-          isSkillInstructions = realpathSync(pathResult.resolvedPath).toLowerCase() === realpathSync(skillInstructionsPath).toLowerCase();
-        } catch {
-          // The resource read below reports missing or unreadable paths.
-        }
-      }
-      if (isSkillInstructions) {
-        const activationDecision = evaluateSkillActivationPolicy(skill.trustLevel);
-        if (!activationDecision.allowed) {
-          activationLogger.warn('Skill resource load blocked — skill instructions trust policy', {
-            name,
-            resourcePath,
-            trustLevel: skill.trustLevel,
-            reason: activationDecision.reason,
-            message: activationDecision.message,
-          });
-
-          registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
-            name: skill.metadata.name,
-            resourcePath: 'SKILL.md',
-            trustLevel: skill.trustLevel,
-            reason: activationDecision.reason,
-            message: activationDecision.message,
-          });
-
-          return activationDecision.message;
-        }
-      }
-
-      const policyDecision = evaluateTrustPolicy(
-        resourcePath,
-        skill.trustLevel,
-        registry.getAllowUntrustedScripts(),
-      );
-
-      if (!policyDecision.allowed) {
-        activationLogger.warn('Skill resource load blocked — trust policy', {
-          name,
-          resourcePath,
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-          message: policyDecision.message,
-        });
-
-        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
-          name: skill.metadata.name,
-          resourcePath,
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-          message: policyDecision.message,
-        });
-
-        return policyDecision.message;
-      }
-
-      if (policyDecision.reason !== TrustPolicyReason.NOT_SCRIPT) {
-        activationLogger.info('Skill resource trust policy — allowed', {
-          name,
-          resourcePath,
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-        });
-
-        registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_ALLOWED, {
-          name: skill.metadata.name,
-          resourcePath,
-          trustLevel: skill.trustLevel,
-          reason: policyDecision.reason,
-        });
-      }
-
-      try {
-        const content = readFileSync(pathResult.resolvedPath, 'utf-8');
-
-        activationLogger.info('Skill resource loaded', {
-          name: skill.metadata.name,
-          resourcePath,
-          resolvedPath: pathResult.resolvedPath,
-          contentLength: content.length,
-        });
-
-        registry.emitEvent(SkillRegistryEvent.SKILL_RESOURCE_LOADED, {
-          name: skill.metadata.name,
-          resourcePath,
-          resolvedPath: pathResult.resolvedPath,
-          contentLength: content.length,
-        });
-
-        return content;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        activationLogger.warn('Skill resource load failed — file not found or unreadable', {
-          name,
-          resourcePath,
-          error: message,
-        });
-        return `Failed to read resource "${resourcePath}" from skill "${name}": ${message}`;
+      switch (result.kind) {
+        case 'success':
+          return result.content;
+        case 'skill-not-found':
+          return formatMissingSkillMessage(result.name, result.availableNames);
+        case 'access-denied':
+          return result.message;
+        case 'resource-not-found':
+        case 'read-failure':
+          return `Failed to read resource "${result.resourcePath}" from skill "${result.name}": ${result.error}`;
       }
     })
     .build();

--- a/packages/skills/src/activation-shared.ts
+++ b/packages/skills/src/activation-shared.ts
@@ -1,5 +1,4 @@
 import { createLogger, LogLevel } from '@agentforge/core';
-import type { SkillRegistry } from './registry.js';
 
 export const activationLogger = createLogger('agentforge:skills:activation', {
   level: LogLevel.INFO,
@@ -11,15 +10,4 @@ export function formatMissingSkillMessage(name: string, availableNames: string[]
     : ' No skills are currently registered.';
 
   return `Skill "${name}" not found.${suggestion}`;
-}
-
-export function buildMissingSkillMessage(registry: SkillRegistry, name: string): {
-  availableCount: number;
-  errorMessage: string;
-} {
-  const availableNames = registry.getNames();
-  return {
-    availableCount: availableNames.length,
-    errorMessage: formatMissingSkillMessage(name, availableNames),
-  };
 }

--- a/packages/skills/src/agent-skill-access.ts
+++ b/packages/skills/src/agent-skill-access.ts
@@ -1,11 +1,11 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { SkillRegistry } from './registry.js';
-import { SkillRegistryEvent } from './types.js';
-import type { TrustPolicyReason } from './types.js';
+import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
 import { extractBody } from './activation-content.js';
+import { resolveResourcePath } from './activation-path.js';
 import { activationLogger } from './activation-shared.js';
-import { evaluateSkillActivationPolicy } from './trust.js';
+import { evaluateSkillActivationPolicy, evaluateTrustPolicy } from './trust.js';
 
 export type SkillActivationResult =
   | { kind: 'success'; body: string }
@@ -13,9 +13,154 @@ export type SkillActivationResult =
   | { kind: 'access-denied'; reason: TrustPolicyReason; message: string }
   | { kind: 'read-failure'; name: string; error: string };
 
+export type SkillResourceResult =
+  | { kind: 'success'; content: string }
+  | { kind: 'skill-not-found'; name: string; availableNames: string[] }
+  | { kind: 'access-denied'; message: string; reason?: TrustPolicyReason }
+  | { kind: 'resource-not-found'; name: string; resourcePath: string; error: string }
+  | { kind: 'read-failure'; name: string; resourcePath: string; error: string };
+
 /** Package-internal owner of Agent Skill lookup, policy, reads, and audit signals. */
 export class AgentSkillAccess {
   constructor(private readonly registry: SkillRegistry) {}
+
+  async readResource(name: string, resourcePath: string): Promise<SkillResourceResult> {
+    const skill = this.registry.get(name);
+    if (!skill) {
+      const availableNames = this.registry.getNames();
+      activationLogger.warn('Skill resource load failed — skill not found', {
+        name,
+        resourcePath,
+      });
+      return { kind: 'skill-not-found', name, availableNames };
+    }
+
+    const pathResult = resolveResourcePath(skill.skillPath, resourcePath);
+    if (!pathResult.success) {
+      activationLogger.warn('Skill resource load blocked — path traversal', {
+        name,
+        resourcePath,
+        error: pathResult.error,
+      });
+      return { kind: 'access-denied', message: pathResult.error };
+    }
+
+    const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
+    let isSkillInstructions =
+      pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
+    if (!isSkillInstructions) {
+      try {
+        isSkillInstructions =
+          realpathSync(pathResult.resolvedPath).toLowerCase() ===
+          realpathSync(skillInstructionsPath).toLowerCase();
+      } catch {
+        // The resource read below reports missing or unreadable paths.
+      }
+    }
+    if (isSkillInstructions) {
+      const activationDecision = evaluateSkillActivationPolicy(skill.trustLevel);
+      if (!activationDecision.allowed) {
+        activationLogger.warn('Skill resource load blocked — skill instructions trust policy', {
+          name,
+          resourcePath,
+          trustLevel: skill.trustLevel,
+          reason: activationDecision.reason,
+          message: activationDecision.message,
+        });
+
+        this.registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+          name: skill.metadata.name,
+          resourcePath: 'SKILL.md',
+          trustLevel: skill.trustLevel,
+          reason: activationDecision.reason,
+          message: activationDecision.message,
+        });
+
+        return {
+          kind: 'access-denied',
+          reason: activationDecision.reason,
+          message: activationDecision.message,
+        };
+      }
+    }
+
+    const policyDecision = evaluateTrustPolicy(
+      resourcePath,
+      skill.trustLevel,
+      this.registry.getAllowUntrustedScripts()
+    );
+    if (!policyDecision.allowed) {
+      activationLogger.warn('Skill resource load blocked — trust policy', {
+        name,
+        resourcePath,
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      });
+
+      this.registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_DENIED, {
+        name: skill.metadata.name,
+        resourcePath,
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      });
+
+      return {
+        kind: 'access-denied',
+        reason: policyDecision.reason,
+        message: policyDecision.message,
+      };
+    }
+
+    if (policyDecision.reason !== TrustPolicyReason.NOT_SCRIPT) {
+      activationLogger.info('Skill resource trust policy — allowed', {
+        name,
+        resourcePath,
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+      });
+
+      this.registry.emitEvent(SkillRegistryEvent.TRUST_POLICY_ALLOWED, {
+        name: skill.metadata.name,
+        resourcePath,
+        trustLevel: skill.trustLevel,
+        reason: policyDecision.reason,
+      });
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(pathResult.resolvedPath, 'utf-8');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      activationLogger.warn('Skill resource load failed — file not found or unreadable', {
+        name,
+        resourcePath,
+        error: message,
+      });
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { kind: 'resource-not-found', name, resourcePath, error: message };
+      }
+      return { kind: 'read-failure', name, resourcePath, error: message };
+    }
+
+    activationLogger.info('Skill resource loaded', {
+      name: skill.metadata.name,
+      resourcePath,
+      resolvedPath: pathResult.resolvedPath,
+      contentLength: content.length,
+    });
+
+    this.registry.emitEvent(SkillRegistryEvent.SKILL_RESOURCE_LOADED, {
+      name: skill.metadata.name,
+      resourcePath,
+      resolvedPath: pathResult.resolvedPath,
+      contentLength: content.length,
+    });
+
+    return { kind: 'success', content };
+  }
 
   async activate(name: string): Promise<SkillActivationResult> {
     const skill = this.registry.get(name);

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -106,10 +106,11 @@ describe('read-skill-resource tool', () => {
       name: 'my-skill',
       path: 'references/nonexistent.md',
     });
-    expect(missingResource).toBe(
-      'Failed to read resource "references/nonexistent.md" from skill "my-skill": ' +
-        `ENOENT: no such file or directory, open '${join(skillDir, 'references/nonexistent.md')}'`
+    expect(missingResource).toContain(
+      'Failed to read resource "references/nonexistent.md" from skill "my-skill":'
     );
+    expect(missingResource).toContain('ENOENT');
+    expect(missingResource).toContain(join(skillDir, 'references/nonexistent.md'));
   });
 
   it('blocks SKILL.md reads from untrusted roots, including normalized paths', async () => {

--- a/packages/skills/tests/activation/read-skill-resource.suite.ts
+++ b/packages/skills/tests/activation/read-skill-resource.suite.ts
@@ -36,46 +36,89 @@ describe('read-skill-resource tool', () => {
   });
 
   it('reads resources from safe locations', async () => {
-    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    const skillDir = createSkillFixture(
+      tempDir,
+      'my-skill',
+      'name: my-skill\ndescription: Test',
+      '\nbody'
+    );
     createResourceFile(skillDir, 'references/guide.md', '# Reference Guide\n\nSome content.');
     createResourceFile(skillDir, 'assets/config.json', '{"key": "value"}');
     createResourceFile(skillDir, 'references/api/endpoints.md', '# Endpoints');
 
     const trustedRoot = createTempDir();
     tempDirs.push(trustedRoot);
-    const trustedSkillDir = createSkillFixture(trustedRoot, 'trusted-skill', 'name: trusted-skill\ndescription: Test', '\nbody');
+    const trustedSkillDir = createSkillFixture(
+      trustedRoot,
+      'trusted-skill',
+      'name: trusted-skill\ndescription: Test',
+      '\nbody'
+    );
     createResourceFile(trustedSkillDir, 'scripts/setup.sh', '#!/bin/bash\necho "Hello"');
 
     const regularRegistry = new SkillRegistry({ skillRoots: [tempDir] });
     const regularTool = createReadSkillResourceTool(regularRegistry);
 
-    expect(await regularTool.invoke({ name: 'my-skill', path: 'references/guide.md' })).toBe('# Reference Guide\n\nSome content.');
-    expect(await regularTool.invoke({ name: 'my-skill', path: 'assets/config.json' })).toBe('{"key": "value"}');
-    expect(await regularTool.invoke({ name: 'my-skill', path: 'references/api/endpoints.md' })).toBe('# Endpoints');
+    expect(await regularTool.invoke({ name: 'my-skill', path: 'references/guide.md' })).toBe(
+      '# Reference Guide\n\nSome content.'
+    );
+    expect(await regularTool.invoke({ name: 'my-skill', path: 'assets/config.json' })).toBe(
+      '{"key": "value"}'
+    );
+    expect(
+      await regularTool.invoke({ name: 'my-skill', path: 'references/api/endpoints.md' })
+    ).toBe('# Endpoints');
 
-    const trustedRegistry = new SkillRegistry({ skillRoots: [{ path: trustedRoot, trust: 'trusted' }] });
+    const trustedRegistry = new SkillRegistry({
+      skillRoots: [{ path: trustedRoot, trust: 'trusted' }],
+    });
     const trustedTool = createReadSkillResourceTool(trustedRegistry);
-    expect(await trustedTool.invoke({ name: 'trusted-skill', path: 'scripts/setup.sh' })).toBe('#!/bin/bash\necho "Hello"');
+    expect(await trustedTool.invoke({ name: 'trusted-skill', path: 'scripts/setup.sh' })).toBe(
+      '#!/bin/bash\necho "Hello"'
+    );
   });
 
   it('blocks invalid paths and missing skills/resources', async () => {
-    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    const skillDir = createSkillFixture(
+      tempDir,
+      'my-skill',
+      'name: my-skill\ndescription: Test',
+      '\nbody'
+    );
 
     const registry = new SkillRegistry({ skillRoots: [tempDir] });
     const tool = createReadSkillResourceTool(registry);
 
-    expect(await tool.invoke({ name: 'my-skill', path: '../SKILL.md' })).toContain('Path traversal');
-    expect(await tool.invoke({ name: 'my-skill', path: 'references/../../../etc/passwd' })).toContain('Path traversal');
-    expect(await tool.invoke({ name: 'my-skill', path: '/etc/passwd' })).toContain('Absolute resource paths');
-    expect(await tool.invoke({ name: 'ghost', path: 'file.txt' })).toContain('Skill "ghost" not found');
+    expect(await tool.invoke({ name: 'my-skill', path: '../SKILL.md' })).toBe(
+      'Path traversal is not allowed — resource paths must stay within the skill directory'
+    );
+    expect(await tool.invoke({ name: 'my-skill', path: 'references/../../../etc/passwd' })).toBe(
+      'Path traversal is not allowed — resource paths must stay within the skill directory'
+    );
+    expect(await tool.invoke({ name: 'my-skill', path: '/etc/passwd' })).toBe(
+      'Absolute resource paths are not allowed'
+    );
+    expect(await tool.invoke({ name: 'ghost', path: 'file.txt' })).toBe(
+      'Skill "ghost" not found. Available skills: my-skill'
+    );
 
-    const missingResource = await tool.invoke({ name: 'my-skill', path: 'references/nonexistent.md' });
-    expect(missingResource).toContain('Failed to read resource');
-    expect(missingResource).toContain('nonexistent.md');
+    const missingResource = await tool.invoke({
+      name: 'my-skill',
+      path: 'references/nonexistent.md',
+    });
+    expect(missingResource).toBe(
+      'Failed to read resource "references/nonexistent.md" from skill "my-skill": ' +
+        `ENOENT: no such file or directory, open '${join(skillDir, 'references/nonexistent.md')}'`
+    );
   });
 
   it('blocks SKILL.md reads from untrusted roots, including normalized paths', async () => {
-    createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nsecret instructions');
+    createSkillFixture(
+      tempDir,
+      'my-skill',
+      'name: my-skill\ndescription: Test',
+      '\nsecret instructions'
+    );
 
     const registry = new SkillRegistry({ skillRoots: [tempDir] });
     const tool = createReadSkillResourceTool(registry);
@@ -85,7 +128,10 @@ describe('read-skill-resource tool', () => {
     const directResult = await tool.invoke({ name: 'my-skill', path: 'SKILL.md' });
     const normalizedResult = await tool.invoke({ name: 'my-skill', path: './SKILL.md' });
     const caseVariantResult = await tool.invoke({ name: 'my-skill', path: 'skill.md' });
-    symlinkSync(join(tempDir, 'my-skill', 'SKILL.md'), join(tempDir, 'my-skill', 'instructions.md'));
+    symlinkSync(
+      join(tempDir, 'my-skill', 'SKILL.md'),
+      join(tempDir, 'my-skill', 'instructions.md')
+    );
     const symlinkResult = await tool.invoke({ name: 'my-skill', path: 'instructions.md' });
 
     expect(directResult).toContain('Skill activation blocked');
@@ -98,16 +144,23 @@ describe('read-skill-resource tool', () => {
     expect(symlinkResult).not.toContain('secret instructions');
     expect(deniedEvents).toHaveLength(4);
     for (const event of deniedEvents) {
-      expect(event).toEqual(expect.objectContaining({
-        name: 'my-skill',
-        resourcePath: 'SKILL.md',
-        trustLevel: 'untrusted',
-      }));
+      expect(event).toEqual(
+        expect.objectContaining({
+          name: 'my-skill',
+          resourcePath: 'SKILL.md',
+          trustLevel: 'untrusted',
+        })
+      );
     }
   });
 
   it('emits resource events on success and not on failure', async () => {
-    const skillDir = createSkillFixture(tempDir, 'my-skill', 'name: my-skill\ndescription: Test', '\nbody');
+    const skillDir = createSkillFixture(
+      tempDir,
+      'my-skill',
+      'name: my-skill\ndescription: Test',
+      '\nbody'
+    );
     createResourceFile(skillDir, 'references/guide.md', 'Guide content');
 
     const registry = new SkillRegistry({ skillRoots: [tempDir] });
@@ -123,7 +176,7 @@ describe('read-skill-resource tool', () => {
         name: 'my-skill',
         resourcePath: 'references/guide.md',
         contentLength: expect.any(Number),
-      }),
+      })
     );
 
     handler.mockClear();

--- a/packages/skills/tests/agent-skill-access.test.ts
+++ b/packages/skills/tests/agent-skill-access.test.ts
@@ -1,22 +1,29 @@
-import { rmSync } from 'node:fs';
+import { mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentSkillAccess } from '../src/agent-skill-access.js';
 import { activationLogger } from '../src/activation-shared.js';
 import { SkillRegistry } from '../src/registry.js';
 import { SkillRegistryEvent, TrustPolicyReason } from '../src/types.js';
-import { cleanupTempDirs, createSkillFixture, createTempDir } from './activation/shared.js';
+import {
+  cleanupTempDirs,
+  createResourceFile,
+  createSkillFixture,
+  createTempDir,
+} from './activation/shared.js';
 
 describe('AgentSkillAccess', () => {
   let tempDir: string;
+  let tempDirs: string[];
 
   beforeEach(() => {
     tempDir = createTempDir();
+    tempDirs = [tempDir];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    cleanupTempDirs([tempDir]);
+    cleanupTempDirs(tempDirs);
   });
 
   it('activates a trusted Agent Skill and publishes the existing registry event', async () => {
@@ -54,6 +61,273 @@ describe('AgentSkillAccess', () => {
         activationReason: TrustPolicyReason.WORKSPACE_SKILL_ACTIVATION,
       })
     );
+  });
+
+  it('reads an ordinary Agent Skill resource and publishes the existing registry event', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    createResourceFile(skillDir, 'references/style-guide.md', '# Style Guide');
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'untrusted' }],
+    });
+    const loaded = vi.fn();
+    const info = vi.spyOn(activationLogger, 'info');
+    registry.on(SkillRegistryEvent.SKILL_RESOURCE_LOADED, loaded);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'code-review',
+      'references/style-guide.md'
+    );
+
+    expect(result).toEqual({ kind: 'success', content: '# Style Guide' });
+    expect(loaded).toHaveBeenCalledWith({
+      name: 'code-review',
+      resourcePath: 'references/style-guide.md',
+      resolvedPath: join(skillDir, 'references/style-guide.md'),
+      contentLength: 13,
+    });
+    expect(info).toHaveBeenCalledWith('Skill resource loaded', {
+      name: 'code-review',
+      resourcePath: 'references/style-guide.md',
+      resolvedPath: join(skillDir, 'references/style-guide.md'),
+      contentLength: 13,
+    });
+  });
+
+  it('normalizes a missing Agent Skill resource owner without throwing', async () => {
+    createSkillFixture(
+      tempDir,
+      'available-skill',
+      'name: available-skill\ndescription: Available skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const warn = vi.spyOn(activationLogger, 'warn');
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'missing-skill',
+      'references/guide.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'skill-not-found',
+      name: 'missing-skill',
+      availableNames: ['available-skill'],
+    });
+    expect(warn).toHaveBeenCalledWith('Skill resource load failed — skill not found', {
+      name: 'missing-skill',
+      resourcePath: 'references/guide.md',
+    });
+  });
+
+  it('normalizes resource paths that escape the Agent Skill root as denied access', async () => {
+    createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const warn = vi.spyOn(activationLogger, 'warn');
+
+    const result = await new AgentSkillAccess(registry).readResource('code-review', '../SKILL.md');
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      message:
+        'Path traversal is not allowed — resource paths must stay within the skill directory',
+    });
+    expect(warn).toHaveBeenCalledWith('Skill resource load blocked — path traversal', {
+      name: 'code-review',
+      resourcePath: '../SKILL.md',
+      error: 'Path traversal is not allowed — resource paths must stay within the skill directory',
+    });
+  });
+
+  it('denies a resource symlink that escapes the Agent Skill root', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    const outsideDir = createTempDir();
+    tempDirs.push(outsideDir);
+    const outsideResource = createResourceFile(outsideDir, 'secret.md', 'secret');
+    mkdirSync(join(skillDir, 'references'), { recursive: true });
+    symlinkSync(outsideResource, join(skillDir, 'references', 'guide.md'));
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'code-review',
+      'references/guide.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      message: 'Symlink target escapes the skill directory — access denied',
+    });
+  });
+
+  it('denies executable resources at the Skill trust policy seam and publishes the existing event', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nInstructions'
+    );
+    createResourceFile(skillDir, 'scripts/install.sh', '#!/bin/sh');
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const denied = vi.fn();
+    const warn = vi.spyOn(activationLogger, 'warn');
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, denied);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'scripts/install.sh'
+    );
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+    expect(denied).toHaveBeenCalledWith({
+      name: 'community-skill',
+      resourcePath: 'scripts/install.sh',
+      trustLevel: 'untrusted',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Skill resource load blocked — trust policy',
+      expect.objectContaining({
+        name: 'community-skill',
+        resourcePath: 'scripts/install.sh',
+        reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      })
+    );
+  });
+
+  it('applies Skill activation policy when resource access targets the instructions', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nSecret instructions'
+    );
+    symlinkSync(join(skillDir, 'SKILL.md'), join(skillDir, 'instructions.md'));
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const denied = vi.fn();
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, denied);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'instructions.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      message: expect.stringContaining('Skill activation blocked'),
+    });
+    expect(denied).toHaveBeenCalledWith({
+      name: 'community-skill',
+      resourcePath: 'SKILL.md',
+      trustLevel: 'untrusted',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      message: expect.stringContaining('Skill activation blocked'),
+    });
+  });
+
+  it('publishes the existing allow event for executable resources from trusted roots', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'trusted-skill',
+      'name: trusted-skill\ndescription: Trusted skill',
+      '\nInstructions'
+    );
+    createResourceFile(skillDir, 'scripts/install.sh', '#!/bin/sh');
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'trusted' }],
+    });
+    const allowed = vi.fn();
+    const info = vi.spyOn(activationLogger, 'info');
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, allowed);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'trusted-skill',
+      'scripts/install.sh'
+    );
+
+    expect(result).toEqual({ kind: 'success', content: '#!/bin/sh' });
+    expect(allowed).toHaveBeenCalledWith({
+      name: 'trusted-skill',
+      resourcePath: 'scripts/install.sh',
+      trustLevel: 'trusted',
+      reason: TrustPolicyReason.TRUSTED_ROOT,
+    });
+    expect(info).toHaveBeenCalledWith('Skill resource trust policy — allowed', {
+      name: 'trusted-skill',
+      resourcePath: 'scripts/install.sh',
+      trustLevel: 'trusted',
+      reason: TrustPolicyReason.TRUSTED_ROOT,
+    });
+  });
+
+  it('distinguishes a missing resource from other read failures', async () => {
+    createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const warn = vi.spyOn(activationLogger, 'warn');
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'code-review',
+      'references/missing.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'resource-not-found',
+      name: 'code-review',
+      resourcePath: 'references/missing.md',
+      error: expect.stringContaining('ENOENT'),
+    });
+    expect(warn).toHaveBeenCalledWith('Skill resource load failed — file not found or unreadable', {
+      name: 'code-review',
+      resourcePath: 'references/missing.md',
+      error: expect.stringContaining('ENOENT'),
+    });
+  });
+
+  it('normalizes a non-missing resource read failure without throwing', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    mkdirSync(join(skillDir, 'references', 'directory.md'), { recursive: true });
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'code-review',
+      'references/directory.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'read-failure',
+      name: 'code-review',
+      resourcePath: 'references/directory.md',
+      error: expect.any(String),
+    });
   });
 
   it('denies activation at the Skill trust policy seam and publishes the existing registry event', async () => {


### PR DESCRIPTION
## Summary

- move supporting-resource lookup, path validation, trust enforcement, reads, logging, and registry events into package-internal Agent Skill access
- keep read-skill-resource as a compatibility adapter over discriminated internal outcomes
- add policy-owner tests for ordinary, executable, missing, traversal, read-failure, and symlink behavior

## Validation

- pnpm test
- pnpm --filter @agentforge/skills typecheck
- pnpm --filter @agentforge/skills lint
- pnpm --filter @agentforge/skills build

Closes #210