### PR TITLE
Make Agent Skill access own canonical resource confinement

### DIFF
--- a/packages/skills/src/agent-skill-access.ts
+++ b/packages/skills/src/agent-skill-access.ts
@@ -1,11 +1,82 @@
 import { readFileSync, realpathSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { SkillRegistry } from './registry.js';
 import { SkillRegistryEvent, TrustPolicyReason } from './types.js';
 import { extractBody } from './activation-content.js';
-import { resolveResourcePath } from './activation-path.js';
 import { activationLogger } from './activation-shared.js';
 import { evaluateSkillActivationPolicy, evaluateTrustPolicy } from './trust.js';
+
+const PATH_TRAVERSAL_MESSAGE =
+  'Path traversal is not allowed — resource paths must stay within the skill directory';
+const SYMLINK_ESCAPE_MESSAGE = 'Symlink target escapes the skill directory — access denied';
+
+type CanonicalResourcePathResult =
+  | { kind: 'success'; resolvedPath: string; canonicalPath: string }
+  | { kind: 'access-denied'; message: string }
+  | { kind: 'resource-not-found'; error: string }
+  | { kind: 'read-failure'; error: string };
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatResourceReadError(error: unknown, resolvedPath: string): string {
+  const message = formatError(error);
+  const detailIndex = message.indexOf(', ');
+  const prefix = detailIndex === -1 ? message : message.slice(0, detailIndex);
+  return `${prefix}, open '${resolvedPath}'`;
+}
+
+function resolveCanonicalResourcePath(
+  skillPath: string,
+  resourcePath: string
+): CanonicalResourcePathResult {
+  if (isAbsolute(resourcePath)) {
+    return { kind: 'access-denied', message: 'Absolute resource paths are not allowed' };
+  }
+
+  if (resourcePath.split(/[/\\]/).some((segment) => segment === '..')) {
+    return { kind: 'access-denied', message: PATH_TRAVERSAL_MESSAGE };
+  }
+
+  const resolvedSkillPath = resolve(skillPath);
+  const resolvedPath = resolve(resolvedSkillPath, resourcePath);
+  const lexicalRelativePath = relative(resolvedSkillPath, resolvedPath);
+  if (
+    lexicalRelativePath.startsWith('..') ||
+    isAbsolute(lexicalRelativePath) ||
+    resolve(resolvedSkillPath, lexicalRelativePath) !== resolvedPath
+  ) {
+    return { kind: 'access-denied', message: PATH_TRAVERSAL_MESSAGE };
+  }
+
+  let canonicalSkillPath: string;
+  try {
+    canonicalSkillPath = realpathSync(resolvedSkillPath);
+  } catch (error) {
+    return { kind: 'read-failure', error: formatResourceReadError(error, resolvedPath) };
+  }
+
+  let canonicalPath: string;
+  try {
+    canonicalPath = realpathSync(resolvedPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        kind: 'resource-not-found',
+        error: formatResourceReadError(error, resolvedPath),
+      };
+    }
+    return { kind: 'read-failure', error: formatResourceReadError(error, resolvedPath) };
+  }
+
+  const canonicalRelativePath = relative(canonicalSkillPath, canonicalPath);
+  if (canonicalRelativePath.startsWith('..') || isAbsolute(canonicalRelativePath)) {
+    return { kind: 'access-denied', message: SYMLINK_ESCAPE_MESSAGE };
+  }
+
+  return { kind: 'success', resolvedPath, canonicalPath };
+}
 
 export type SkillActivationResult =
   | { kind: 'success'; body: string }
@@ -35,14 +106,22 @@ export class AgentSkillAccess {
       return { kind: 'skill-not-found', name, availableNames };
     }
 
