### PR TITLE
Prepare relational mutation tools for owned sessions

### DIFF
--- a/packages/tools/src/data/relational/tools/mutation-execution.ts
+++ b/packages/tools/src/data/relational/tools/mutation-execution.ts
@@ -1,0 +1,10 @@
+import type { TransactionContext } from '../query/transaction.js';
+import type { SqlExecutor } from '../query/types.js';
+import type { DatabaseVendor } from '../types.js';
+
+/** Runtime dependencies supplied by a session-owning Relational Tool Set. */
+export interface RelationalMutationExecution {
+  executor: SqlExecutor;
+  vendor: DatabaseVendor;
+  transaction?: TransactionContext;
+}

--- a/packages/tools/src/data/relational/tools/relational-delete/executor-batch.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor-batch.ts
@@ -2,13 +2,13 @@ import {
   benchmarkBatchExecution,
   executeBatchedTask,
 } from '../../query/batch-executor.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
   DeleteBatchMetadata,
   DeleteBatchOperation,
   DeleteBatchOptions,
   DeleteResult,
-  RelationalDeleteInput,
+  RelationalDeleteExecutionInput,
 } from './types.js';
 import { executeSingleDelete } from './executor-single.js';
 import {
@@ -19,8 +19,8 @@ import {
 } from './executor-shared.js';
 
 export async function executeDeleteInBatchMode(
-  manager: ConnectionManager,
-  input: RelationalDeleteInput & { operations: DeleteBatchOperation[] },
+  executor: SqlExecutor,
+  input: RelationalDeleteExecutionInput & { operations: DeleteBatchOperation[] },
   context: DeleteExecutionContext | undefined,
   options: Required<DeleteBatchOptions>
 ): Promise<DeleteResult> {
@@ -38,7 +38,7 @@ export async function executeDeleteInBatchMode(
         for (const operation of operations) {
           try {
             const result = await executeSingleDelete(
-              manager,
+              executor,
               input,
               {
                 where: operation.where,

--- a/packages/tools/src/data/relational/tools/relational-delete/executor-shared.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor-shared.ts
@@ -3,7 +3,7 @@ import type { TransactionContext } from '../../query/transaction.js';
 import type {
   DeleteBatchMetadata,
   DeleteBatchOptions,
-  RelationalDeleteInput,
+  RelationalDeleteExecutionInput,
 } from './types.js';
 
 export const deleteExecutorLogger = createLogger('agentforge:tools:data:relational:delete');
@@ -18,10 +18,10 @@ export interface DeleteExecutionContext {
 }
 
 export interface SingleDeleteOperation {
-  where?: RelationalDeleteInput['where'];
-  allowFullTableDelete?: RelationalDeleteInput['allowFullTableDelete'];
-  cascade?: RelationalDeleteInput['cascade'];
-  softDelete?: RelationalDeleteInput['softDelete'];
+  where?: RelationalDeleteExecutionInput['where'];
+  allowFullTableDelete?: RelationalDeleteExecutionInput['allowFullTableDelete'];
+  cascade?: RelationalDeleteExecutionInput['cascade'];
+  softDelete?: RelationalDeleteExecutionInput['softDelete'];
 }
 
 export interface DeleteChunkExecutionResult {
@@ -78,7 +78,7 @@ export function resolveBatchOptions(batch: DeleteBatchOptions | undefined): Requ
   };
 }
 
-export function toSingleDeleteOperation(input: RelationalDeleteInput): SingleDeleteOperation {
+export function toSingleDeleteOperation(input: RelationalDeleteExecutionInput): SingleDeleteOperation {
   return {
     where: input.where,
     allowFullTableDelete: input.allowFullTableDelete,

--- a/packages/tools/src/data/relational/tools/relational-delete/executor-single.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor-single.ts
@@ -1,6 +1,6 @@
 import { buildDeleteQuery } from '../../query/query-builder.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
-import type { DeleteResult, RelationalDeleteInput } from './types.js';
+import type { SqlExecutor } from '../../query/types.js';
+import type { DeleteResult, RelationalDeleteExecutionInput } from './types.js';
 import {
   normalizeAffectedRows,
   type DeleteExecutionContext,
@@ -8,8 +8,8 @@ import {
 } from './executor-shared.js';
 
 export async function executeSingleDelete(
-  manager: ConnectionManager,
-  input: RelationalDeleteInput,
+  executor: SqlExecutor,
+  input: RelationalDeleteExecutionInput,
   operation: SingleDeleteOperation,
   context?: DeleteExecutionContext
 ): Promise<DeleteResult> {
@@ -21,8 +21,8 @@ export async function executeSingleDelete(
     vendor: input.vendor,
   });
 
-  const executor = context?.transaction ?? manager;
-  const rawResult = await executor.execute(built.query);
+  const session = context?.transaction ?? executor;
+  const rawResult = await session.execute(built.query);
   const rowCount = normalizeAffectedRows(rawResult);
 
   return {

--- a/packages/tools/src/data/relational/tools/relational-delete/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/executor.ts
@@ -3,11 +3,11 @@
  * @module tools/relational-delete/executor
  */
 
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
   DeleteBatchOperation,
   DeleteResult,
-  RelationalDeleteInput,
+  RelationalDeleteExecutionInput,
 } from './types.js';
 import { getDeleteConstraintViolationMessage, isSafeDeleteValidationError } from './error-utils.js';
 import { executeDeleteInBatchMode } from './executor-batch.js';
@@ -25,8 +25,8 @@ export type { DeleteExecutionContext } from './executor-shared.js';
  * Execute a DELETE query using the shared query builder.
  */
 export async function executeDelete(
-  manager: ConnectionManager,
-  input: RelationalDeleteInput,
+  executor: SqlExecutor,
+  input: RelationalDeleteExecutionInput,
   context?: DeleteExecutionContext
 ): Promise<DeleteResult> {
   const startTime = Date.now();
@@ -47,12 +47,12 @@ export async function executeDelete(
 
     const result = input.operations && batchOptions
       ? await executeDeleteInBatchMode(
-        manager,
-        input as RelationalDeleteInput & { operations: DeleteBatchOperation[] },
+        executor,
+        input as RelationalDeleteExecutionInput & { operations: DeleteBatchOperation[] },
         context,
         batchOptions
       )
-      : await executeSingleDelete(manager, input, toSingleDeleteOperation(input), context);
+      : await executeSingleDelete(executor, input, toSingleDeleteOperation(input), context);
 
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/tools/relational-delete/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/index.ts
@@ -11,11 +11,54 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { ConnectionManager } from '../../connection/connection-manager.js';
 import { relationalDeleteSchema } from './schemas.js';
 import { executeDelete } from './executor.js';
-import type { RelationalDeleteInput, DeleteResponse } from './types.js';
+import type {
+  DeleteErrorResponse,
+  DeleteResponse,
+  RelationalDeleteInput,
+  RelationalDeleteOperationInput,
+} from './types.js';
 import { isSafeDeleteError } from './error-utils.js';
+import type { RelationalMutationExecution } from '../mutation-execution.js';
 
 export * from './types.js';
 export * from './schemas.js';
+
+function toDeleteErrorResponse(error: unknown): DeleteErrorResponse {
+  const errorMessage = isSafeDeleteError(error)
+    ? error.message
+    : 'Failed to execute DELETE query. Please verify your input and database connection.';
+
+  return {
+    success: false,
+    error: errorMessage,
+    rowCount: 0,
+    softDeleted: false,
+  };
+}
+
+/** Execute DELETE through a session owned by the caller. */
+export async function invokeRelationalDelete(
+  execution: RelationalMutationExecution,
+  input: RelationalDeleteOperationInput
+): Promise<DeleteResponse> {
+  try {
+    const result = await executeDelete(
+      execution.executor,
+      { ...input, vendor: execution.vendor },
+      execution.transaction ? { transaction: execution.transaction } : undefined
+    );
+
+    return {
+      success: true,
+      rowCount: result.rowCount,
+      executionTime: result.executionTime,
+      softDeleted: result.softDeleted,
+      batch: result.batch,
+    };
+  } catch (error) {
+    return toDeleteErrorResponse(error);
+  }
+}
 
 /**
  * LangGraph tool for type-safe DELETE queries with single and batched operation support.
@@ -80,28 +123,12 @@ export const relationalDelete = toolBuilder()
     try {
       await manager.connect();
 
-      const result = await executeDelete(manager, input);
-
-      return {
-        success: true,
-        rowCount: result.rowCount,
-        executionTime: result.executionTime,
-        softDeleted: result.softDeleted,
-        batch: result.batch,
-      };
+      return await invokeRelationalDelete(
+        { executor: manager, vendor: input.vendor },
+        input
+      );
     } catch (error) {
-      let errorMessage = 'Failed to execute DELETE query. Please verify your input and database connection.';
-
-      if (isSafeDeleteError(error)) {
-        errorMessage = error.message;
-      }
-
-      return {
-        success: false,
-        error: errorMessage,
-        rowCount: 0,
-        softDeleted: false,
-      };
+      return toDeleteErrorResponse(error);
     } finally {
       await manager.disconnect();
     }

--- a/packages/tools/src/data/relational/tools/relational-delete/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/index.ts
@@ -115,17 +115,18 @@ export const relationalDelete = toolBuilder()
     },
   })
   .implement(async (input: RelationalDeleteInput): Promise<DeleteResponse> => {
+    const { connectionString, vendor, ...operation } = input;
     const manager = new ConnectionManager({
-      vendor: input.vendor,
-      connection: input.connectionString,
+      vendor,
+      connection: connectionString,
     });
 
     try {
       await manager.connect();
 
       return await invokeRelationalDelete(
-        { executor: manager, vendor: input.vendor },
-        input
+        { executor: manager, vendor },
+        operation
       );
     } catch (error) {
       return toDeleteErrorResponse(error);

--- a/packages/tools/src/data/relational/tools/relational-delete/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/types.ts
@@ -47,6 +47,12 @@ export interface DeleteBatchMetadata {
 /** Validated input for the relational-delete tool. */
 export type RelationalDeleteInput = z.input<typeof relationalDeleteSchema>;
 
+/** DELETE input after database credentials have been bound by a session owner. */
+export type RelationalDeleteExecutionInput = Omit<RelationalDeleteInput, 'connectionString'>;
+
+/** Agent-facing DELETE operation input for a configured database session. */
+export type RelationalDeleteOperationInput = Omit<RelationalDeleteExecutionInput, 'vendor'>;
+
 /** Internal result from a single or batched DELETE execution. */
 export interface DeleteResult {
   rowCount: number;

--- a/packages/tools/src/data/relational/tools/relational-insert/executor-batch.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/executor-batch.ts
@@ -1,18 +1,18 @@
 import { benchmarkBatchExecution, executeBatchedTask } from '../../query/batch-executor.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
   InsertBatchMetadata,
   InsertBatchOptions,
   InsertResult,
   InsertRow,
-  RelationalInsertInput,
+  RelationalInsertExecutionInput,
 } from './types.js';
 import { executeInsertOnce } from './executor-single.js';
 import { insertExecutorLogger, type InsertExecutionContext } from './executor-shared.js';
 
 export async function executeInsertInBatchMode(
-  manager: ConnectionManager,
-  input: RelationalInsertInput & { data: InsertRow[] },
+  executor: SqlExecutor,
+  input: RelationalInsertExecutionInput & { data: InsertRow[] },
   context: InsertExecutionContext | undefined,
   options: Required<InsertBatchOptions>
 ): Promise<InsertResult> {
@@ -21,7 +21,7 @@ export async function executeInsertInBatchMode(
       operation: 'insert',
       items: input.data,
       executeBatch: async (rows) =>
-        executeInsertOnce(manager, {
+        executeInsertOnce(executor, {
           ...input,
           data: rows,
           batch: undefined,

--- a/packages/tools/src/data/relational/tools/relational-insert/executor-single.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/executor-single.ts
@@ -1,6 +1,6 @@
 import { buildInsertQuery } from '../../query/query-builder.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
-import type { RelationalInsertInput, InsertResult } from './types.js';
+import type { SqlExecutor } from '../../query/types.js';
+import type { RelationalInsertExecutionInput, InsertResult } from './types.js';
 import {
   deriveInsertedIds,
   normalizeExecutionResult,
@@ -9,8 +9,8 @@ import {
 } from './executor-shared.js';
 
 export async function executeInsertOnce(
-  manager: ConnectionManager,
-  input: RelationalInsertInput,
+  executor: SqlExecutor,
+  input: RelationalInsertExecutionInput,
   context?: InsertExecutionContext
 ): Promise<InsertResult> {
   const built = buildInsertQuery({
@@ -20,7 +20,7 @@ export async function executeInsertOnce(
     vendor: input.vendor,
   });
 
-  const executor = context?.transaction ?? manager;
+  const session = context?.transaction ?? executor;
 
   if (Array.isArray(built.query)) {
     let totalRowCount = 0;
@@ -28,7 +28,7 @@ export async function executeInsertOnce(
     const allIds: Array<string | number> = [];
 
     for (const singleQuery of built.query) {
-      const rawResult = await executor.execute(singleQuery);
+      const rawResult = await session.execute(singleQuery);
       const normalized = normalizeExecutionResult(rawResult);
       totalRowCount += normalized.rowCount > 0 ? normalized.rowCount : 1;
       if (built.returningMode === 'row') {
@@ -55,7 +55,7 @@ export async function executeInsertOnce(
     };
   }
 
-  const rawResult = await executor.execute(built.query);
+  const rawResult = await session.execute(built.query);
   const normalized = normalizeExecutionResult(rawResult);
 
   const rowCount = normalized.rowCount > 0 ? normalized.rowCount : built.rows.length;

--- a/packages/tools/src/data/relational/tools/relational-insert/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/executor.ts
@@ -3,11 +3,11 @@
  * @module tools/relational-insert/executor
  */
 
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
   InsertResult,
   InsertRow,
-  RelationalInsertInput,
+  RelationalInsertExecutionInput,
 } from './types.js';
 import { getConstraintViolationMessage, isSafeInsertValidationError } from './error-utils.js';
 import { executeInsertInBatchMode } from './executor-batch.js';
@@ -24,8 +24,8 @@ export type { InsertExecutionContext } from './executor-shared.js';
  * Execute an INSERT query using the shared query builder.
  */
 export async function executeInsert(
-  manager: ConnectionManager,
-  input: RelationalInsertInput,
+  executor: SqlExecutor,
+  input: RelationalInsertExecutionInput,
   context?: InsertExecutionContext
 ): Promise<InsertResult> {
   const startTime = Date.now();
@@ -43,12 +43,12 @@ export async function executeInsert(
 
     const result = Array.isArray(input.data) && batchOptions
       ? await executeInsertInBatchMode(
-        manager,
-        input as RelationalInsertInput & { data: InsertRow[] },
+        executor,
+        input as RelationalInsertExecutionInput & { data: InsertRow[] },
         context,
         batchOptions
       )
-      : await executeInsertOnce(manager, input, context);
+      : await executeInsertOnce(executor, input, context);
 
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/tools/relational-insert/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/index.ts
@@ -11,12 +11,57 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { ConnectionManager } from '../../connection/connection-manager.js';
 import { relationalInsertSchema } from './schemas.js';
 import { executeInsert } from './executor.js';
-import type { InsertResponse, RelationalInsertInput } from './types.js';
+import type {
+  InsertErrorResponse,
+  InsertResponse,
+  RelationalInsertInput,
+  RelationalInsertOperationInput,
+} from './types.js';
 import { isSafeInsertError } from './error-utils.js';
+import type { RelationalMutationExecution } from '../mutation-execution.js';
 
 // Re-export types and schemas for external use
 export * from './types.js';
 export * from './schemas.js';
+
+function toInsertErrorResponse(error: unknown): InsertErrorResponse {
+  const errorMessage = isSafeInsertError(error)
+    ? error.message
+    : 'Failed to execute INSERT query. Please verify your input and database connection.';
+
+  return {
+    success: false,
+    error: errorMessage,
+    rowCount: 0,
+    insertedIds: [],
+    rows: [],
+  };
+}
+
+/** Execute INSERT through a session owned by the caller. */
+export async function invokeRelationalInsert(
+  execution: RelationalMutationExecution,
+  input: RelationalInsertOperationInput
+): Promise<InsertResponse> {
+  try {
+    const result = await executeInsert(
+      execution.executor,
+      { ...input, vendor: execution.vendor },
+      execution.transaction ? { transaction: execution.transaction } : undefined
+    );
+
+    return {
+      success: true,
+      rowCount: result.rowCount,
+      insertedIds: result.insertedIds,
+      rows: result.rows,
+      executionTime: result.executionTime,
+      batch: result.batch,
+    };
+  } catch (error) {
+    return toInsertErrorResponse(error);
+  }
+}
 
 /**
  * Relational INSERT Tool
@@ -66,30 +111,12 @@ export const relationalInsert = toolBuilder()
     try {
       await manager.connect();
 
-      const result = await executeInsert(manager, input);
-
-      return {
-        success: true,
-        rowCount: result.rowCount,
-        insertedIds: result.insertedIds,
-        rows: result.rows,
-        executionTime: result.executionTime,
-        batch: result.batch,
-      };
+      return await invokeRelationalInsert(
+        { executor: manager, vendor: input.vendor },
+        input
+      );
     } catch (error) {
-      let errorMessage = 'Failed to execute INSERT query. Please verify your input and database connection.';
-
-      if (isSafeInsertError(error)) {
-        errorMessage = error.message;
-      }
-
-      return {
-        success: false,
-        error: errorMessage,
-        rowCount: 0,
-        insertedIds: [],
-        rows: [],
-      };
+      return toInsertErrorResponse(error);
     } finally {
       await manager.disconnect();
     }

--- a/packages/tools/src/data/relational/tools/relational-insert/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/index.ts
@@ -103,17 +103,18 @@ export const relationalInsert = toolBuilder()
     },
   })
   .implement(async (input: RelationalInsertInput): Promise<InsertResponse> => {
+    const { connectionString, vendor, ...operation } = input;
     const manager = new ConnectionManager({
-      vendor: input.vendor,
-      connection: input.connectionString,
+      vendor,
+      connection: connectionString,
     });
 
     try {
       await manager.connect();
 
       return await invokeRelationalInsert(
-        { executor: manager, vendor: input.vendor },
-        input
+        { executor: manager, vendor },
+        operation
       );
     } catch (error) {
       return toInsertErrorResponse(error);

--- a/packages/tools/src/data/relational/tools/relational-insert/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/types.ts
@@ -61,6 +61,12 @@ export interface InsertBatchMetadata {
  */
 export type RelationalInsertInput = z.input<typeof relationalInsertSchema>;
 
+/** INSERT input after database credentials have been bound by a session owner. */
+export type RelationalInsertExecutionInput = Omit<RelationalInsertInput, 'connectionString'>;
+
+/** Agent-facing INSERT operation input for a configured database session. */
+export type RelationalInsertOperationInput = Omit<RelationalInsertExecutionInput, 'vendor'>;
+
 /**
  * INSERT execution result.
  */

--- a/packages/tools/src/data/relational/tools/relational-update/executor-batch.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/executor-batch.ts
@@ -1,7 +1,7 @@
 import { benchmarkBatchExecution, executeBatchedTask } from '../../query/batch-executor.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
-  RelationalUpdateInput,
+  RelationalUpdateExecutionInput,
   UpdateBatchMetadata,
   UpdateBatchOperation,
   UpdateBatchOptions,
@@ -16,8 +16,8 @@ import {
 } from './executor-shared.js';
 
 export async function executeUpdateInBatchMode(
-  manager: ConnectionManager,
-  input: RelationalUpdateInput & { operations: UpdateBatchOperation[] },
+  executor: SqlExecutor,
+  input: RelationalUpdateExecutionInput & { operations: UpdateBatchOperation[] },
   context: UpdateExecutionContext | undefined,
   options: Required<UpdateBatchOptions>
 ): Promise<UpdateResult> {
@@ -34,7 +34,7 @@ export async function executeUpdateInBatchMode(
         for (const operation of operations) {
           try {
             const result = await executeSingleUpdate(
-              manager,
+              executor,
               input,
               {
                 data: operation.data,

--- a/packages/tools/src/data/relational/tools/relational-update/executor-shared.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/executor-shared.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@agentforge/core';
 import type { TransactionContext } from '../../query/transaction.js';
 import type {
-  RelationalUpdateInput,
+  RelationalUpdateExecutionInput,
   UpdateBatchMetadata,
   UpdateBatchOptions,
 } from './types.js';
@@ -18,10 +18,10 @@ export interface UpdateExecutionContext {
 }
 
 export interface SingleUpdateOperation {
-  data: NonNullable<RelationalUpdateInput['data']>;
-  where?: RelationalUpdateInput['where'];
-  allowFullTableUpdate?: RelationalUpdateInput['allowFullTableUpdate'];
-  optimisticLock?: RelationalUpdateInput['optimisticLock'];
+  data: NonNullable<RelationalUpdateExecutionInput['data']>;
+  where?: RelationalUpdateExecutionInput['where'];
+  allowFullTableUpdate?: RelationalUpdateExecutionInput['allowFullTableUpdate'];
+  optimisticLock?: RelationalUpdateExecutionInput['optimisticLock'];
 }
 
 export interface UpdateChunkExecutionResult {
@@ -77,7 +77,7 @@ export function resolveBatchOptions(batch: UpdateBatchOptions | undefined): Requ
   };
 }
 
-export function toSingleUpdateOperation(input: RelationalUpdateInput): SingleUpdateOperation {
+export function toSingleUpdateOperation(input: RelationalUpdateExecutionInput): SingleUpdateOperation {
   if (!input.data) {
     throw new Error('UPDATE data is required when operations[] is not provided.');
   }

--- a/packages/tools/src/data/relational/tools/relational-update/executor-single.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/executor-single.ts
@@ -1,6 +1,6 @@
 import { buildUpdateQuery } from '../../query/query-builder.js';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
-import type { RelationalUpdateInput, UpdateResult } from './types.js';
+import type { SqlExecutor } from '../../query/types.js';
+import type { RelationalUpdateExecutionInput, UpdateResult } from './types.js';
 import {
   normalizeAffectedRows,
   type SingleUpdateOperation,
@@ -8,8 +8,8 @@ import {
 } from './executor-shared.js';
 
 export async function executeSingleUpdate(
-  manager: ConnectionManager,
-  input: RelationalUpdateInput,
+  executor: SqlExecutor,
+  input: RelationalUpdateExecutionInput,
   operation: SingleUpdateOperation,
   context?: UpdateExecutionContext
 ): Promise<UpdateResult> {
@@ -22,8 +22,8 @@ export async function executeSingleUpdate(
     vendor: input.vendor,
   });
 
-  const executor = context?.transaction ?? manager;
-  const rawResult = await executor.execute(built.query);
+  const session = context?.transaction ?? executor;
+  const rawResult = await session.execute(built.query);
   const rowCount = normalizeAffectedRows(rawResult);
 
   if (built.usesOptimisticLock && rowCount === 0) {

--- a/packages/tools/src/data/relational/tools/relational-update/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/executor.ts
@@ -3,9 +3,9 @@
  * @module tools/relational-update/executor
  */
 
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type {
-  RelationalUpdateInput,
+  RelationalUpdateExecutionInput,
   UpdateBatchOperation,
   UpdateResult,
 } from './types.js';
@@ -25,8 +25,8 @@ export type { UpdateExecutionContext } from './executor-shared.js';
  * Execute an UPDATE query using the shared query builder.
  */
 export async function executeUpdate(
-  manager: ConnectionManager,
-  input: RelationalUpdateInput,
+  executor: SqlExecutor,
+  input: RelationalUpdateExecutionInput,
   context?: UpdateExecutionContext
 ): Promise<UpdateResult> {
   const startTime = Date.now();
@@ -46,12 +46,12 @@ export async function executeUpdate(
 
     const result = input.operations && batchOptions
       ? await executeUpdateInBatchMode(
-        manager,
-        input as RelationalUpdateInput & { operations: UpdateBatchOperation[] },
+        executor,
+        input as RelationalUpdateExecutionInput & { operations: UpdateBatchOperation[] },
         context,
         batchOptions
       )
-      : await executeSingleUpdate(manager, input, toSingleUpdateOperation(input), context);
+      : await executeSingleUpdate(executor, input, toSingleUpdateOperation(input), context);
 
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/tools/relational-update/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/index.ts
@@ -115,17 +115,18 @@ export const relationalUpdate = toolBuilder()
     },
   })
   .implement(async (input: RelationalUpdateInput): Promise<UpdateResponse> => {
+    const { connectionString, vendor, ...operation } = input;
     const manager = new ConnectionManager({
-      vendor: input.vendor,
-      connection: input.connectionString,
+      vendor,
+      connection: connectionString,
     });
 
     try {
       await manager.connect();
 
       return await invokeRelationalUpdate(
-        { executor: manager, vendor: input.vendor },
-        input
+        { executor: manager, vendor },
+        operation
       );
     } catch (error) {
       return toUpdateErrorResponse(error);

--- a/packages/tools/src/data/relational/tools/relational-update/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/index.ts
@@ -11,12 +11,53 @@ import { toolBuilder, ToolCategory } from '@agentforge/core';
 import { ConnectionManager } from '../../connection/connection-manager.js';
 import { relationalUpdateSchema } from './schemas.js';
 import { executeUpdate } from './executor.js';
-import type { RelationalUpdateInput, UpdateResponse } from './types.js';
+import type {
+  RelationalUpdateInput,
+  RelationalUpdateOperationInput,
+  UpdateErrorResponse,
+  UpdateResponse,
+} from './types.js';
 import { isSafeUpdateError } from './error-utils.js';
+import type { RelationalMutationExecution } from '../mutation-execution.js';
 
 // Re-export types and schemas for external use
 export * from './types.js';
 export * from './schemas.js';
+
+function toUpdateErrorResponse(error: unknown): UpdateErrorResponse {
+  const errorMessage = isSafeUpdateError(error)
+    ? error.message
+    : 'Failed to execute UPDATE query. Please verify your input and database connection.';
+
+  return {
+    success: false,
+    error: errorMessage,
+    rowCount: 0,
+  };
+}
+
+/** Execute UPDATE through a session owned by the caller. */
+export async function invokeRelationalUpdate(
+  execution: RelationalMutationExecution,
+  input: RelationalUpdateOperationInput
+): Promise<UpdateResponse> {
+  try {
+    const result = await executeUpdate(
+      execution.executor,
+      { ...input, vendor: execution.vendor },
+      execution.transaction ? { transaction: execution.transaction } : undefined
+    );
+
+    return {
+      success: true,
+      rowCount: result.rowCount,
+      executionTime: result.executionTime,
+      batch: result.batch,
+    };
+  } catch (error) {
+    return toUpdateErrorResponse(error);
+  }
+}
 
 /**
  * Relational UPDATE Tool
@@ -82,26 +123,12 @@ export const relationalUpdate = toolBuilder()
     try {
       await manager.connect();
 
-      const result = await executeUpdate(manager, input);
-
-      return {
-        success: true,
-        rowCount: result.rowCount,
-        executionTime: result.executionTime,
-        batch: result.batch,
-      };
+      return await invokeRelationalUpdate(
+        { executor: manager, vendor: input.vendor },
+        input
+      );
     } catch (error) {
-      let errorMessage = 'Failed to execute UPDATE query. Please verify your input and database connection.';
-
-      if (isSafeUpdateError(error)) {
-        errorMessage = error.message;
-      }
-
-      return {
-        success: false,
-        error: errorMessage,
-        rowCount: 0,
-      };
+      return toUpdateErrorResponse(error);
     } finally {
       await manager.disconnect();
     }

--- a/packages/tools/src/data/relational/tools/relational-update/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/types.ts
@@ -73,6 +73,12 @@ export interface UpdateBatchMetadata {
  */
 export type RelationalUpdateInput = z.input<typeof relationalUpdateSchema>;
 
+/** UPDATE input after database credentials have been bound by a session owner. */
+export type RelationalUpdateExecutionInput = Omit<RelationalUpdateInput, 'connectionString'>;
+
+/** Agent-facing UPDATE operation input for a configured database session. */
+export type RelationalUpdateOperationInput = Omit<RelationalUpdateExecutionInput, 'vendor'>;
+
 /**
  * UPDATE execution result.
  */

--- a/packages/tools/tests/data/relational/tools/mutation-owned-session.test.ts
+++ b/packages/tools/tests/data/relational/tools/mutation-owned-session.test.ts
@@ -6,6 +6,26 @@ import { invokeRelationalInsert } from '../../../../src/data/relational/tools/re
 import { invokeRelationalUpdate } from '../../../../src/data/relational/tools/relational-update/index.js';
 import { invokeRelationalDelete } from '../../../../src/data/relational/tools/relational-delete/index.js';
 
+function createTransactionContext(
+  vendor: TransactionContext['vendor'],
+  executionResult: unknown
+): TransactionContext {
+  const transaction: TransactionContext = {
+    id: 'test-transaction',
+    vendor,
+    execute: vi.fn().mockResolvedValue(executionResult),
+    isActive: vi.fn().mockReturnValue(true),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    createSavepoint: vi.fn().mockResolvedValue('test-savepoint'),
+    rollbackToSavepoint: vi.fn().mockResolvedValue(undefined),
+    releaseSavepoint: vi.fn().mockResolvedValue(undefined),
+    withSavepoint: async (operation) => operation(transaction),
+  };
+
+  return transaction;
+}
+
 describe('owned-session relational mutation execution', () => {
   it('reuses one SQLite session across batch insert, update, and delete operations', async () => {
     const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
@@ -68,10 +88,10 @@ describe('owned-session relational mutation execution', () => {
   });
 
   it('keeps transaction context outside the operation input while using its session', async () => {
-    const transactionExecute = vi.fn().mockResolvedValue([{ affectedRows: 1, insertId: 73 }]);
-    const transaction = {
-      execute: transactionExecute,
-    } as unknown as TransactionContext;
+    const transaction = createTransactionContext(
+      'mysql',
+      [{ affectedRows: 1, insertId: 73 }]
+    );
 
     const result = await invokeRelationalInsert(
       {
@@ -117,9 +137,7 @@ describe('owned-session relational mutation execution', () => {
   });
 
   it('returns normalized delete results from a caller-owned transaction session', async () => {
-    const transaction = {
-      execute: vi.fn().mockResolvedValue({ rowCount: 3 }),
-    } as unknown as TransactionContext;
+    const transaction = createTransactionContext('postgresql', { rowCount: 3 });
 
     const result = await invokeRelationalDelete(
       {

--- a/packages/tools/tests/data/relational/tools/mutation-owned-session.test.ts
+++ b/packages/tools/tests/data/relational/tools/mutation-owned-session.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import type { TransactionContext } from '../../../../src/data/relational/query/transaction.js';
+import { invokeRelationalInsert } from '../../../../src/data/relational/tools/relational-insert/index.js';
+import { invokeRelationalUpdate } from '../../../../src/data/relational/tools/relational-update/index.js';
+import { invokeRelationalDelete } from '../../../../src/data/relational/tools/relational-delete/index.js';
+
+describe('owned-session relational mutation execution', () => {
+  it('reuses one SQLite session across batch insert, update, and delete operations', async () => {
+    const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
+    await session.connect();
+
+    try {
+      await session.execute(sql.raw(`
+        CREATE TABLE users (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          status TEXT NOT NULL
+        )
+      `));
+
+      const execution = { executor: session, vendor: 'sqlite' } as const;
+      const insert = await invokeRelationalInsert(execution, {
+        table: 'users',
+        data: [
+          { name: 'Alice', status: 'pending' },
+          { name: 'Bob', status: 'pending' },
+        ],
+      });
+      const update = await invokeRelationalUpdate(execution, {
+        table: 'users',
+        data: { status: 'active' },
+        where: [{ column: 'status', operator: 'eq', value: 'pending' }],
+      });
+      const deletion = await invokeRelationalDelete(execution, {
+        table: 'users',
+        where: [{ column: 'status', operator: 'eq', value: 'active' }],
+      });
+
+      expect([insert.rowCount, update.rowCount, deletion.rowCount]).toEqual([2, 2, 2]);
+    } finally {
+      await session.disconnect();
+    }
+  });
+
+  it('returns the observable insert result from an already-owned session', async () => {
+    const execute = vi.fn().mockResolvedValue([{ affectedRows: 1, insertId: 42 }]);
+
+    const result = await invokeRelationalInsert(
+      {
+        executor: { execute },
+        vendor: 'mysql',
+      },
+      {
+        table: 'users',
+        data: { name: 'Alice' },
+        returning: { mode: 'id' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      rowCount: 1,
+      insertedIds: [42],
+      rows: [],
+    });
+  });
+
+  it('keeps transaction context outside the operation input while using its session', async () => {
+    const transactionExecute = vi.fn().mockResolvedValue([{ affectedRows: 1, insertId: 73 }]);
+    const transaction = {
+      execute: transactionExecute,
+    } as unknown as TransactionContext;
+
+    const result = await invokeRelationalInsert(
+      {
+        executor: {
+          execute: vi.fn().mockRejectedValue(new Error('the owned pool must not execute')),
+        },
+        vendor: 'mysql',
+        transaction,
+      },
+      {
+        table: 'users',
+        data: { name: 'Transaction Alice' },
+        returning: { mode: 'id' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      rowCount: 1,
+      insertedIds: [73],
+    });
+  });
+
+  it('returns normalized update results from an already-owned session', async () => {
+    const result = await invokeRelationalUpdate(
+      {
+        executor: {
+          execute: vi.fn().mockResolvedValue({ changes: 2 }),
+        },
+        vendor: 'sqlite',
+      },
+      {
+        table: 'users',
+        data: { status: 'active' },
+        where: [{ column: 'status', operator: 'eq', value: 'pending' }],
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      rowCount: 2,
+    });
+  });
+
+  it('returns normalized delete results from a caller-owned transaction session', async () => {
+    const transaction = {
+      execute: vi.fn().mockResolvedValue({ rowCount: 3 }),
+    } as unknown as TransactionContext;
+
+    const result = await invokeRelationalDelete(
+      {
+        executor: {
+          execute: vi.fn().mockRejectedValue(new Error('the owned pool must not execute')),
+        },
+        vendor: 'postgresql',
+        transaction,
+      },
+      {
+        table: 'sessions',
+        where: [{ column: 'expired', operator: 'eq', value: true }],
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      rowCount: 3,
+      softDeleted: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add credential-free owned-session invocation seams for relational insert, update, and delete
- generalize mutation executors from `ConnectionManager` to the existing `SqlExecutor` interface
- preserve legacy credential-bearing tools, schemas, lifecycle, safe errors, and normalized results
- verify shared SQLite session reuse and hidden transaction-context routing

## Validation

- `pnpm --filter @agentforge/tools typecheck`
- `pnpm --filter @agentforge/tools lint`
- focused relational mutation tests (211 passed)
- `pnpm test` (2,654 passed, 110 skipped)
- two-axis standards/spec review

Closes #220