### PR TITLE
Prepare read-oriented Relational Tools for owned sessions

### DIFF
--- a/packages/tools/src/data/relational/query/query-executor.ts
+++ b/packages/tools/src/data/relational/query/query-executor.ts
@@ -5,9 +5,8 @@
 
 import { sql, type SQL } from 'drizzle-orm';
 import { createLogger } from '@agentforge/core';
-import type { ConnectionManager } from '../connection/connection-manager.js';
 import type { TransactionContext } from './transaction.js';
-import type { QueryInput, QueryExecutionResult, QueryParams } from './types.js';
+import type { QueryInput, QueryExecutionResult, QueryParams, SqlExecutor } from './types.js';
 import {
   validateSqlString,
   enforceParameterizedQueryUsage,
@@ -163,7 +162,7 @@ function buildParameterizedQuery(sqlString: string, params?: QueryParams): SQL {
  * @throws {Error} If database is not initialized or query execution fails
  */
 export async function executeQuery(
-  manager: ConnectionManager,
+  executor: SqlExecutor,
   input: QueryInput,
   context?: QueryExecutionContext
 ): Promise<QueryExecutionResult> {
@@ -186,8 +185,8 @@ export async function executeQuery(
     const parameterizedQuery = buildParameterizedQuery(input.sql, input.params);
 
     // Execute query through ConnectionManager's public execute method
-    const executor = context?.transaction ?? manager;
-    const result = await executor.execute(parameterizedQuery);
+    const session = context?.transaction ?? executor;
+    const result = await session.execute(parameterizedQuery);
 
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/schema/index.ts
+++ b/packages/tools/src/data/relational/schema/index.ts
@@ -11,9 +11,11 @@ export type {
   DatabaseSchema,
   SchemaInspectOptions,
   SchemaInspectorConfig,
+  SchemaCacheEntry,
+  SchemaCache as SchemaCacheInterface,
 } from './types.js';
 
-export { SchemaInspector } from './schema-inspector.js';
+export { SchemaCache, SchemaInspector } from './schema-inspector.js';
 
 // Schema validation (ST-03002)
 export type { ValidationResult } from './schema-validator.js';

--- a/packages/tools/src/data/relational/schema/schema-inspector.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector.ts
@@ -96,7 +96,7 @@ export class SchemaInspector {
     const tableFilters = validateTableFilters(options?.tables);
     const bypassCache = options?.bypassCache ?? false;
 
-    if (!bypassCache && this.cacheKey) {
+    if (!bypassCache && this.cacheKey && this.cacheTtlMs > 0) {
       const cached = this.cache.get(this.cacheKey);
       if (cached && cached.expiresAt > Date.now()) {
         logger.debug('Schema cache hit', { vendor: this.vendor });

--- a/packages/tools/src/data/relational/schema/schema-inspector.ts
+++ b/packages/tools/src/data/relational/schema/schema-inspector.ts
@@ -4,8 +4,8 @@
  */
 
 import { createLogger } from '@agentforge/core';
-import type { ConnectionManager } from '../connection/connection-manager.js';
 import { executeQuery } from '../query/query-executor.js';
+import type { SqlExecutor } from '../query/types.js';
 import type { DatabaseVendor } from '../types.js';
 import { inspectMySQL } from './schema-inspector-mysql.js';
 import { inspectPostgreSQL } from './schema-inspector-postgresql.js';
@@ -18,6 +18,8 @@ import {
 import { inspectSQLite } from './schema-inspector-sqlite.js';
 import type {
   DatabaseSchema,
+  SchemaCache as SchemaCacheInterface,
+  SchemaCacheEntry,
   SchemaInspectOptions,
   SchemaInspectorConfig,
   TableSchema,
@@ -26,12 +28,28 @@ import type {
 const logger = createLogger('agentforge:tools:data:relational:schema-inspector');
 const DEFAULT_CACHE_TTL_MS = 60_000;
 
-interface CacheEntry {
-  expiresAt: number;
-  schema: DatabaseSchema;
+/** Cache state whose lifetime can be owned by a Relational Tool Set. */
+export class SchemaCache implements SchemaCacheInterface {
+  private readonly entries = new Map<string, SchemaCacheEntry>();
+
+  get(cacheKey: string): SchemaCacheEntry | undefined {
+    return this.entries.get(cacheKey);
+  }
+
+  set(cacheKey: string, entry: SchemaCacheEntry): void {
+    this.entries.set(cacheKey, entry);
+  }
+
+  delete(cacheKey: string): void {
+    this.entries.delete(cacheKey);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
 }
 
-const schemaCache = new Map<string, CacheEntry>();
+const schemaCache = new SchemaCache();
 
 /**
  * Inspects database schemas across PostgreSQL, MySQL, and SQLite.
@@ -45,13 +63,16 @@ export class SchemaInspector {
   private readonly cacheKey?: string;
 
   constructor(
-    private readonly manager: ConnectionManager,
+    private readonly executor: SqlExecutor,
     private readonly vendor: DatabaseVendor,
     config?: SchemaInspectorConfig,
   ) {
     this.cacheTtlMs = config?.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
     this.cacheKey = config?.cacheKey;
+    this.cache = config?.cache ?? schemaCache;
   }
+
+  private readonly cache: SchemaCacheInterface;
 
   static clearCache(cacheKey?: string): void {
     if (cacheKey) {
@@ -63,7 +84,12 @@ export class SchemaInspector {
   }
 
   invalidateCache(): void {
-    SchemaInspector.clearCache(this.cacheKey);
+    if (this.cacheKey) {
+      this.cache.delete(this.cacheKey);
+      return;
+    }
+
+    this.cache.clear();
   }
 
   async inspect(options?: SchemaInspectOptions): Promise<DatabaseSchema> {
@@ -71,7 +97,7 @@ export class SchemaInspector {
     const bypassCache = options?.bypassCache ?? false;
 
     if (!bypassCache && this.cacheKey) {
-      const cached = schemaCache.get(this.cacheKey);
+      const cached = this.cache.get(this.cacheKey);
       if (cached && cached.expiresAt > Date.now()) {
         logger.debug('Schema cache hit', { vendor: this.vendor });
         return filterSchemaTables(cloneSchema(cached.schema), tableFilters);
@@ -80,8 +106,8 @@ export class SchemaInspector {
 
     const schema = await this.inspectFromDatabase();
 
-    if (this.cacheKey && this.cacheTtlMs > 0) {
-      schemaCache.set(this.cacheKey, {
+    if (!bypassCache && this.cacheKey && this.cacheTtlMs > 0) {
+      this.cache.set(this.cacheKey, {
         schema: cloneSchema(schema),
         expiresAt: Date.now() + this.cacheTtlMs,
       });
@@ -118,7 +144,7 @@ export class SchemaInspector {
   }
 
   private async runQueryRows(query: string): Promise<QueryRow[]> {
-    const result = await executeQuery(this.manager, {
+    const result = await executeQuery(this.executor, {
       sql: query,
       vendor: this.vendor,
     });

--- a/packages/tools/src/data/relational/schema/types.ts
+++ b/packages/tools/src/data/relational/schema/types.ts
@@ -71,4 +71,19 @@ export interface SchemaInspectOptions {
 export interface SchemaInspectorConfig {
   cacheTtlMs?: number;
   cacheKey?: string;
+  cache?: SchemaCache;
+}
+
+/** Cache entry retained by a schema-cache owner. */
+export interface SchemaCacheEntry {
+  expiresAt: number;
+  schema: DatabaseSchema;
+}
+
+/** Minimal cache state accepted by schema inspection. */
+export interface SchemaCache {
+  get(cacheKey: string): SchemaCacheEntry | undefined;
+  set(cacheKey: string, entry: SchemaCacheEntry): void;
+  delete(cacheKey: string): void;
+  clear(): void;
 }

--- a/packages/tools/src/data/relational/tools/read-execution.ts
+++ b/packages/tools/src/data/relational/tools/read-execution.ts
@@ -1,0 +1,13 @@
+import type { TransactionContext } from '../query/transaction.js';
+import type { SqlExecutor } from '../query/types.js';
+import type { SchemaCache } from '../schema/types.js';
+import type { DatabaseVendor } from '../types.js';
+
+/** Runtime dependencies supplied by a session-owning Relational Tool Set. */
+export interface RelationalReadExecution {
+  executor: SqlExecutor;
+  vendor: DatabaseVendor;
+  transaction?: TransactionContext;
+  schemaCache?: SchemaCache;
+  schemaCacheKey?: string;
+}

--- a/packages/tools/src/data/relational/tools/relational-get-schema.ts
+++ b/packages/tools/src/data/relational/tools/relational-get-schema.ts
@@ -8,9 +8,11 @@ import { createLogger, toolBuilder, ToolCategory } from '@agentforge/core';
 import { createHash } from 'node:crypto';
 import { ConnectionManager } from '../connection/connection-manager.js';
 import { SchemaInspector } from '../schema/schema-inspector.js';
+import type { DatabaseSchema } from '../schema/types.js';
 import { VALID_TABLE_FILTER_PATTERN } from '../schema/validation.js';
 import type { DatabaseVendor } from '../types.js';
 import { isSafeGetSchemaValidationError } from './relational-get-schema-error-utils.js';
+import type { RelationalReadExecution } from './read-execution.js';
 const logger = createLogger('agentforge:tools:data:relational:get-schema');
 
 function buildSchemaCacheKey(vendor: DatabaseVendor, connectionString: string, database?: string): string {
@@ -24,7 +26,7 @@ function buildSchemaCacheKey(vendor: DatabaseVendor, connectionString: string, d
 /**
  * Zod schema for relational-get-schema input.
  */
-const relationalGetSchemaInputSchema = z.object({
+export const relationalGetSchemaInputSchema = z.object({
   vendor: z.enum(['postgresql', 'mysql', 'sqlite']).describe('Database vendor'),
   connectionString: z
     .string()
@@ -58,6 +60,92 @@ const relationalGetSchemaInputSchema = z.object({
     .describe('Force cache invalidation before introspecting schema'),
 });
 
+export type RelationalGetSchemaInput = z.input<typeof relationalGetSchemaInputSchema>;
+export type RelationalGetSchemaOperationInput = Omit<
+  RelationalGetSchemaInput,
+  'vendor' | 'connectionString'
+>;
+
+interface SchemaSummary {
+  tableCount: number;
+  columnCount: number;
+  foreignKeyCount: number;
+  indexCount: number;
+}
+
+export type GetSchemaResponse =
+  | { success: true; schema: DatabaseSchema; summary: SchemaSummary }
+  | { success: false; error: string; schema: null };
+
+function toGetSchemaErrorResponse(
+  execution: RelationalReadExecution,
+  input: RelationalGetSchemaOperationInput,
+  error: unknown,
+): GetSchemaResponse {
+  logger.error('Schema introspection failed', {
+    vendor: execution.vendor,
+    hasTablesFilter: Array.isArray(input.tables),
+    tablesFilterCount: input.tables?.length ?? 0,
+    refreshCache: input.refreshCache ?? false,
+    error: error instanceof Error ? error.message : String(error),
+  });
+
+  const errorMessage = isSafeGetSchemaValidationError(error)
+    ? error.message
+    : 'Failed to inspect schema. See logs for details.';
+
+  return {
+    success: false,
+    error: errorMessage,
+    schema: null,
+  };
+}
+
+/** Inspect schema through a session and optional cache owned by the caller. */
+export async function invokeRelationalGetSchema(
+  execution: RelationalReadExecution,
+  input: RelationalGetSchemaOperationInput,
+): Promise<GetSchemaResponse> {
+  const cacheKey = execution.schemaCacheKey
+    ?? (execution.schemaCache ? input.database ?? 'default' : undefined);
+  const inspector = new SchemaInspector(
+    execution.transaction ?? execution.executor,
+    execution.vendor,
+    {
+      cacheTtlMs: input.cacheTtlMs,
+      cacheKey,
+      cache: execution.schemaCache,
+    },
+  );
+
+  try {
+    if (input.refreshCache) {
+      inspector.invalidateCache();
+    }
+
+    const schema = await inspector.inspect(
+      execution.transaction
+        ? { tables: input.tables, bypassCache: true }
+        : { tables: input.tables },
+    );
+
+    const summary = schema.tables.reduce<SchemaSummary>(
+      (accumulator, table) => {
+        accumulator.tableCount += 1;
+        accumulator.columnCount += table.columns.length;
+        accumulator.foreignKeyCount += table.foreignKeys.length;
+        accumulator.indexCount += table.indexes.length;
+        return accumulator;
+      },
+      { tableCount: 0, columnCount: 0, foreignKeyCount: 0, indexCount: 0 },
+    );
+
+    return { success: true, schema, summary };
+  } catch (error) {
+    return toGetSchemaErrorResponse(execution, input, error);
+  }
+}
+
 /**
  * Relational Get Schema Tool
  *
@@ -89,66 +177,26 @@ export const relationalGetSchema = toolBuilder()
     },
   })
   .implement(async (input) => {
+    const { connectionString, vendor, ...operation } = input;
     const manager = new ConnectionManager({
-      vendor: input.vendor,
-      connection: input.connectionString,
+      vendor,
+      connection: connectionString,
     });
 
     const cacheKey = buildSchemaCacheKey(
-      input.vendor,
-      input.connectionString,
+      vendor,
+      connectionString,
       input.database,
     );
-    const inspector = new SchemaInspector(manager, input.vendor, {
-      cacheTtlMs: input.cacheTtlMs,
-      cacheKey,
-    });
 
     try {
       await manager.connect();
-
-      if (input.refreshCache) {
-        inspector.invalidateCache();
-      }
-
-      const schema = await inspector.inspect({
-        tables: input.tables,
-      });
-
-      const summary = schema.tables.reduce(
-        (accumulator, table) => {
-          accumulator.tableCount += 1;
-          accumulator.columnCount += table.columns.length;
-          accumulator.foreignKeyCount += table.foreignKeys.length;
-          accumulator.indexCount += table.indexes.length;
-          return accumulator;
-        },
-        { tableCount: 0, columnCount: 0, foreignKeyCount: 0, indexCount: 0 },
+      return await invokeRelationalGetSchema(
+        { executor: manager, vendor, schemaCacheKey: cacheKey },
+        operation,
       );
-
-      return {
-        success: true,
-        schema,
-        summary,
-      };
     } catch (error) {
-      logger.error('Schema introspection failed', {
-        vendor: input.vendor,
-        hasTablesFilter: Array.isArray(input.tables),
-        tablesFilterCount: input.tables?.length ?? 0,
-        refreshCache: input.refreshCache ?? false,
-        error: error instanceof Error ? error.message : String(error),
-      });
-
-      const errorMessage = isSafeGetSchemaValidationError(error)
-        ? error.message
-        : 'Failed to inspect schema. See logs for details.';
-
-      return {
-        success: false,
-        error: errorMessage,
-        schema: null,
-      };
+      return toGetSchemaErrorResponse({ executor: manager, vendor }, operation, error);
     } finally {
       await manager.disconnect();
     }

--- a/packages/tools/src/data/relational/tools/relational-get-schema.ts
+++ b/packages/tools/src/data/relational/tools/relational-get-schema.ts
@@ -119,7 +119,7 @@ export async function invokeRelationalGetSchema(
   );
 
   try {
-    if (input.refreshCache) {
+    if (input.refreshCache && cacheKey) {
       inspector.invalidateCache();
     }
 

--- a/packages/tools/src/data/relational/tools/relational-query.ts
+++ b/packages/tools/src/data/relational/tools/relational-query.ts
@@ -4,15 +4,18 @@
  */
 
 import { z } from 'zod';
-import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { createLogger, toolBuilder, ToolCategory } from '@agentforge/core';
 import { ConnectionManager } from '../connection/connection-manager.js';
 import { executeQuery } from '../query/query-executor.js';
 import type { DatabaseVendor } from '../types.js';
+import type { RelationalReadExecution } from './read-execution.js';
+
+const logger = createLogger('agentforge:tools:data:relational:query');
 
 /**
  * Zod schema for relational-query tool input
  */
-const relationalQuerySchema = z.object({
+export const relationalQuerySchema = z.object({
   sql: z.string().describe('SQL query string to execute'),
   params: z.union([
     z.array(z.unknown()).describe('Positional parameters (e.g., [value1, value2])'),
@@ -24,6 +27,61 @@ const relationalQuerySchema = z.object({
     .min(1, 'Database connection string is required')
     .describe('Database connection string used to create a new connection'),
 });
+
+export type RelationalQueryInput = z.input<typeof relationalQuerySchema>;
+export type RelationalQueryOperationInput = Omit<
+  RelationalQueryInput,
+  'vendor' | 'connectionString'
+>;
+
+export type QueryResponse =
+  | {
+      success: true;
+      rows: unknown[];
+      rowCount: number;
+      executionTime: number;
+    }
+  | {
+      success: false;
+      error: string;
+      rows: [];
+      rowCount: 0;
+    };
+
+function toQueryErrorResponse(error: unknown): QueryResponse {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : 'Unknown error occurred',
+    rows: [],
+    rowCount: 0,
+  };
+}
+
+/** Execute a raw query through a session owned by the caller. */
+export async function invokeRelationalQuery(
+  execution: RelationalReadExecution,
+  input: RelationalQueryOperationInput,
+): Promise<QueryResponse> {
+  try {
+    const queryInput = {
+      sql: input.sql,
+      params: input.params,
+      vendor: execution.vendor,
+    };
+    const result = execution.transaction
+      ? await executeQuery(execution.executor, queryInput, { transaction: execution.transaction })
+      : await executeQuery(execution.executor, queryInput);
+
+    return {
+      success: true,
+      rows: result.rows,
+      rowCount: result.rowCount,
+      executionTime: result.executionTime,
+    };
+  } catch (error) {
+    return toQueryErrorResponse(error);
+  }
+}
 
 /**
  * Relational Query Tool
@@ -114,32 +172,22 @@ export const relationalQuery = toolBuilder()
       // Initialize connection
       await manager.initialize();
 
-      // Execute query
-      const result = await executeQuery(manager, {
-        sql: input.sql,
-        params: input.params,
-        vendor: input.vendor
-      });
-
-      // Return formatted result
-      return {
-        success: true,
-        rows: result.rows,
-        rowCount: result.rowCount,
-        executionTime: result.executionTime
-      };
+      return await invokeRelationalQuery(
+        { executor: manager, vendor: input.vendor },
+        {
+          sql: input.sql,
+          params: input.params,
+        },
+      );
     } catch (error) {
-      // Return error with sanitized message
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Unknown error occurred',
-        rows: [],
-        rowCount: 0
-      };
+      logger.error('Relational Query connection initialization failed', {
+        vendor: input.vendor,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return toQueryErrorResponse(error);
     } finally {
       // Always close connection
       await manager.close();
     }
   })
   .build();
-

--- a/packages/tools/src/data/relational/tools/relational-select/executor.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/executor.ts
@@ -4,7 +4,7 @@
  */
 
 import { createLogger } from '@agentforge/core';
-import type { ConnectionManager } from '../../connection/connection-manager.js';
+import type { SqlExecutor } from '../../query/types.js';
 import type { TransactionContext } from '../../query/transaction.js';
 import {
   DEFAULT_CHUNK_SIZE,
@@ -12,7 +12,7 @@ import {
   benchmarkStreamingSelectMemory,
   type SelectQueryInput,
 } from '../../query/index.js';
-import type { RelationalSelectInput, SelectResult } from './types.js';
+import type { RelationalSelectExecutionInput, SelectResult } from './types.js';
 import { buildSelectQuery } from './query-builder.js';
 import { isSafeValidationError } from './error-utils.js';
 
@@ -27,7 +27,7 @@ export interface SelectExecutionContext {
   transaction?: TransactionContext;
 }
 
-function toSelectQueryInput(input: RelationalSelectInput): SelectQueryInput {
+function toSelectQueryInput(input: RelationalSelectExecutionInput): SelectQueryInput {
   return {
     table: input.table,
     columns: input.columns,
@@ -43,8 +43,8 @@ function toSelectQueryInput(input: RelationalSelectInput): SelectQueryInput {
  * Execute a SELECT query using Drizzle query builder
  */
 export async function executeSelect(
-  manager: ConnectionManager,
-  input: RelationalSelectInput,
+  executor: SqlExecutor,
+  input: RelationalSelectExecutionInput,
   context?: SelectExecutionContext
 ): Promise<SelectResult> {
   const startTime = Date.now();
@@ -59,7 +59,7 @@ export async function executeSelect(
   });
 
   try {
-    const executor = context?.transaction ?? manager;
+    const session = context?.transaction ?? executor;
 
     if (input.streaming?.enabled) {
       const streamOptions = {
@@ -80,10 +80,10 @@ export async function executeSelect(
         });
       }
 
-      const streamResult = await executeStreamingSelect(executor, streamInput, streamOptions);
+      const streamResult = await executeStreamingSelect(session, streamInput, streamOptions);
 
       const benchmark = input.streaming.benchmark
-        ? await benchmarkStreamingSelectMemory(executor, streamInput, streamOptions)
+        ? await benchmarkStreamingSelectMemory(session, streamInput, streamOptions)
         : undefined;
 
       const executionTime = Date.now() - startTime;
@@ -118,7 +118,7 @@ export async function executeSelect(
     const query = buildSelectQuery(input);
 
     // Execute query
-    const result = await executor.execute(query);
+    const result = await session.execute(query);
 
     const executionTime = Date.now() - startTime;
 

--- a/packages/tools/src/data/relational/tools/relational-select/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/index.ts
@@ -7,16 +7,61 @@
  * @module tools/relational-select
  */
 
-import { toolBuilder, ToolCategory } from '@agentforge/core';
+import { createLogger, toolBuilder, ToolCategory } from '@agentforge/core';
 import { ConnectionManager } from '../../connection/connection-manager.js';
 import { relationalSelectSchema } from './schemas.js';
 import { executeSelect } from './executor.js';
-import type { RelationalSelectInput, SelectResponse } from './types.js';
+import type {
+  RelationalSelectInput,
+  RelationalSelectOperationInput,
+  SelectErrorResponse,
+  SelectResponse,
+} from './types.js';
 import { isSafeValidationError } from './error-utils.js';
+import type { RelationalReadExecution } from '../read-execution.js';
+
+const logger = createLogger('agentforge:tools:data:relational:select');
 
 // Re-export types and schemas for external use
 export * from './types.js';
 export * from './schemas.js';
+
+function toSelectErrorResponse(error: unknown): SelectErrorResponse {
+  const errorMessage = isSafeValidationError(error)
+    ? error.message
+    : 'Failed to execute SELECT query. Please verify your input and database connection.';
+
+  return {
+    success: false,
+    error: errorMessage,
+    rows: [],
+    rowCount: 0,
+  };
+}
+
+/** Execute SELECT through a session owned by the caller. */
+export async function invokeRelationalSelect(
+  execution: RelationalReadExecution,
+  input: RelationalSelectOperationInput,
+): Promise<SelectResponse> {
+  try {
+    const result = await executeSelect(
+      execution.executor,
+      { ...input, vendor: execution.vendor },
+      execution.transaction ? { transaction: execution.transaction } : undefined,
+    );
+
+    return {
+      success: true,
+      rows: result.rows,
+      rowCount: result.rowCount,
+      executionTime: result.executionTime,
+      streaming: result.streaming,
+    };
+  } catch (error) {
+    return toSelectErrorResponse(error);
+  }
+}
 
 /**
  * Relational SELECT Tool
@@ -92,40 +137,23 @@ export const relationalSelect = toolBuilder()
     }
   })
   .implement(async (input: RelationalSelectInput): Promise<SelectResponse> => {
+    const { connectionString, vendor, ...operation } = input;
     const manager = new ConnectionManager({
-      vendor: input.vendor,
-      connection: input.connectionString
+      vendor,
+      connection: connectionString,
     });
 
     try {
       // Connect to database
       await manager.connect();
 
-      // Build and execute SELECT query
-      const result = await executeSelect(manager, input);
-
-      // Return formatted result
-      return {
-        success: true,
-        rows: result.rows,
-        rowCount: result.rowCount,
-        executionTime: result.executionTime,
-        streaming: result.streaming,
-      };
+      return await invokeRelationalSelect({ executor: manager, vendor }, operation);
     } catch (error) {
-      let errorMessage = 'Failed to execute SELECT query. Please verify your input and database connection.';
-
-      // Propagate known-safe validation messages so callers can correct input.
-      if (isSafeValidationError(error)) {
-        errorMessage = error.message;
-      }
-
-      return {
-        success: false,
-        error: errorMessage,
-        rows: [],
-        rowCount: 0
-      };
+      logger.error('Relational SELECT connection initialization failed', {
+        vendor,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return toSelectErrorResponse(error);
     } finally {
       // Always disconnect
       await manager.disconnect();

--- a/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/query-builder.ts
@@ -7,12 +7,12 @@ import {
   buildSelectQuery as buildSharedSelectQuery,
   type SelectQueryInput,
 } from '../../query/query-builder.js';
-import type { RelationalSelectInput } from './types.js';
+import type { RelationalSelectExecutionInput } from './types.js';
 
 /**
  * Build a complete SELECT query using shared query builder utilities.
  */
-export function buildSelectQuery(input: RelationalSelectInput) {
+export function buildSelectQuery(input: RelationalSelectExecutionInput) {
   const queryInput: SelectQueryInput = {
     table: input.table,
     columns: input.columns,

--- a/packages/tools/src/data/relational/tools/relational-select/types.ts
+++ b/packages/tools/src/data/relational/tools/relational-select/types.ts
@@ -69,6 +69,12 @@ export interface StreamingMetadata {
  */
 export type RelationalSelectInput = z.input<typeof relationalSelectSchema>;
 
+/** SELECT input after database credentials have been bound by a session owner. */
+export type RelationalSelectExecutionInput = Omit<RelationalSelectInput, 'connectionString'>;
+
+/** Agent-facing SELECT operation input for a configured database session. */
+export type RelationalSelectOperationInput = Omit<RelationalSelectExecutionInput, 'vendor'>;
+
 /**
  * SELECT query execution result
  */

--- a/packages/tools/tests/data/relational/schema-inspector-cache.test.ts
+++ b/packages/tools/tests/data/relational/schema-inspector-cache.test.ts
@@ -38,4 +38,34 @@ describe('SchemaInspector cache behavior', () => {
     await inspector.inspect();
     expect(executeMock).toHaveBeenCalledTimes(10);
   });
+
+  it('should bypass existing cache entries when caching is disabled', async () => {
+    const queue = [
+      { rows: [{ schema_name: 'public', table_name: 'users' }] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [{ schema_name: 'public', table_name: 'posts' }] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+      { rows: [] },
+    ];
+    const { manager, executeMock } = createMockManager(queue);
+    const cachedInspector = new SchemaInspector(manager, 'postgresql', {
+      cacheKey: 'pg:disabled-cache-test',
+      cacheTtlMs: 60_000,
+    });
+    const uncachedInspector = new SchemaInspector(manager, 'postgresql', {
+      cacheKey: 'pg:disabled-cache-test',
+      cacheTtlMs: 0,
+    });
+
+    await cachedInspector.inspect();
+    const freshSchema = await uncachedInspector.inspect();
+
+    expect(executeMock).toHaveBeenCalledTimes(10);
+    expect(freshSchema.tables.map((table) => table.name)).toEqual(['posts']);
+  });
 });

--- a/packages/tools/tests/data/relational/tools/read-owned-session.test.ts
+++ b/packages/tools/tests/data/relational/tools/read-owned-session.test.ts
@@ -1,12 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { sql } from 'drizzle-orm';
 import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
-import { SchemaCache } from '../../../../src/data/relational/schema/schema-inspector.js';
+import {
+  SchemaCache,
+  SchemaInspector,
+} from '../../../../src/data/relational/schema/schema-inspector.js';
 import { invokeRelationalGetSchema } from '../../../../src/data/relational/tools/relational-get-schema.js';
 import { invokeRelationalQuery } from '../../../../src/data/relational/tools/relational-query.js';
 import { invokeRelationalSelect } from '../../../../src/data/relational/tools/relational-select/index.js';
 
 describe('owned-session relational read execution', () => {
+  afterEach(() => {
+    SchemaInspector.clearCache();
+  });
+
   it('reuses one SQLite session across query, select, and schema operations', async () => {
     const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
     await session.connect();
@@ -73,6 +80,31 @@ describe('owned-session relational read execution', () => {
       await session.execute(sql.raw('CREATE TABLE comments (id INTEGER PRIMARY KEY)'));
       const afterOwnerClear = await invokeRelationalGetSchema(execution, {});
       expect(afterOwnerClear.success && afterOwnerClear.summary.tableCount).toBe(3);
+    } finally {
+      await session.disconnect();
+    }
+  });
+
+  it('does not clear unrelated global cache state when refreshing without an owned cache', async () => {
+    const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
+    await session.connect();
+
+    try {
+      await session.execute(sql.raw('CREATE TABLE users (id INTEGER PRIMARY KEY)'));
+      const legacyInspector = new SchemaInspector(session, 'sqlite', {
+        cacheKey: 'unrelated-legacy-session',
+      });
+      const initialLegacySchema = await legacyInspector.inspect();
+
+      await session.execute(sql.raw('CREATE TABLE posts (id INTEGER PRIMARY KEY)'));
+      await invokeRelationalGetSchema(
+        { executor: session, vendor: 'sqlite' },
+        { refreshCache: true },
+      );
+      const cachedLegacySchema = await legacyInspector.inspect();
+
+      expect(initialLegacySchema.tables).toHaveLength(1);
+      expect(cachedLegacySchema.tables).toHaveLength(1);
     } finally {
       await session.disconnect();
     }

--- a/packages/tools/tests/data/relational/tools/read-owned-session.test.ts
+++ b/packages/tools/tests/data/relational/tools/read-owned-session.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { ConnectionManager } from '../../../../src/data/relational/connection/connection-manager.js';
+import { SchemaCache } from '../../../../src/data/relational/schema/schema-inspector.js';
+import { invokeRelationalGetSchema } from '../../../../src/data/relational/tools/relational-get-schema.js';
+import { invokeRelationalQuery } from '../../../../src/data/relational/tools/relational-query.js';
+import { invokeRelationalSelect } from '../../../../src/data/relational/tools/relational-select/index.js';
+
+describe('owned-session relational read execution', () => {
+  it('reuses one SQLite session across query, select, and schema operations', async () => {
+    const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
+    await session.connect();
+
+    try {
+      await session.execute(sql.raw(`
+        CREATE TABLE users (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL
+        )
+      `));
+      await session.execute(sql.raw("INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')"));
+
+      const execution = { executor: session, vendor: 'sqlite' } as const;
+      const query = await invokeRelationalQuery(execution, {
+        sql: 'SELECT COUNT(*) AS count FROM users',
+      });
+      const select = await invokeRelationalSelect(execution, {
+        table: 'users',
+        columns: ['id', 'name'],
+        orderBy: [{ column: 'id', direction: 'asc' }],
+      });
+      const schema = await invokeRelationalGetSchema(execution, {
+        tables: ['users'],
+      });
+
+      expect(query).toMatchObject({ success: true, rows: [{ count: 2 }], rowCount: 1 });
+      expect(select).toMatchObject({
+        success: true,
+        rows: [
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ],
+        rowCount: 2,
+      });
+      expect(schema).toMatchObject({
+        success: true,
+        summary: { tableCount: 1, columnCount: 2 },
+      });
+    } finally {
+      await session.disconnect();
+    }
+  });
+
+  it('uses and invalidates schema cache state owned by the caller', async () => {
+    const session = new ConnectionManager({ vendor: 'sqlite', connection: ':memory:' });
+    const schemaCache = new SchemaCache();
+    await session.connect();
+
+    try {
+      await session.execute(sql.raw('CREATE TABLE users (id INTEGER PRIMARY KEY)'));
+      const execution = { executor: session, vendor: 'sqlite', schemaCache } as const;
+
+      const initial = await invokeRelationalGetSchema(execution, {});
+      await session.execute(sql.raw('CREATE TABLE posts (id INTEGER PRIMARY KEY)'));
+      const cached = await invokeRelationalGetSchema(execution, {});
+      const refreshed = await invokeRelationalGetSchema(execution, { refreshCache: true });
+
+      expect(initial.success && initial.summary.tableCount).toBe(1);
+      expect(cached.success && cached.summary.tableCount).toBe(1);
+      expect(refreshed.success && refreshed.summary.tableCount).toBe(2);
+
+      schemaCache.clear();
+      await session.execute(sql.raw('CREATE TABLE comments (id INTEGER PRIMARY KEY)'));
+      const afterOwnerClear = await invokeRelationalGetSchema(execution, {});
+      expect(afterOwnerClear.success && afterOwnerClear.summary.tableCount).toBe(3);
+    } finally {
+      await session.disconnect();
+    }
+  });
+
+  it('preserves safe validation and sanitized driver errors for owned sessions', async () => {
+    const validation = await invokeRelationalQuery(
+      { executor: { execute: async () => [] }, vendor: 'sqlite' },
+      { sql: 'DROP TABLE users' },
+    );
+    const driverFailure = await invokeRelationalSelect(
+      {
+        executor: {
+          execute: async () => {
+            throw new Error('secret driver detail');
+          },
+        },
+        vendor: 'sqlite',
+      },
+      { table: 'users' },
+    );
+
+    expect(validation).toMatchObject({ success: false });
+    expect(validation.success || validation.error).toMatch(/dangerous SQL operation/);
+    expect(driverFailure).toEqual({
+      success: false,
+      error: 'Failed to execute SELECT query. Please verify your input and database connection.',
+      rows: [],
+      rowCount: 0,
+    });
+  });
+});


### PR DESCRIPTION
Closes #221

## Summary
- add owned-session execution seams for Query, Select, and Get Schema
- preserve credential-bearing Tool schemas and result behavior through compatibility adapters
- support caller-owned schema cache state with explicit invalidation
- cover session reuse, cache ownership, validation, and sanitization with observable tests

## Validation
- pnpm --filter @agentforge/tools typecheck
- pnpm --filter @agentforge/tools lint
- focused relational read Tool tests (50 passed)
- pnpm test -- --run (2657 passed, 110 skipped)