### PR TITLE
fix(skills): classify trust from canonical resource targets

### DIFF
--- a/packages/skills/src/agent-skill-access.ts
+++ b/packages/skills/src/agent-skill-access.ts
@@ -11,7 +11,12 @@ const PATH_TRAVERSAL_MESSAGE =
 const SYMLINK_ESCAPE_MESSAGE = 'Symlink target escapes the skill directory — access denied';
 
 type CanonicalResourcePathResult =
-  | { kind: 'success'; resolvedPath: string; canonicalPath: string }
+  | {
+      kind: 'success';
+      resolvedPath: string;
+      canonicalPath: string;
+      canonicalRelativePath: string;
+    }
   | { kind: 'access-denied'; message: string }
   | { kind: 'resource-not-found'; resolvedPath: string; error: string }
   | { kind: 'target-read-failure'; resolvedPath: string; error: string }
@@ -81,7 +86,7 @@ function resolveCanonicalResourcePath(
     return { kind: 'access-denied', message: SYMLINK_ESCAPE_MESSAGE };
   }
 
-  return { kind: 'success', resolvedPath, canonicalPath };
+  return { kind: 'success', resolvedPath, canonicalPath, canonicalRelativePath };
 }
 
 export type SkillActivationResult =
@@ -170,7 +175,7 @@ export class AgentSkillAccess {
     }
 
     const policyDecision = evaluateTrustPolicy(
-      resourcePath,
+      pathResult.kind === 'success' ? pathResult.canonicalRelativePath : resourcePath,
       skill.trustLevel,
       this.registry.getAllowUntrustedScripts()
     );

--- a/packages/skills/tests/agent-skill-access.test.ts
+++ b/packages/skills/tests/agent-skill-access.test.ts
@@ -213,6 +213,48 @@ describe('AgentSkillAccess', () => {
     );
   });
 
+  it('denies an ordinary-looking symlink to an executable resource using its canonical target', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'community-skill',
+      'name: community-skill\ndescription: Community skill',
+      '\nInstructions'
+    );
+    createResourceFile(skillDir, 'scripts/install.sh', '#!/bin/sh');
+    mkdirSync(join(skillDir, 'references'), { recursive: true });
+    symlinkSync('../scripts/install.sh', join(skillDir, 'references', 'guide.md'));
+    const registry = new SkillRegistry({ skillRoots: [tempDir] });
+    const denied = vi.fn();
+    const warn = vi.spyOn(activationLogger, 'warn');
+    registry.on(SkillRegistryEvent.TRUST_POLICY_DENIED, denied);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'community-skill',
+      'references/guide.md'
+    );
+
+    expect(result).toEqual({
+      kind: 'access-denied',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+    expect(denied).toHaveBeenCalledWith({
+      name: 'community-skill',
+      resourcePath: 'references/guide.md',
+      trustLevel: 'untrusted',
+      reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      message: expect.stringContaining('Script access denied'),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Skill resource load blocked — trust policy',
+      expect.objectContaining({
+        name: 'community-skill',
+        resourcePath: 'references/guide.md',
+        reason: TrustPolicyReason.UNTRUSTED_SCRIPT_DENIED,
+      })
+    );
+  });
+
   it('applies existing trust policies before normalizing missing sensitive resources', async () => {
     const skillDir = createSkillFixture(
       tempDir,
@@ -328,6 +370,43 @@ describe('AgentSkillAccess', () => {
     expect(info).toHaveBeenCalledWith('Skill resource trust policy — allowed', {
       name: 'trusted-skill',
       resourcePath: 'scripts/install.sh',
+      trustLevel: 'trusted',
+      reason: TrustPolicyReason.TRUSTED_ROOT,
+    });
+  });
+
+  it('reads an ordinary-looking symlink to an executable resource from a trusted root', async () => {
+    const skillDir = createSkillFixture(
+      tempDir,
+      'trusted-skill',
+      'name: trusted-skill\ndescription: Trusted skill',
+      '\nInstructions'
+    );
+    createResourceFile(skillDir, 'scripts/install.sh', '#!/bin/sh');
+    mkdirSync(join(skillDir, 'references'), { recursive: true });
+    symlinkSync('../scripts/install.sh', join(skillDir, 'references', 'guide.md'));
+    const registry = new SkillRegistry({
+      skillRoots: [{ path: tempDir, trust: 'trusted' }],
+    });
+    const allowed = vi.fn();
+    const info = vi.spyOn(activationLogger, 'info');
+    registry.on(SkillRegistryEvent.TRUST_POLICY_ALLOWED, allowed);
+
+    const result = await new AgentSkillAccess(registry).readResource(
+      'trusted-skill',
+      'references/guide.md'
+    );
+
+    expect(result).toEqual({ kind: 'success', content: '#!/bin/sh' });
+    expect(allowed).toHaveBeenCalledWith({
+      name: 'trusted-skill',
+      resourcePath: 'references/guide.md',
+      trustLevel: 'trusted',
+      reason: TrustPolicyReason.TRUSTED_ROOT,
+    });
+    expect(info).toHaveBeenCalledWith('Skill resource trust policy — allowed', {
+      name: 'trusted-skill',
+      resourcePath: 'references/guide.md',
       trustLevel: 'trusted',
       reason: TrustPolicyReason.TRUSTED_ROOT,
     });


### PR DESCRIPTION
Closes #212

## Summary
- classify existing Agent Skill resources from their canonical Skill-relative target
- preserve lexical resource paths in public logging and registry audit payloads
- cover denied untrusted and allowed trusted executable-resource aliases

## Validation
- pnpm typecheck
- pnpm --filter @agentforge/skills lint
- pnpm vitest run packages/skills/tests
- pnpm test