### PR TITLE
docs(skills): deprecate resource path helper

### DIFF
--- a/docs-site/api/skills.md
+++ b/docs-site/api/skills.md
@@ -180,7 +180,7 @@ interface SkillMetadata {
 | `createActivateSkillTool(registry)` | `(SkillRegistry) => Tool` | Create standalone activate-skill tool |
 | `createReadSkillResourceTool(registry)` | `(SkillRegistry) => Tool` | Create standalone read-skill-resource tool |
 | `createSkillActivationTools(registry)` | `(SkillRegistry) => [Tool, Tool]` | Create both tools as a tuple |
-| `resolveResourcePath(skillDir, resourcePath)` | `(string, string) => { success: true; resolvedPath: string } \| { success: false; error: string }` | Validate and resolve a resource path (returns discriminated union) |
+| `resolveResourcePath(skillDir, resourcePath)` | `(string, string) => { success: true; resolvedPath: string } \| { success: false; error: string }` | **Deprecated.** Compatibility-only resource path validation; planned for removal in the next major release |
 | `evaluateTrustPolicy(resourcePath, trustLevel, allowUntrustedScripts?)` | `(...) => TrustPolicyDecision` | Evaluate whether a resource access is allowed |
 | `isScriptResource(resourcePath)` | `(string) => boolean` | Check if path targets `scripts/` directory |
 | `normalizeRootConfig(root)` | `(string \| SkillRootConfig) => SkillRootConfig` | Normalize string to root config |
@@ -188,6 +188,10 @@ interface SkillMetadata {
 | `validateSkillName(name)` | `(string) => SkillValidationError[]` | Validate skill name format |
 | `scanSkillRoot(rootPath)` | `(string) => SkillCandidate[]` | Scan a directory for skill candidates |
 | `scanAllSkillRoots(roots)` | `(string[]) => SkillCandidate[]` | Scan multiple root directories |
+
+::: warning Deprecated resource-path helper
+`resolveResourcePath` remains exported during the compatibility window, but Agent Skill access should use the `read-skill-resource` Tool returned by `SkillRegistry.toActivationTools()`. The standalone helper is planned for removal in the next major release.
+:::
 
 ## Type Definitions
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -24,6 +24,26 @@ yarn add @agentforge/skills
 
 Full source code and API will be available after ST-07002 (Move Skills Source Files). See the [AgentForge docs](https://tvscoundrel.github.io/agentforge/) for usage guides and tutorials.
 
+## Agent Skill Access
+
+Access Agent Skill instructions and supporting resources through the Tools bound
+to a `SkillRegistry`:
+
+```typescript
+import { SkillRegistry } from '@agentforge/skills';
+
+const registry = new SkillRegistry({
+  enabled: true,
+  skillRoots: [{ path: '.agentskills', trust: 'workspace' }],
+});
+
+const [activateSkill, readSkillResource] = registry.toActivationTools();
+```
+
+`resolveResourcePath` remains exported for compatibility, but it is deprecated
+and planned for removal in the next major release. Use the
+`read-skill-resource` Tool for Agent Skill resource access instead.
+
 ## License
 
 MIT — see [LICENSE](../../LICENSE) for details.

--- a/packages/skills/src/activation-path.ts
+++ b/packages/skills/src/activation-path.ts
@@ -6,7 +6,7 @@ import { realpathSync } from 'node:fs';
  *
  * @param skillPath - Absolute path to the skill directory
  * @param resourcePath - Relative path to the resource file
- * @returns Absolute path to the resource, or an error string
+ * @returns A result containing either the resolved absolute path or an error message
  * @deprecated Use the `read-skill-resource` Tool from
  * `SkillRegistry.toActivationTools()` for Agent Skill resource access. This
  * compatibility helper is planned for removal in the next major release.

--- a/packages/skills/src/activation-path.ts
+++ b/packages/skills/src/activation-path.ts
@@ -7,6 +7,9 @@ import { realpathSync } from 'node:fs';
  * @param skillPath - Absolute path to the skill directory
  * @param resourcePath - Relative path to the resource file
  * @returns Absolute path to the resource, or an error string
+ * @deprecated Use the `read-skill-resource` Tool from
+ * `SkillRegistry.toActivationTools()` for Agent Skill resource access. This
+ * compatibility helper is planned for removal in the next major release.
  */
 export function resolveResourcePath(
   skillPath: string,

--- a/packages/skills/tests/activation/resolve-resource-path.suite.ts
+++ b/packages/skills/tests/activation/resolve-resource-path.suite.ts
@@ -1,7 +1,7 @@
 import { symlinkSync, writeFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveResourcePath } from '../../src/activation.js';
+import { resolveResourcePath } from '../../src/index.js';
 import { createTempDir } from './shared.js';
 
 describe('resolveResourcePath', () => {


### PR DESCRIPTION
Closes #213

## Summary
- mark resolveResourcePath as deprecated with next-major removal guidance
- direct package consumers to Tool-based Agent Skill access
- protect the helper's public export and established behavior through the package entrypoint

## Validation
- pnpm --filter @agentforge/skills build
- pnpm --filter @agentforge/skills lint
- pnpm vitest run packages/skills/tests
- pnpm typecheck
- pnpm test