### PR TITLE
Deliver the configured Relational Tool Set

### DIFF
--- a/packages/tools/src/data/relational/index.ts
+++ b/packages/tools/src/data/relational/index.ts
@@ -1,17 +1,17 @@
 /**
  * Relational database access tools using Drizzle ORM
- * 
+ *
  * Provides vendor-agnostic database operations for PostgreSQL, MySQL, and SQLite.
- * 
+ *
  * ## Peer Dependencies
- * 
+ *
  * This module requires database-specific drivers as peer dependencies.
  * Install only the drivers you need:
- * 
+ *
  * - **PostgreSQL**: `pnpm add pg @types/pg`
  * - **MySQL**: `pnpm add mysql2`
  * - **SQLite**: `pnpm add better-sqlite3 @types/better-sqlite3`
- * 
+ *
  * @module relational
  */
 
@@ -40,6 +40,9 @@ export * from './query/index.js';
 
 // Schema introspection
 export * from './schema/index.js';
+
+// Configured Relational Tool Sets
+export * from './tool-set.js';
 
 // LangGraph tools
 export * from './tools/index.js';

--- a/packages/tools/src/data/relational/tool-set.ts
+++ b/packages/tools/src/data/relational/tool-set.ts
@@ -77,7 +77,11 @@ type SelectTool = Tool<RelationalSelectOperationInput, SelectResponse>;
 type InsertTool = Tool<RelationalInsertOperationInput, InsertResponse>;
 type UpdateTool = Tool<RelationalUpdateOperationInput, UpdateResponse>;
 type DeleteTool = Tool<RelationalDeleteOperationInput, DeleteResponse>;
-type GetSchemaTool = Tool<RelationalGetSchemaOperationInput, GetSchemaResponse>;
+export type RelationalToolSetGetSchemaInput = Omit<
+  RelationalGetSchemaOperationInput,
+  'database' | 'cacheTtlMs'
+>;
+type GetSchemaTool = Tool<RelationalToolSetGetSchemaInput, GetSchemaResponse>;
 type ConfiguredTool = QueryTool | SelectTool | InsertTool | UpdateTool | DeleteTool | GetSchemaTool;
 
 export interface RelationalToolSet extends Iterable<ConfiguredTool> {
@@ -141,11 +145,28 @@ function cloneImmutableValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return Object.freeze(value.map(cloneImmutableValue));
   }
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0);
+  }
+  if (Buffer.isBuffer(value)) {
+    return Buffer.from(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return structuredClone(value);
+  }
   if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
     return Object.freeze(
       Object.fromEntries(
         Object.entries(value).map(([key, nestedValue]) => [key, cloneImmutableValue(nestedValue)])
       )
+    );
+  }
+  if (value && typeof value === 'object') {
+    throw new RelationalToolSetConfigurationError(
+      'Database configuration contains an unsupported mutable object.'
     );
   }
   return value;