-    const pathResult = resolveResourcePath(skill.skillPath, resourcePath);
-    if (!pathResult.success) {
+    const pathResult = resolveCanonicalResourcePath(skill.skillPath, resourcePath);
+    if (pathResult.kind === 'access-denied') {
       activationLogger.warn('Skill resource load blocked — path traversal', {
+        name,
+        resourcePath,
+        error: pathResult.message,
+      });
+      return pathResult;
+    }
+    if (pathResult.kind === 'resource-not-found' || pathResult.kind === 'read-failure') {
+      activationLogger.warn('Skill resource load failed — file not found or unreadable', {
         name,
         resourcePath,
         error: pathResult.error,
       });
-      return { kind: 'access-denied', message: pathResult.error };
+      return { ...pathResult, name, resourcePath };
     }
 
     const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
@@ -51,7 +130,7 @@ export class AgentSkillAccess {
     if (!isSkillInstructions) {
       try {
         isSkillInstructions =
-          realpathSync(pathResult.resolvedPath).toLowerCase() ===
+          pathResult.canonicalPath.toLowerCase() ===
           realpathSync(skillInstructionsPath).toLowerCase();
       } catch {
         // The resource read below reports missing or unreadable paths.
@@ -131,7 +210,7 @@ export class AgentSkillAccess {
 
     let content: string;
     try {
-      content = readFileSync(pathResult.resolvedPath, 'utf-8');
+      content = readFileSync(pathResult.canonicalPath, 'utf-8');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       activationLogger.warn('Skill resource load failed — file not found or unreadable', {

--- a/packages/skills/src/agent-skill-access.ts
+++ b/packages/skills/src/agent-skill-access.ts
@@ -13,7 +13,8 @@ const SYMLINK_ESCAPE_MESSAGE = 'Symlink target escapes the skill directory — a
 type CanonicalResourcePathResult =
   | { kind: 'success'; resolvedPath: string; canonicalPath: string }
   | { kind: 'access-denied'; message: string }
-  | { kind: 'resource-not-found'; error: string }
+  | { kind: 'resource-not-found'; resolvedPath: string; error: string }
+  | { kind: 'target-read-failure'; resolvedPath: string; error: string }
   | { kind: 'read-failure'; error: string };
 
 function formatError(error: unknown): string {
@@ -64,10 +65,15 @@ function resolveCanonicalResourcePath(
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return {
         kind: 'resource-not-found',
+        resolvedPath,
         error: formatResourceReadError(error, resolvedPath),
       };
     }
-    return { kind: 'read-failure', error: formatResourceReadError(error, resolvedPath) };
+    return {
+      kind: 'target-read-failure',
+      resolvedPath,
+      error: formatResourceReadError(error, resolvedPath),
+    };
   }
 
   const canonicalRelativePath = relative(canonicalSkillPath, canonicalPath);
@@ -115,7 +121,7 @@ export class AgentSkillAccess {
       });
       return pathResult;
     }
-    if (pathResult.kind === 'resource-not-found' || pathResult.kind === 'read-failure') {
+    if (pathResult.kind === 'read-failure') {
       activationLogger.warn('Skill resource load failed — file not found or unreadable', {
         name,
         resourcePath,
@@ -127,7 +133,7 @@ export class AgentSkillAccess {
     const skillInstructionsPath = resolve(skill.skillPath, 'SKILL.md');
     let isSkillInstructions =
       pathResult.resolvedPath.toLowerCase() === skillInstructionsPath.toLowerCase();
-    if (!isSkillInstructions) {
+    if (!isSkillInstructions && pathResult.kind === 'success') {
       try {
         isSkillInstructions =
           pathResult.canonicalPath.toLowerCase() ===
@@ -206,6 +212,20 @@ export class AgentSkillAccess {
         trustLevel: skill.trustLevel,
         reason: policyDecision.reason,
       });
+    }
+
+    if (pathResult.kind === 'resource-not-found' || pathResult.kind === 'target-read-failure') {
+      activationLogger.warn('Skill resource load failed — file not found or unreadable', {
+        name,
+        resourcePath,
+        error: pathResult.error,
+      });
+      return {
+        kind: pathResult.kind === 'resource-not-found' ? 'resource-not-found' : 'read-failure',
+        name,
+        resourcePath,
+        error: pathResult.error,
+      };
     }
 
     let content: string;

--- a/packages/skills/tests/agent-skill-access.test.ts
+++ b/packages/skills/tests/agent-skill-access.test.ts
@@ -213,6 +213,60 @@ describe('AgentSkillAccess', () => {
     );
   });
 
+  it('applies existing trust policies before normalizing missing sensitive resources', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    const missingScript = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'scripts/missing.sh'
+    );
+    rmSync(join(skillDir, 'SKILL.md'));
+    const missingInstructions = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'SKILL.md'
+    );
+
+    expect(missingScript).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+    expect(missingInstructions).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SKILL_ACTIVATION_DENIED,
+      message: expect.stringContaining('Skill activation blocked'),
+    });
+  });
+
+  it('applies trust policy before normalizing a target canonicalization failure', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nInstructions'
+    );
+    mkdirSync(join(skillDir, 'scripts'), { recursive: true });
+    symlinkSync('install.sh', join(skillDir, 'scripts', 'install.sh'));
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'scripts/install.sh'
+    );
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+  });
+
   it('applies Skill activation policy when resource access targets the instructions', async () => {
     const skillDir = createSkillFixture(
       tempDir,

--- a/packages/skills/tests/agent-skill-access.test.ts
+++ b/packages/skills/tests/agent-skill-access.test.ts
@@ -307,6 +307,29 @@ describe('AgentSkillAccess', () => {
     });
   });
 
+  it('fails closed when the canonical Agent Skill root can no longer be resolved', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'code-review',
+      'name: code-review\ndescription: Code review skill',
+      '\nInstructions'
+    );
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    rmSync(skillDir, { recursive: true });
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'code-review',
+      'references/guide.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'read-failure',
+      name: 'code-review',
+      resourcePath: 'references/guide.md',
+      error: expect.stringContaining(`open '${join(skillDir, 'references/guide.md')}'`),
+    });
+  });
+
   it('normalizes a non-missing resource read failure without throwing', async () => {
     const skillDir = createSkillFixture(
       tempDir,


### PR DESCRIPTION
## Summary
- resolve Agent Skill resource targets against the canonical Skill root before reading
- deny lexical and symlink escapes while normalizing missing and filesystem failures
- preserve existing Tool messages, logging, and registry event payloads

## Validation
- pnpm --filter @agentforge/skills typecheck
- pnpm --filter @agentforge/skills lint
- pnpm exec vitest run packages/skills/tests/agent-skill-access.test.ts packages/skills/tests/activation.test.ts packages/skills/tests/conformance.test.ts --project skills
- pnpm test

Closes #211