@@ -233,7 +254,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
       relationalQuerySchema.omit({ vendor: true, connectionString: true }),
       (input) =>
         execution(
-          (manager) => invokeRelationalQuery({ executor: manager, vendor: config.vendor }, input),
+          (manager) => invokeRelationalQuery(this.executionFor(manager), input),
           () => ({
             success: false,
             error: 'Failed to connect to the configured database.',
@@ -247,7 +268,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
       relationalSelectSchema.omit({ vendor: true, connectionString: true }),
       (input) =>
         execution(
-          (manager) => invokeRelationalSelect({ executor: manager, vendor: config.vendor }, input),
+          (manager) => invokeRelationalSelect(this.executionFor(manager), input),
           () => ({
             success: false,
             error:
@@ -262,7 +283,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
       relationalInsertSchema.omit({ vendor: true, connectionString: true }),
       (input) =>
         execution(
-          (manager) => invokeRelationalInsert({ executor: manager, vendor: config.vendor }, input),
+          (manager) => invokeRelationalInsert(this.executionFor(manager), input),
           () => ({
             success: false,
             error:
@@ -278,7 +299,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
       relationalUpdateOperationSchema,
       (input) =>
         execution(
-          (manager) => invokeRelationalUpdate({ executor: manager, vendor: config.vendor }, input),
+          (manager) => invokeRelationalUpdate(this.executionFor(manager), input),
           () => ({
             success: false,
             error:
@@ -292,7 +313,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
       relationalDeleteOperationSchema,
       (input) =>
         execution(
-          (manager) => invokeRelationalDelete({ executor: manager, vendor: config.vendor }, input),
+          (manager) => invokeRelationalDelete(this.executionFor(manager), input),
           () => ({
             success: false,
             error:
@@ -315,8 +336,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
           (manager) =>
             invokeRelationalGetSchema(
               {
-                executor: manager,
-                vendor: config.vendor,
+                ...this.executionFor(manager),
                 schemaCache: this.schemaCache,
                 schemaCacheKey: TOOL_SET_SCHEMA_CACHE_KEY,
               },
@@ -405,6 +425,10 @@ class RelationalToolSetImplementation implements RelationalToolSet {
         });
     }
     return this.initialization;
+  }
+
+  private executionFor(manager: ConnectionManager) {
+    return { executor: manager, vendor: this.config.vendor };
   }
 
   private async finishDisposal(): Promise<void> {

--- a/packages/tools/src/data/relational/tool-set.ts
+++ b/packages/tools/src/data/relational/tool-set.ts
@@ -1,0 +1,437 @@
+import { createTool, type Tool, type ToolMetadata } from '@agentforge/core';
+import type { z } from 'zod';
+
+import { ConnectionManager } from './connection/connection-manager.js';
+import type { ConnectionConfig } from './connection/types.js';
+import { SchemaCache } from './schema/schema-inspector.js';
+import { invokeRelationalDelete } from './tools/relational-delete/index.js';
+import { relationalDeleteSchema } from './tools/relational-delete/schemas.js';
+import type {
+  DeleteResponse,
+  RelationalDeleteOperationInput,
+} from './tools/relational-delete/types.js';
+import {
+  invokeRelationalGetSchema,
+  relationalGetSchemaInputSchema,
+  type GetSchemaResponse,
+  type RelationalGetSchemaOperationInput,
+} from './tools/relational-get-schema.js';
+import { invokeRelationalInsert } from './tools/relational-insert/index.js';
+import { relationalInsertSchema } from './tools/relational-insert/schemas.js';
+import type {
+  InsertResponse,
+  RelationalInsertOperationInput,
+} from './tools/relational-insert/types.js';
+import {
+  invokeRelationalQuery,
+  relationalQuerySchema,
+  type QueryResponse,
+  type RelationalQueryOperationInput,
+} from './tools/relational-query.js';
+import { invokeRelationalSelect } from './tools/relational-select/index.js';
+import { relationalSelectSchema } from './tools/relational-select/schemas.js';
+import type {
+  RelationalSelectOperationInput,
+  SelectResponse,
+} from './tools/relational-select/types.js';
+import { invokeRelationalUpdate } from './tools/relational-update/index.js';
+import { relationalUpdateSchema } from './tools/relational-update/schemas.js';
+import type {
+  RelationalUpdateOperationInput,
+  UpdateResponse,
+} from './tools/relational-update/types.js';
+import {
+  relationalDelete,
+  relationalGetSchema,
+  relationalInsert,
+  relationalQuery,
+  relationalSelect,
+  relationalUpdate,
+} from './tools/index.js';
+
+const DEFAULT_SCHEMA_CACHE_TTL_MS = 60_000;
+const TOOL_SET_SCHEMA_CACHE_KEY = 'relational-tool-set';
+const PREFIX_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+export interface RelationalToolSetOptions {
+  /** Kebab-case prefix prepended to every configured Tool name. */
+  prefix?: string;
+  /** Lifetime of cached schema results. Use 0 to disable caching. */
+  schemaCacheTtlMs?: number;
+}
+
+export class RelationalToolSetConfigurationError extends Error {
+  override readonly name = 'RelationalToolSetConfigurationError';
+}
+
+export class RelationalToolSetDisposedError extends Error {
+  override readonly name = 'RelationalToolSetDisposedError';
+
+  constructor() {
+    super('The Relational Tool Set is disposing or has been disposed.');
+  }
+}
+
+type QueryTool = Tool<RelationalQueryOperationInput, QueryResponse>;
+type SelectTool = Tool<RelationalSelectOperationInput, SelectResponse>;
+type InsertTool = Tool<RelationalInsertOperationInput, InsertResponse>;
+type UpdateTool = Tool<RelationalUpdateOperationInput, UpdateResponse>;
+type DeleteTool = Tool<RelationalDeleteOperationInput, DeleteResponse>;
+type GetSchemaTool = Tool<RelationalGetSchemaOperationInput, GetSchemaResponse>;
+type ConfiguredTool = QueryTool | SelectTool | InsertTool | UpdateTool | DeleteTool | GetSchemaTool;
+
+export interface RelationalToolSet extends Iterable<ConfiguredTool> {
+  readonly query: QueryTool;
+  readonly select: SelectTool;
+  readonly insert: InsertTool;
+  readonly update: UpdateTool;
+  readonly delete: DeleteTool;
+  readonly getSchema: GetSchemaTool;
+  refreshSchema(): void;
+  dispose(): Promise<void>;
+}
+
+function validateConfiguration(config: ConnectionConfig, options: RelationalToolSetOptions): void {
+  if (!config || !['postgresql', 'mysql', 'sqlite'].includes(config.vendor)) {
+    throw new RelationalToolSetConfigurationError(
+      'Database vendor must be postgresql, mysql, or sqlite.'
+    );
+  }
+  if (
+    (typeof config.connection === 'string' && config.connection.trim().length === 0) ||
+    (typeof config.connection !== 'string' &&
+      (!config.connection || Array.isArray(config.connection)))
+  ) {
+    throw new RelationalToolSetConfigurationError(
+      'Database connection must be a non-empty string or configuration object.'
+    );
+  }
+  if (
+    config.vendor === 'sqlite' &&
+    typeof config.connection !== 'string' &&
+    (typeof config.connection.url !== 'string' || config.connection.url.trim().length === 0)
+  ) {
+    throw new RelationalToolSetConfigurationError(
+      'SQLite object configuration requires a non-empty url.'
+    );
+  }
+  if (options.prefix !== undefined && !PREFIX_PATTERN.test(options.prefix)) {
+    throw new RelationalToolSetConfigurationError(
+      'Tool name prefix must be non-empty kebab-case starting with a letter.'
+    );
+  }
+  if (
+    options.schemaCacheTtlMs !== undefined &&
+    (!Number.isInteger(options.schemaCacheTtlMs) || options.schemaCacheTtlMs < 0)
+  ) {
+    throw new RelationalToolSetConfigurationError(
+      'Schema cache TTL must be a non-negative integer.'
+    );
+  }
+
+  const longestName = configuredName('relational-get-schema', options.prefix);
+  if (longestName.length > 50) {
+    throw new RelationalToolSetConfigurationError(
+      'Tool name prefix is too long; configured Tool names must not exceed 50 characters.'
+    );
+  }
+}
+
+function cloneImmutableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map(cloneImmutableValue));
+  }
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    return Object.freeze(
+      Object.fromEntries(
+        Object.entries(value).map(([key, nestedValue]) => [key, cloneImmutableValue(nestedValue)])
+      )
+    );
+  }
+  return value;
+}
+
+function snapshotConfiguration(config: ConnectionConfig): ConnectionConfig {
+  const connection = cloneImmutableValue(config.connection) as ConnectionConfig['connection'];
+  return Object.freeze({ vendor: config.vendor, connection }) as ConnectionConfig;
+}
+
+function configuredName(name: string, prefix?: string): string {
+  return prefix ? `${prefix}-${name}` : name;
+}
+
+function configuredMetadata(tool: { metadata: ToolMetadata }, prefix?: string): ToolMetadata {
+  return {
+    ...tool.metadata,
+    name: configuredName(tool.metadata.name, prefix),
+    examples: undefined,
+  };
+}
+
+function preserveOperationValidation<T extends Record<string, unknown>>(
+  legacySchema: z.ZodTypeAny,
+  input: T,
+  context: z.RefinementCtx
+): void {
+  const result = legacySchema.safeParse({
+    ...input,
+    vendor: 'sqlite',
+    connectionString: 'configured',
+  });
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      context.addIssue(issue);
+    }
+  }
+}
+
+const relationalUpdateOperationSchema = relationalUpdateSchema
+  .innerType()
+  .omit({ vendor: true, connectionString: true })
+  .superRefine((input, context) => {
+    preserveOperationValidation(relationalUpdateSchema, input, context);
+  }) as z.ZodSchema<RelationalUpdateOperationInput>;
+
+const relationalDeleteOperationSchema = relationalDeleteSchema
+  .innerType()
+  .omit({ vendor: true, connectionString: true })
+  .superRefine((input, context) => {
+    preserveOperationValidation(relationalDeleteSchema, input, context);
+  }) as z.ZodSchema<RelationalDeleteOperationInput>;
+
+class RelationalToolSetImplementation implements RelationalToolSet {
+  readonly query: QueryTool;
+  readonly select: SelectTool;
+  readonly insert: InsertTool;
+  readonly update: UpdateTool;
+  readonly delete: DeleteTool;
+  readonly getSchema: GetSchemaTool;
+
+  private readonly tools: readonly ConfiguredTool[];
+  private readonly schemaCache = new SchemaCache();
+  private readonly schemaCacheTtlMs: number;
+  private manager?: ConnectionManager;
+  private initialization?: Promise<ConnectionManager>;
+  private activeWork = 0;
+  private state: 'open' | 'closing' | 'closed' = 'open';
+  private drain?: Promise<void>;
+  private resolveDrain?: () => void;
+  private disposal?: Promise<void>;
+
+  constructor(
+    private readonly config: ConnectionConfig,
+    options: RelationalToolSetOptions
+  ) {
+    this.schemaCacheTtlMs = options.schemaCacheTtlMs ?? DEFAULT_SCHEMA_CACHE_TTL_MS;
+    const execution = <T>(
+      operation: (manager: ConnectionManager) => Promise<T>,
+      connectionFailure: () => T
+    ) => this.run(operation, connectionFailure);
+
+    this.query = createTool(
+      configuredMetadata(relationalQuery, options.prefix),
+      relationalQuerySchema.omit({ vendor: true, connectionString: true }),
+      (input) =>
+        execution(
+          (manager) => invokeRelationalQuery({ executor: manager, vendor: config.vendor }, input),
+          () => ({
+            success: false,
+            error: 'Failed to connect to the configured database.',
+            rows: [],
+            rowCount: 0,
+          })
+        )
+    );
+    this.select = createTool(
+      configuredMetadata(relationalSelect, options.prefix),
+      relationalSelectSchema.omit({ vendor: true, connectionString: true }),
+      (input) =>
+        execution(
+          (manager) => invokeRelationalSelect({ executor: manager, vendor: config.vendor }, input),
+          () => ({
+            success: false,
+            error:
+              'Failed to execute SELECT query. Please verify the configured database connection.',
+            rows: [],
+            rowCount: 0,
+          })
+        )
+    );
+    this.insert = createTool(
+      configuredMetadata(relationalInsert, options.prefix),
+      relationalInsertSchema.omit({ vendor: true, connectionString: true }),
+      (input) =>
+        execution(
+          (manager) => invokeRelationalInsert({ executor: manager, vendor: config.vendor }, input),
+          () => ({
+            success: false,
+            error:
+              'Failed to execute INSERT query. Please verify the configured database connection.',
+            rowCount: 0,
+            insertedIds: [],
+            rows: [],
+          })
+        )
+    );
+    this.update = createTool(
+      configuredMetadata(relationalUpdate, options.prefix),
+      relationalUpdateOperationSchema,
+      (input) =>
+        execution(
+          (manager) => invokeRelationalUpdate({ executor: manager, vendor: config.vendor }, input),
+          () => ({
+            success: false,
+            error:
+              'Failed to execute UPDATE query. Please verify the configured database connection.',
+            rowCount: 0,
+          })
+        )
+    );
+    this.delete = createTool(
+      configuredMetadata(relationalDelete, options.prefix),
+      relationalDeleteOperationSchema,
+      (input) =>
+        execution(
+          (manager) => invokeRelationalDelete({ executor: manager, vendor: config.vendor }, input),
+          () => ({
+            success: false,
+            error:
+              'Failed to execute DELETE query. Please verify the configured database connection.',
+            rowCount: 0,
+            softDeleted: false,
+          })
+        )
+    );
+    this.getSchema = createTool(
+      configuredMetadata(relationalGetSchema, options.prefix),
+      relationalGetSchemaInputSchema.omit({
+        vendor: true,
+        connectionString: true,
+        database: true,
+        cacheTtlMs: true,
+      }),
+      (input) =>
+        execution(
+          (manager) =>
+            invokeRelationalGetSchema(
+              {
+                executor: manager,
+                vendor: config.vendor,
+                schemaCache: this.schemaCache,
+                schemaCacheKey: TOOL_SET_SCHEMA_CACHE_KEY,
+              },
+              { ...input, cacheTtlMs: this.schemaCacheTtlMs }
+            ),
+          () => ({
+            success: false,
+            error: 'Failed to inspect schema. See logs for details.',
+            schema: null,
+          })
+        )
+    );
+
+    this.tools = Object.freeze([
+      this.query,
+      this.select,
+      this.insert,
+      this.update,
+      this.delete,
+      this.getSchema,
+    ]) as readonly ConfiguredTool[];
+  }
+
+  [Symbol.iterator](): Iterator<ConfiguredTool> {
+    return this.tools[Symbol.iterator]();
+  }
+
+  refreshSchema(): void {
+    if (this.state !== 'open') {
+      throw new RelationalToolSetDisposedError();
+    }
+    this.schemaCache.delete(TOOL_SET_SCHEMA_CACHE_KEY);
+  }
+
+  dispose(): Promise<void> {
+    if (!this.disposal) {
+      this.state = 'closing';
+      this.disposal = this.finishDisposal();
+    }
+    return this.disposal;
+  }
+
+  private async run<T>(
+    operation: (manager: ConnectionManager) => Promise<T>,
+    connectionFailure: () => T
+  ): Promise<T> {
+    if (this.state !== 'open') {
+      throw new RelationalToolSetDisposedError();
+    }
+    this.activeWork += 1;
+    try {
+      let manager: ConnectionManager;
+      try {
+        manager = await this.ensureConnection();
+      } catch {
+        return connectionFailure();
+      }
+      return await operation(manager);
+    } finally {
+      this.activeWork -= 1;
+      if (this.activeWork === 0) {
+        this.resolveDrain?.();
+      }
+    }
+  }
+
+  private ensureConnection(): Promise<ConnectionManager> {
+    if (this.manager?.isConnected()) {
+      return Promise.resolve(this.manager);
+    }
+    if (!this.initialization) {
+      const manager = new ConnectionManager(this.config);
+      this.manager = manager;
+      this.initialization = manager
+        .connect()
+        .then(() => manager)
+        .catch(async (error: unknown) => {
+          this.manager = undefined;
+          this.initialization = undefined;
+          try {
+            await manager.dispose();
+          } catch {
+            // Preserve the connection failure as the outcome shared by all waiters.
+          }
+          throw error;
+        });
+    }
+    return this.initialization;
+  }
+
+  private async finishDisposal(): Promise<void> {
+    if (this.activeWork > 0) {
+      this.drain = new Promise<void>((resolve) => {
+        this.resolveDrain = resolve;
+      });
+      await this.drain;
+    }
+    this.schemaCache.clear();
+    try {
+      await this.manager?.dispose();
+    } finally {
+      this.state = 'closed';
+      this.resolveDrain = undefined;
+    }
+  }
+}
+
+/**
+ * Configure all six Relational Tools around one lazily connected database session or pool.
+ * Construction performs validation only and never connects to the database.
+ */
+export function createRelationalToolSet(
+  config: ConnectionConfig,
+  options: RelationalToolSetOptions = {}
+): RelationalToolSet {
+  validateConfiguration(config, options);
+  return new RelationalToolSetImplementation(snapshotConfiguration(config), { ...options });
+}

--- a/packages/tools/tests/data/relational/connection/relational-tool-set-adapters.mocked.test.ts
+++ b/packages/tools/tests/data/relational/connection/relational-tool-set-adapters.mocked.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mockMysqlCreatePool,
+  mockMysqlExecute,
+  mockMysqlPoolEnd,
+  mockPgExecute,
+  mockPool,
+  mockPoolEnd,
+} from './connection-manager.mock-harness.js';
+import { createRelationalToolSet } from '../../../../src/data/relational/tool-set.js';
+
+describe('Relational Tool Set adapter contracts', () => {
+  it('coalesces and reuses the PostgreSQL pool through the configured Tool seam', async () => {
+    const certificate = Buffer.from('original-certificate');
+    const toolSet = createRelationalToolSet({
+      vendor: 'postgresql',
+      connection: {
+        host: 'localhost',
+        database: 'agentforge',
+        ssl: { ca: certificate },
+      },
+    });
+    certificate.fill(0);
+
+    const results = await Promise.all([
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+    ]);
+
+    expect(results.every((result) => result.success)).toBe(true);
+    expect(mockPool).toHaveBeenCalledTimes(1);
+    const poolConfiguration = (mockPool.mock.calls as unknown[][])[0]?.[0] as {
+      ssl: { ca: Buffer };
+    };
+    expect(poolConfiguration.ssl.ca.toString()).toBe('original-certificate');
+    // One initialization health probe plus the two Tool invocations.
+    expect(mockPgExecute).toHaveBeenCalledTimes(3);
+    await toolSet.dispose();
+    expect(mockPoolEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces and reuses the MySQL pool through the configured Tool seam', async () => {
+    const toolSet = createRelationalToolSet({
+      vendor: 'mysql',
+      connection: 'mysql://localhost/agentforge',
+    });
+
+    const results = await Promise.all([
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+    ]);
+
+    expect(results.every((result) => result.success)).toBe(true);
+    expect(mockMysqlCreatePool).toHaveBeenCalledTimes(1);
+    // One initialization health probe plus the two Tool invocations.
+    expect(mockMysqlExecute).toHaveBeenCalledTimes(3);
+    await toolSet.dispose();
+    expect(mockMysqlPoolEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/tools/tests/data/relational/relational-tool-set.test.ts
+++ b/packages/tools/tests/data/relational/relational-tool-set.test.ts
@@ -1,0 +1,280 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  ConnectionManager,
+  createRelationalToolSet,
+  RelationalToolSetConfigurationError,
+  RelationalToolSetDisposedError,
+  SchemaCache,
+} from '../../../src/data/relational/index.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function temporaryDatabase(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'agentforge-tool-set-'));
+  temporaryDirectories.push(directory);
+  return join(directory, 'database.sqlite');
+}
+
+function seedUsers(databasePath: string): void {
+  const database = new Database(databasePath);
+  database.exec(`
+    CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO users (id, name) VALUES (1, 'Alice');
+  `);
+  database.close();
+}
+
+function schemaFields(schema: z.ZodTypeAny): string[] {
+  const objectSchema = schema instanceof z.ZodEffects ? schema.innerType() : schema;
+  return Object.keys((objectSchema as z.AnyZodObject).shape);
+}
+
+describe('Relational Tool Set', () => {
+  it('exposes six named and iterable credential-free Tools without connecting', () => {
+    const toolSet = createRelationalToolSet(
+      { vendor: 'sqlite', connection: ':memory:' },
+      { prefix: 'warehouse' }
+    );
+
+    expect([...toolSet]).toEqual([
+      toolSet.query,
+      toolSet.select,
+      toolSet.insert,
+      toolSet.update,
+      toolSet.delete,
+      toolSet.getSchema,
+    ]);
+    expect([...toolSet].map((tool) => tool.metadata.name)).toEqual([
+      'warehouse-relational-query',
+      'warehouse-relational-select',
+      'warehouse-relational-insert',
+      'warehouse-relational-update',
+      'warehouse-relational-delete',
+      'warehouse-relational-get-schema',
+    ]);
+
+    for (const tool of toolSet) {
+      const fields = schemaFields(tool.schema);
+      expect(fields).not.toContain('vendor');
+      expect(fields).not.toContain('connectionString');
+    }
+  });
+
+  it('validates configuration synchronously and preserves default Tool names', () => {
+    const connect = vi.spyOn(ConnectionManager.prototype, 'connect');
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection: ':memory:' });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect([...toolSet].map((tool) => tool.metadata.name)).toEqual([
+      'relational-query',
+      'relational-select',
+      'relational-insert',
+      'relational-update',
+      'relational-delete',
+      'relational-get-schema',
+    ]);
+    expect(() =>
+      createRelationalToolSet({ vendor: 'sqlite', connection: ':memory:' }, { prefix: 'Not Valid' })
+    ).toThrow(RelationalToolSetConfigurationError);
+    expect(() =>
+      createRelationalToolSet(
+        { vendor: 'sqlite', connection: ':memory:' },
+        { schemaCacheTtlMs: -1 }
+      )
+    ).toThrow(RelationalToolSetConfigurationError);
+  });
+
+  it('accepts every supported adapter configuration without performing I/O', () => {
+    const connect = vi.spyOn(ConnectionManager.prototype, 'connect');
+
+    expect(() =>
+      createRelationalToolSet({
+        vendor: 'postgresql',
+        connection: 'postgresql://localhost/agentforge',
+      })
+    ).not.toThrow();
+    expect(() =>
+      createRelationalToolSet({
+        vendor: 'mysql',
+        connection: { host: 'localhost', database: 'agentforge' },
+      })
+    ).not.toThrow();
+    expect(() =>
+      createRelationalToolSet({
+        vendor: 'sqlite',
+        connection: { url: ':memory:' },
+      })
+    ).not.toThrow();
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('snapshots the database configuration at construction', async () => {
+    const databasePath = temporaryDatabase();
+    seedUsers(databasePath);
+    const connection = { url: databasePath };
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection });
+
+    connection.url = join(databasePath, 'mutated');
+    await expect(toolSet.query.invoke({ sql: 'SELECT name FROM users' })).resolves.toMatchObject({
+      success: true,
+      rowCount: 1,
+    });
+
+    await toolSet.dispose();
+  });
+
+  it('retains operation validation after credentials are removed', () => {
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection: ':memory:' });
+
+    expect(toolSet.update.schema.safeParse({ table: 'users', data: { name: 'Bob' } }).success).toBe(
+      false
+    );
+    expect(toolSet.delete.schema.safeParse({ table: 'users' }).success).toBe(false);
+    expect(toolSet.select.schema.safeParse({ table: '' }).success).toBe(false);
+  });
+
+  it('coalesces concurrent first use and reuses one SQLite session for all Tools', async () => {
+    const databasePath = temporaryDatabase();
+    seedUsers(databasePath);
+    const connect = vi.spyOn(ConnectionManager.prototype, 'connect');
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection: databasePath });
+
+    const [firstQuery, secondQuery] = await Promise.all([
+      toolSet.query.invoke({ sql: 'SELECT name FROM users WHERE id = ?', params: [1] }),
+      toolSet.query.invoke({ sql: 'SELECT name FROM users WHERE id = ?', params: [1] }),
+    ]);
+    const inserted = await toolSet.insert.invoke({ table: 'users', data: { id: 2, name: 'Bob' } });
+    const selected = await toolSet.select.invoke({
+      table: 'users',
+      orderBy: [{ column: 'id', direction: 'asc' }],
+    });
+    const updated = await toolSet.update.invoke({
+      table: 'users',
+      data: { name: 'Robert' },
+      where: [{ column: 'id', operator: 'eq', value: 2 }],
+    });
+    const deleted = await toolSet.delete.invoke({
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 1 }],
+    });
+    const schema = await toolSet.getSchema.invoke({});
+
+    expect([firstQuery.success, secondQuery.success]).toEqual([true, true]);
+    expect(inserted.success && inserted.rowCount).toBe(1);
+    expect(selected.success && selected.rowCount).toBe(2);
+    expect(updated.success && updated.rowCount).toBe(1);
+    expect(deleted.success && deleted.rowCount).toBe(1);
+    expect(schema.success && schema.summary.tableCount).toBe(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    await toolSet.dispose();
+  });
+
+  it('retries a failed first connection attempt', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'agentforge-tool-set-retry-'));
+    temporaryDirectories.push(directory);
+    const parent = join(directory, 'later');
+    const toolSet = createRelationalToolSet({
+      vendor: 'sqlite',
+      connection: join(parent, 'database.sqlite'),
+    });
+
+    const connect = vi.spyOn(ConnectionManager.prototype, 'connect');
+    const [firstFailure, secondFailure] = await Promise.all([
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+      toolSet.query.invoke({ sql: 'SELECT 1 AS value' }),
+    ]);
+    expect(firstFailure).toEqual(secondFailure);
+    expect(firstFailure).toMatchObject({ success: false, rowCount: 0 });
+    expect(firstFailure.success || firstFailure.error).not.toContain(parent);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    mkdirSync(parent);
+    await expect(toolSet.query.invoke({ sql: 'SELECT 1 AS value' })).resolves.toMatchObject({
+      success: true,
+      rowCount: 1,
+    });
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    await toolSet.dispose();
+  });
+
+  it('owns schema refresh and clears cached state during disposal', async () => {
+    const databasePath = temporaryDatabase();
+    seedUsers(databasePath);
+    const clearCache = vi.spyOn(SchemaCache.prototype, 'clear');
+    const toolSet = createRelationalToolSet(
+      { vendor: 'sqlite', connection: databasePath },
+      { schemaCacheTtlMs: 60_000 }
+    );
+
+    const initial = await toolSet.getSchema.invoke({});
+    const database = new Database(databasePath);
+    database.exec('ALTER TABLE users ADD COLUMN email TEXT');
+    database.close();
+    const cached = await toolSet.getSchema.invoke({});
+    toolSet.refreshSchema();
+    const refreshed = await toolSet.getSchema.invoke({});
+
+    const columnCount = (result: typeof initial) =>
+      result.success ? result.schema.tables[0]?.columns.length : undefined;
+    expect(columnCount(initial)).toBe(2);
+    expect(columnCount(cached)).toBe(2);
+    expect(columnCount(refreshed)).toBe(3);
+
+    await toolSet.dispose();
+    expect(clearCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects new work while disposal drains admitted work and closes once', async () => {
+    const disposeConnection = vi.spyOn(ConnectionManager.prototype, 'dispose');
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection: ':memory:' });
+    const admitted = toolSet.query.invoke({ sql: 'SELECT 1 AS value' });
+    const firstDisposal = toolSet.dispose();
+    const secondDisposal = toolSet.dispose();
+
+    await expect(toolSet.query.invoke({ sql: 'SELECT 2 AS value' })).rejects.toBeInstanceOf(
+      RelationalToolSetDisposedError
+    );
+    await expect(admitted).resolves.toMatchObject({ success: true, rowCount: 1 });
+    await expect(Promise.all([firstDisposal, secondDisposal])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(disposeConnection).toHaveBeenCalledTimes(1);
+    await expect(toolSet.dispose()).resolves.toBeUndefined();
+    expect(disposeConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports one deterministic disposal failure to every caller', async () => {
+    const toolSet = createRelationalToolSet({ vendor: 'sqlite', connection: ':memory:' });
+    await toolSet.query.invoke({ sql: 'SELECT 1 AS value' });
+    const failure = new Error('close failed');
+    const disposeConnection = vi
+      .spyOn(ConnectionManager.prototype, 'dispose')
+      .mockRejectedValueOnce(failure);
+
+    const firstDisposal = toolSet.dispose();
+    const secondDisposal = toolSet.dispose();
+    await expect(firstDisposal).rejects.toBe(failure);
+    await expect(secondDisposal).rejects.toBe(failure);
+    await expect(toolSet.dispose()).rejects.toBe(failure);
+    expect(disposeConnection).toHaveBeenCalledTimes(1);
+    await expect(toolSet.query.invoke({ sql: 'SELECT 2 AS value' })).rejects.toBeInstanceOf(
+      RelationalToolSetDisposedError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a synchronous configured Relational Tool Set factory with six named, iterable, credential-free Tools
- coalesce lazy connections, reuse sessions/pools, own schema caching and refresh, and provide draining idempotent disposal
- cover SQLite interface behavior plus PostgreSQL/MySQL adapter contracts

## Validation

- `pnpm --filter @agentforge/tools typecheck`
- `pnpm --filter @agentforge/tools lint` (0 errors; existing warnings only)
- `pnpm --filter @agentforge/tools exec vitest run --config vitest.config.ts` (1190 passed, 110 skipped)

Closes #222