### PR TITLE
Migrate legacy Relational mutation Tools to compatibility adapters

### DIFF
--- a/docs-site/api/tools.md
+++ b/docs-site/api/tools.md
@@ -938,12 +938,12 @@ All relational tools return `{ success: true, ... }` on success or `{ success: f
 **Exception:** If the required vendor driver (`pg`, `mysql2`, or `better-sqlite3`) is not installed, the tool will throw a `MissingPeerDependencyError` synchronously. Ensure peer dependencies are installed to avoid this.
 :::
 
-::: warning Legacy read Tools
-`relationalQuery`, `relationalSelect`, and `relationalGetSchema` keep their
-credential-bearing inputs for compatibility, but are deprecated. Prefer
-`createRelationalToolSet(...)`; its configured Tools omit database credentials,
-reuse an owned session, and expose explicit `dispose()` cleanup. Each invocation
-of a deprecated read Tool uses and disposes an ephemeral Relational Tool Set.
+::: warning Legacy Relational Tools
+The six credential-bearing Relational Tools remain available for compatibility,
+but are deprecated. Prefer `createRelationalToolSet(...)`; its configured Tools
+omit database credentials, reuse an owned session, and expose explicit
+`dispose()` cleanup. Each invocation of a deprecated Tool uses and disposes an
+ephemeral Relational Tool Set.
 :::
 
 #### relationalQuery

--- a/packages/tools/src/data/relational/README.md
+++ b/packages/tools/src/data/relational/README.md
@@ -97,11 +97,11 @@ try {
 }
 ```
 
-The credential-bearing `relationalQuery`, `relationalSelect`, and
-`relationalGetSchema` exports remain available as deprecated compatibility
-Tools. Each legacy invocation creates and disposes an ephemeral Relational Tool
-Set. Migrate new code to `createRelationalToolSet(...)` to reuse its owned
-session and keep credentials out of Tool inputs.
+The six credential-bearing Relational Tool exports remain available as
+deprecated compatibility Tools. Each legacy invocation creates and disposes an
+ephemeral Relational Tool Set. Migrate new code to
+`createRelationalToolSet(...)` to reuse its owned session and keep credentials
+out of Tool inputs.
 
 ---
 
@@ -111,9 +111,9 @@ session and keep credentials out of Tool inputs.
 | ---------------------- | ------------------------------------------------------------------------ |
 | `relationalQuery`      | Deprecated credential-bearing Query compatibility Tool                  |
 | `relationalSelect`     | Deprecated credential-bearing Select compatibility Tool                 |
-| `relationalInsert`     | Type-safe INSERT (single-row and batch) with RETURNING support           |
-| `relationalUpdate`     | Type-safe UPDATE with WHERE, optimistic locking, and batch support       |
-| `relationalDelete`     | Type-safe DELETE with WHERE, soft delete mode, and batch support         |
+| `relationalInsert`     | Deprecated credential-bearing Insert compatibility Tool                 |
+| `relationalUpdate`     | Deprecated credential-bearing Update compatibility Tool                 |
+| `relationalDelete`     | Deprecated credential-bearing Delete compatibility Tool                 |
 | `relationalGetSchema`  | Deprecated credential-bearing Get Schema compatibility Tool             |
 
 The deprecated compatibility Tools accept `vendor` and `connectionString` on

--- a/packages/tools/src/data/relational/connection-failure-messages.ts
+++ b/packages/tools/src/data/relational/connection-failure-messages.ts
@@ -2,3 +2,12 @@ export const QUERY_CONNECTION_FAILURE = 'Failed to connect to the configured dat
 
 export const SELECT_CONNECTION_FAILURE =
   'Failed to execute SELECT query. Please verify the configured database connection.';
+
+export const INSERT_CONNECTION_FAILURE =
+  'Failed to execute INSERT query. Please verify the configured database connection.';
+
+export const UPDATE_CONNECTION_FAILURE =
+  'Failed to execute UPDATE query. Please verify the configured database connection.';
+
+export const DELETE_CONNECTION_FAILURE =
+  'Failed to execute DELETE query. Please verify the configured database connection.';

--- a/packages/tools/src/data/relational/tool-set.ts
+++ b/packages/tools/src/data/relational/tool-set.ts
@@ -4,8 +4,11 @@ import type { z } from 'zod';
 import { ConnectionManager } from './connection/connection-manager.js';
 import type { ConnectionConfig } from './connection/types.js';
 import {
+  DELETE_CONNECTION_FAILURE,
+  INSERT_CONNECTION_FAILURE,
   QUERY_CONNECTION_FAILURE,
   SELECT_CONNECTION_FAILURE,
+  UPDATE_CONNECTION_FAILURE,
 } from './connection-failure-messages.js';
 import { SchemaCache, SchemaInspector } from './schema/schema-inspector.js';
 import { MissingPeerDependencyError } from './utils/peer-dependency-checker.js';
@@ -292,8 +295,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
           (manager) => invokeRelationalInsert(this.executionFor(manager), input),
           () => ({
             success: false,
-            error:
-              'Failed to execute INSERT query. Please verify the configured database connection.',
+            error: INSERT_CONNECTION_FAILURE,
             rowCount: 0,
             insertedIds: [],
             rows: [],
@@ -308,8 +310,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
           (manager) => invokeRelationalUpdate(this.executionFor(manager), input),
           () => ({
             success: false,
-            error:
-              'Failed to execute UPDATE query. Please verify the configured database connection.',
+            error: UPDATE_CONNECTION_FAILURE,
             rowCount: 0,
           })
         )
@@ -322,8 +323,7 @@ class RelationalToolSetImplementation implements RelationalToolSet {
           (manager) => invokeRelationalDelete(this.executionFor(manager), input),
           () => ({
             success: false,
-            error:
-              'Failed to execute DELETE query. Please verify the configured database connection.',
+            error: DELETE_CONNECTION_FAILURE,
             rowCount: 0,
             softDeleted: false,
           })
@@ -497,4 +497,9 @@ export function createLegacyRelationalReadToolSet(
     { ...options },
     schemaCacheKey
   );
+}
+
+/** @internal Preserve the legacy mutation Tool validation and error contracts. */
+export function createLegacyRelationalMutationToolSet(config: ConnectionConfig): RelationalToolSet {
+  return new RelationalToolSetImplementation(snapshotConfiguration(config), {});
 }

--- a/packages/tools/src/data/relational/tools/legacy-mutation-adapter.ts
+++ b/packages/tools/src/data/relational/tools/legacy-mutation-adapter.ts
@@ -1,0 +1,34 @@
+import { createLegacyRelationalMutationToolSet, type RelationalToolSet } from '../tool-set.js';
+import type { DatabaseVendor } from '../types.js';
+
+interface LegacyDatabaseInput {
+  vendor: DatabaseVendor;
+  connectionString: string;
+}
+
+export function replaceMutationConnectionFailure<T extends { success: boolean; error?: string }>(
+  result: T,
+  configuredMessage: string,
+  legacyMessage: string
+): T {
+  if (!result.success && result.error === configuredMessage) {
+    return { ...result, error: legacyMessage };
+  }
+  return result;
+}
+
+export async function withEphemeralRelationalMutationToolSet<T>(
+  database: LegacyDatabaseInput,
+  invoke: (toolSet: RelationalToolSet) => Promise<T>
+): Promise<T> {
+  const toolSet = createLegacyRelationalMutationToolSet({
+    vendor: database.vendor,
+    connection: database.connectionString,
+  });
+
+  try {
+    return await invoke(toolSet);
+  } finally {
+    await toolSet.dispose();
+  }
+}

--- a/packages/tools/src/data/relational/tools/legacy-mutation-adapter.ts
+++ b/packages/tools/src/data/relational/tools/legacy-mutation-adapter.ts
@@ -1,5 +1,6 @@
 import { createLegacyRelationalMutationToolSet, type RelationalToolSet } from '../tool-set.js';
 import type { DatabaseVendor } from '../types.js';
+import { MissingPeerDependencyError } from '../utils/peer-dependency-checker.js';
 
 interface LegacyDatabaseInput {
   vendor: DatabaseVendor;
@@ -19,7 +20,8 @@ export function replaceMutationConnectionFailure<T extends { success: boolean; e
 
 export async function withEphemeralRelationalMutationToolSet<T>(
   database: LegacyDatabaseInput,
-  invoke: (toolSet: RelationalToolSet) => Promise<T>
+  invoke: (toolSet: RelationalToolSet) => Promise<T>,
+  toErrorResponse: (error: unknown) => T
 ): Promise<T> {
   const toolSet = createLegacyRelationalMutationToolSet({
     vendor: database.vendor,
@@ -27,7 +29,14 @@ export async function withEphemeralRelationalMutationToolSet<T>(
   });
 
   try {
-    return await invoke(toolSet);
+    try {
+      return await invoke(toolSet);
+    } catch (error) {
+      if (error instanceof MissingPeerDependencyError) {
+        throw error;
+      }
+      return toErrorResponse(error);
+    }
   } finally {
     await toolSet.dispose();
   }

--- a/packages/tools/src/data/relational/tools/relational-delete/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { ConnectionManager } from '../../connection/connection-manager.js';
+import { DELETE_CONNECTION_FAILURE } from '../../connection-failure-messages.js';
 import { relationalDeleteSchema } from './schemas.js';
 import { executeDelete } from './executor.js';
 import type {
@@ -19,6 +19,10 @@ import type {
 } from './types.js';
 import { isSafeDeleteError } from './error-utils.js';
 import type { RelationalMutationExecution } from '../mutation-execution.js';
+import {
+  replaceMutationConnectionFailure,
+  withEphemeralRelationalMutationToolSet,
+} from '../legacy-mutation-adapter.js';
 
 export * from './types.js';
 export * from './schemas.js';
@@ -65,6 +69,9 @@ export async function invokeRelationalDelete(
  *
  * Supports WHERE conditions, full-table-delete protection, soft-delete mode,
  * batch operations with retry logic, and optional cascade hints.
+ *
+ * @deprecated Configure a session-owning Relational Tool Set with
+ * `createRelationalToolSet(...)` and use its `delete` Tool instead.
  */
 export const relationalDelete = toolBuilder()
   .name('relational-delete')
@@ -116,22 +123,16 @@ export const relationalDelete = toolBuilder()
   })
   .implement(async (input: RelationalDeleteInput): Promise<DeleteResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    const manager = new ConnectionManager({
-      vendor,
-      connection: connectionString,
+    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
+      try {
+        return replaceMutationConnectionFailure(
+          await toolSet.delete.invoke(operation),
+          DELETE_CONNECTION_FAILURE,
+          'Failed to execute DELETE query. Please verify your input and database connection.'
+        );
+      } catch (error) {
+        return toDeleteErrorResponse(error);
+      }
     });
-
-    try {
-      await manager.connect();
-
-      return await invokeRelationalDelete(
-        { executor: manager, vendor },
-        operation
-      );
-    } catch (error) {
-      return toDeleteErrorResponse(error);
-    } finally {
-      await manager.disconnect();
-    }
   })
   .build();

--- a/packages/tools/src/data/relational/tools/relational-delete/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-delete/index.ts
@@ -123,16 +123,15 @@ export const relationalDelete = toolBuilder()
   })
   .implement(async (input: RelationalDeleteInput): Promise<DeleteResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
-      try {
-        return replaceMutationConnectionFailure(
+    return withEphemeralRelationalMutationToolSet(
+      { vendor, connectionString },
+      async (toolSet) =>
+        replaceMutationConnectionFailure(
           await toolSet.delete.invoke(operation),
           DELETE_CONNECTION_FAILURE,
           'Failed to execute DELETE query. Please verify your input and database connection.'
-        );
-      } catch (error) {
-        return toDeleteErrorResponse(error);
-      }
-    });
+        ),
+      toDeleteErrorResponse
+    );
   })
   .build();

--- a/packages/tools/src/data/relational/tools/relational-insert/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { ConnectionManager } from '../../connection/connection-manager.js';
+import { INSERT_CONNECTION_FAILURE } from '../../connection-failure-messages.js';
 import { relationalInsertSchema } from './schemas.js';
 import { executeInsert } from './executor.js';
 import type {
@@ -19,6 +19,10 @@ import type {
 } from './types.js';
 import { isSafeInsertError } from './error-utils.js';
 import type { RelationalMutationExecution } from '../mutation-execution.js';
+import {
+  replaceMutationConnectionFailure,
+  withEphemeralRelationalMutationToolSet,
+} from '../legacy-mutation-adapter.js';
 
 // Re-export types and schemas for external use
 export * from './types.js';
@@ -67,6 +71,9 @@ export async function invokeRelationalInsert(
  * Relational INSERT Tool
  *
  * Execute type-safe INSERT queries using Drizzle ORM query builder.
+ *
+ * @deprecated Configure a session-owning Relational Tool Set with
+ * `createRelationalToolSet(...)` and use its `insert` Tool instead.
  */
 export const relationalInsert = toolBuilder()
   .name('relational-insert')
@@ -104,22 +111,16 @@ export const relationalInsert = toolBuilder()
   })
   .implement(async (input: RelationalInsertInput): Promise<InsertResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    const manager = new ConnectionManager({
-      vendor,
-      connection: connectionString,
+    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
+      try {
+        return replaceMutationConnectionFailure(
+          await toolSet.insert.invoke(operation),
+          INSERT_CONNECTION_FAILURE,
+          'Failed to execute INSERT query. Please verify your input and database connection.'
+        );
+      } catch (error) {
+        return toInsertErrorResponse(error);
+      }
     });
-
-    try {
-      await manager.connect();
-
-      return await invokeRelationalInsert(
-        { executor: manager, vendor },
-        operation
-      );
-    } catch (error) {
-      return toInsertErrorResponse(error);
-    } finally {
-      await manager.disconnect();
-    }
   })
   .build();

--- a/packages/tools/src/data/relational/tools/relational-insert/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-insert/index.ts
@@ -111,16 +111,15 @@ export const relationalInsert = toolBuilder()
   })
   .implement(async (input: RelationalInsertInput): Promise<InsertResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
-      try {
-        return replaceMutationConnectionFailure(
+    return withEphemeralRelationalMutationToolSet(
+      { vendor, connectionString },
+      async (toolSet) =>
+        replaceMutationConnectionFailure(
           await toolSet.insert.invoke(operation),
           INSERT_CONNECTION_FAILURE,
           'Failed to execute INSERT query. Please verify your input and database connection.'
-        );
-      } catch (error) {
-        return toInsertErrorResponse(error);
-      }
-    });
+        ),
+      toInsertErrorResponse
+    );
   })
   .build();

--- a/packages/tools/src/data/relational/tools/relational-update/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { toolBuilder, ToolCategory } from '@agentforge/core';
-import { ConnectionManager } from '../../connection/connection-manager.js';
+import { UPDATE_CONNECTION_FAILURE } from '../../connection-failure-messages.js';
 import { relationalUpdateSchema } from './schemas.js';
 import { executeUpdate } from './executor.js';
 import type {
@@ -19,6 +19,10 @@ import type {
 } from './types.js';
 import { isSafeUpdateError } from './error-utils.js';
 import type { RelationalMutationExecution } from '../mutation-execution.js';
+import {
+  replaceMutationConnectionFailure,
+  withEphemeralRelationalMutationToolSet,
+} from '../legacy-mutation-adapter.js';
 
 // Re-export types and schemas for external use
 export * from './types.js';
@@ -63,6 +67,9 @@ export async function invokeRelationalUpdate(
  * Relational UPDATE Tool
  *
  * Execute type-safe UPDATE queries using Drizzle ORM query builder.
+ *
+ * @deprecated Configure a session-owning Relational Tool Set with
+ * `createRelationalToolSet(...)` and use its `update` Tool instead.
  */
 export const relationalUpdate = toolBuilder()
   .name('relational-update')
@@ -116,22 +123,16 @@ export const relationalUpdate = toolBuilder()
   })
   .implement(async (input: RelationalUpdateInput): Promise<UpdateResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    const manager = new ConnectionManager({
-      vendor,
-      connection: connectionString,
+    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
+      try {
+        return replaceMutationConnectionFailure(
+          await toolSet.update.invoke(operation),
+          UPDATE_CONNECTION_FAILURE,
+          'Failed to execute UPDATE query. Please verify your input and database connection.'
+        );
+      } catch (error) {
+        return toUpdateErrorResponse(error);
+      }
     });
-
-    try {
-      await manager.connect();
-
-      return await invokeRelationalUpdate(
-        { executor: manager, vendor },
-        operation
-      );
-    } catch (error) {
-      return toUpdateErrorResponse(error);
-    } finally {
-      await manager.disconnect();
-    }
   })
   .build();

--- a/packages/tools/src/data/relational/tools/relational-update/index.ts
+++ b/packages/tools/src/data/relational/tools/relational-update/index.ts
@@ -123,16 +123,15 @@ export const relationalUpdate = toolBuilder()
   })
   .implement(async (input: RelationalUpdateInput): Promise<UpdateResponse> => {
     const { connectionString, vendor, ...operation } = input;
-    return withEphemeralRelationalMutationToolSet({ vendor, connectionString }, async (toolSet) => {
-      try {
-        return replaceMutationConnectionFailure(
+    return withEphemeralRelationalMutationToolSet(
+      { vendor, connectionString },
+      async (toolSet) =>
+        replaceMutationConnectionFailure(
           await toolSet.update.invoke(operation),
           UPDATE_CONNECTION_FAILURE,
           'Failed to execute UPDATE query. Please verify your input and database connection.'
-        );
-      } catch (error) {
-        return toUpdateErrorResponse(error);
-      }
-    });
+        ),
+      toUpdateErrorResponse
+    );
   })
   .build();

--- a/packages/tools/tests/data/relational/connection/legacy-mutation-compatibility.mocked.test.ts
+++ b/packages/tools/tests/data/relational/connection/legacy-mutation-compatibility.mocked.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ConnectionManager,
+  mockPgExecute,
+  mockPool,
+  mockPoolEnd,
+} from './connection-manager.mock-harness.js';
+import {
+  relationalDelete,
+  relationalInsert,
+  relationalUpdate,
+} from '../../../../src/data/relational/tools/index.js';
+
+describe('legacy Relational mutation Tool compatibility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function expectEphemeralLifecycle(invoke: () => Promise<unknown>): Promise<void> {
+    const dispose = vi.spyOn(ConnectionManager.prototype, 'dispose');
+    const emitWarning = vi.spyOn(process, 'emitWarning');
+
+    await invoke();
+
+    expect(mockPool).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(mockPoolEnd).toHaveBeenCalledOnce();
+    expect(emitWarning).not.toHaveBeenCalled();
+  }
+
+  const database = {
+    vendor: 'postgresql' as const,
+    connectionString: 'postgresql://localhost/agentforge',
+  };
+
+  it.each([
+    [
+      'Insert',
+      () => relationalInsert.invoke({ ...database, table: 'users', data: { name: 'Alice' } }),
+    ],
+    [
+      'Update',
+      () =>
+        relationalUpdate.invoke({
+          ...database,
+          table: 'users',
+          data: { status: 'inactive' },
+          where: [{ column: 'id', operator: 'eq' as const, value: 42 }],
+        }),
+    ],
+    [
+      'Delete',
+      () =>
+        relationalDelete.invoke({
+          ...database,
+          table: 'users',
+          where: [{ column: 'id', operator: 'eq' as const, value: 42 }],
+        }),
+    ],
+  ])('runs %s through one ephemeral Relational Tool Set', async (_name, invoke) => {
+    await expectEphemeralLifecycle(async () => {
+      const result = await invoke();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it.each([
+    [
+      'Insert',
+      () => relationalInsert.invoke({ ...database, table: 'users', data: { name: 'Alice' } }),
+      {
+        success: false,
+        error: 'Failed to execute INSERT query. Please verify your input and database connection.',
+        rowCount: 0,
+        insertedIds: [],
+        rows: [],
+      },
+    ],
+    [
+      'Update',
+      () =>
+        relationalUpdate.invoke({
+          ...database,
+          table: 'users',
+          data: { status: 'inactive' },
+          where: [{ column: 'id', operator: 'eq' as const, value: 42 }],
+        }),
+      {
+        success: false,
+        error: 'Failed to execute UPDATE query. Please verify your input and database connection.',
+        rowCount: 0,
+      },
+    ],
+    [
+      'Delete',
+      () =>
+        relationalDelete.invoke({
+          ...database,
+          table: 'users',
+          where: [{ column: 'id', operator: 'eq' as const, value: 42 }],
+        }),
+      {
+        success: false,
+        error: 'Failed to execute DELETE query. Please verify your input and database connection.',
+        rowCount: 0,
+        softDeleted: false,
+      },
+    ],
+  ])('preserves the legacy %s connection-failure result', async (_name, invoke, expected) => {
+    mockPgExecute.mockRejectedValueOnce(new Error('connection refused'));
+
+    await expectEphemeralLifecycle(async () => {
+      await expect(invoke()).resolves.toEqual(expected);
+    });
+  });
+});

--- a/packages/tools/tests/data/relational/legacy-mutation-delegation.test.ts
+++ b/packages/tools/tests/data/relational/legacy-mutation-delegation.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createLegacyRelationalMutationToolSet: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  dispose: vi.fn(),
+}));
+
+vi.mock('../../../src/data/relational/tool-set.js', () => ({
+  createLegacyRelationalMutationToolSet: mocks.createLegacyRelationalMutationToolSet,
+}));
+
+import {
+  relationalDelete,
+  relationalInsert,
+  relationalUpdate,
+} from '../../../src/data/relational/tools/index.js';
+
+describe('legacy Relational mutation Tool delegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createLegacyRelationalMutationToolSet.mockReturnValue({
+      insert: { invoke: mocks.insert },
+      update: { invoke: mocks.update },
+      delete: { invoke: mocks.delete },
+      dispose: mocks.dispose,
+    });
+    mocks.insert.mockResolvedValue({
+      success: true,
+      rowCount: 1,
+      insertedIds: [42],
+      rows: [],
+      executionTime: 1,
+    });
+    mocks.update.mockResolvedValue({ success: true, rowCount: 1, executionTime: 1 });
+    mocks.delete.mockResolvedValue({
+      success: true,
+      rowCount: 1,
+      executionTime: 1,
+      softDeleted: false,
+    });
+    mocks.dispose.mockResolvedValue(undefined);
+  });
+
+  it('delegates Insert without credentials and disposes the Tool Set', async () => {
+    await relationalInsert.invoke({
+      vendor: 'postgresql',
+      connectionString: 'postgresql://localhost/agentforge',
+      table: 'users',
+      data: { name: 'Alice' },
+    });
+
+    expect(mocks.createLegacyRelationalMutationToolSet).toHaveBeenCalledWith({
+      vendor: 'postgresql',
+      connection: 'postgresql://localhost/agentforge',
+    });
+    expect(mocks.insert).toHaveBeenCalledWith({ table: 'users', data: { name: 'Alice' } });
+    expect(mocks.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('delegates Update without credentials and disposes the Tool Set', async () => {
+    await relationalUpdate.invoke({
+      vendor: 'mysql',
+      connectionString: 'mysql://localhost/agentforge',
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 42 }],
+    });
+
+    const operation = mocks.update.mock.calls[0]?.[0];
+    expect(mocks.createLegacyRelationalMutationToolSet).toHaveBeenCalledWith({
+      vendor: 'mysql',
+      connection: 'mysql://localhost/agentforge',
+    });
+    expect(operation).toMatchObject({
+      table: 'users',
+      data: { status: 'inactive' },
+      where: [{ column: 'id', operator: 'eq', value: 42 }],
+    });
+    expect(operation).not.toHaveProperty('vendor');
+    expect(operation).not.toHaveProperty('connectionString');
+    expect(mocks.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('delegates Delete without credentials and disposes the Tool Set', async () => {
+    await relationalDelete.invoke({
+      vendor: 'sqlite',
+      connectionString: 'database.sqlite',
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 42 }],
+    });
+
+    const operation = mocks.delete.mock.calls[0]?.[0];
+    expect(mocks.createLegacyRelationalMutationToolSet).toHaveBeenCalledWith({
+      vendor: 'sqlite',
+      connection: 'database.sqlite',
+    });
+    expect(operation).toMatchObject({
+      table: 'users',
+      where: [{ column: 'id', operator: 'eq', value: 42 }],
+    });
+    expect(operation).not.toHaveProperty('vendor');
+    expect(operation).not.toHaveProperty('connectionString');
+    expect(mocks.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('disposes the Tool Set when delegated invocation throws', async () => {
+    mocks.insert.mockRejectedValueOnce(new Error('missing driver'));
+
+    await expect(
+      relationalInsert.invoke({
+        vendor: 'postgresql',
+        connectionString: 'postgresql://localhost/agentforge',
+        table: 'users',
+        data: { name: 'Alice' },
+      })
+    ).resolves.toMatchObject({ success: false });
+    expect(mocks.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('creates and disposes a fresh Tool Set for every invocation', async () => {
+    const input = {
+      vendor: 'postgresql' as const,
+      connectionString: 'postgresql://localhost/agentforge',
+      table: 'users',
+      data: { name: 'Alice' },
+    };
+
+    await relationalInsert.invoke(input);
+    await relationalInsert.invoke(input);
+
+    expect(mocks.createLegacyRelationalMutationToolSet).toHaveBeenCalledTimes(2);
+    expect(mocks.dispose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tools/tests/data/relational/legacy-mutation-missing-driver.test.ts
+++ b/packages/tools/tests/data/relational/legacy-mutation-missing-driver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/data/relational/utils/peer-dependency-checker.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../src/data/relational/utils/peer-dependency-checker.js')
+    >();
+  return {
+    ...actual,
+    checkPeerDependency: vi.fn((vendor: 'postgresql' | 'mysql' | 'sqlite') => {
+      throw new actual.MissingPeerDependencyError(vendor, 'missing-driver');
+    }),
+  };
+});
+
+import {
+  relationalDelete,
+  relationalInsert,
+  relationalUpdate,
+} from '../../../src/data/relational/index.js';
+
+describe('legacy Relational mutation Tool missing-driver compatibility', () => {
+  it.each([
+    [
+      'Insert',
+      () =>
+        relationalInsert.invoke({
+          table: 'users',
+          data: { name: 'Alice' },
+          vendor: 'postgresql',
+          connectionString: 'postgresql://localhost/agentforge',
+        }),
+      'Failed to execute INSERT query. Please verify your input and database connection.',
+    ],
+    [
+      'Update',
+      () =>
+        relationalUpdate.invoke({
+          table: 'users',
+          data: { status: 'inactive' },
+          where: [{ column: 'id', operator: 'eq', value: 42 }],
+          vendor: 'postgresql',
+          connectionString: 'postgresql://localhost/agentforge',
+        }),
+      'Failed to execute UPDATE query. Please verify your input and database connection.',
+    ],
+    [
+      'Delete',
+      () =>
+        relationalDelete.invoke({
+          table: 'users',
+          where: [{ column: 'id', operator: 'eq', value: 42 }],
+          vendor: 'postgresql',
+          connectionString: 'postgresql://localhost/agentforge',
+        }),
+      'Failed to execute DELETE query. Please verify your input and database connection.',
+    ],
+  ])('%s preserves its sanitized missing-driver result', async (_name, invoke, error) => {
+    await expect(invoke()).resolves.toMatchObject({ success: false, error });
+  });
+});

--- a/packages/tools/tests/data/relational/legacy-mutation-missing-driver.test.ts
+++ b/packages/tools/tests/data/relational/legacy-mutation-missing-driver.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../src/data/relational/utils/peer-dependency-checker.js', async (
 });
 
 import {
+  MissingPeerDependencyError,
   relationalDelete,
   relationalInsert,
   relationalUpdate,
@@ -30,7 +31,6 @@ describe('legacy Relational mutation Tool missing-driver compatibility', () => {
           vendor: 'postgresql',
           connectionString: 'postgresql://localhost/agentforge',
         }),
-      'Failed to execute INSERT query. Please verify your input and database connection.',
     ],
     [
       'Update',
@@ -42,7 +42,6 @@ describe('legacy Relational mutation Tool missing-driver compatibility', () => {
           vendor: 'postgresql',
           connectionString: 'postgresql://localhost/agentforge',
         }),
-      'Failed to execute UPDATE query. Please verify your input and database connection.',
     ],
     [
       'Delete',
@@ -53,9 +52,8 @@ describe('legacy Relational mutation Tool missing-driver compatibility', () => {
           vendor: 'postgresql',
           connectionString: 'postgresql://localhost/agentforge',
         }),
-      'Failed to execute DELETE query. Please verify your input and database connection.',
     ],
-  ])('%s preserves its sanitized missing-driver result', async (_name, invoke, error) => {
-    await expect(invoke()).resolves.toMatchObject({ success: false, error });
+  ])('%s preserves MissingPeerDependencyError', async (_name, invoke) => {
+    await expect(invoke()).rejects.toBeInstanceOf(MissingPeerDependencyError);
   });
 });

--- a/packages/tools/tests/data/relational/tools/delete-tool.test.ts
+++ b/packages/tools/tests/data/relational/tools/delete-tool.test.ts
@@ -6,13 +6,13 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const mockConnect = vi.fn().mockResolvedValue(undefined);
-const mockDisconnect = vi.fn().mockResolvedValue(undefined);
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 const mockExecute = vi.fn().mockResolvedValue([{ affectedRows: 1 }]);
 
 vi.mock('../../../../src/data/relational/connection/connection-manager.js', () => ({
   ConnectionManager: vi.fn().mockImplementation(() => ({
     connect: mockConnect,
-    disconnect: mockDisconnect,
+    dispose: mockDispose,
     execute: mockExecute,
   })),
 }));
@@ -23,7 +23,7 @@ describe('relational-delete > tool > invoke', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConnect.mockResolvedValue(undefined);
-    mockDisconnect.mockResolvedValue(undefined);
+    mockDispose.mockResolvedValue(undefined);
     mockExecute.mockResolvedValue([{ affectedRows: 1 }]);
   });
 
@@ -38,7 +38,7 @@ describe('relational-delete > tool > invoke', () => {
     expect(result.success).toBe(true);
     expect(result.rowCount).toBeGreaterThanOrEqual(0);
     expect(mockConnect).toHaveBeenCalledOnce();
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 
   it('should return error response when connection fails', async () => {
@@ -83,7 +83,7 @@ describe('relational-delete > tool > invoke', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('should always disconnect even on error', async () => {
+  it('should always dispose even on error', async () => {
     mockExecute.mockRejectedValue(new Error('Query failed'));
 
     await relationalDelete.invoke({
@@ -93,6 +93,6 @@ describe('relational-delete > tool > invoke', () => {
       connectionString: 'postgresql://localhost/test',
     });
 
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 });

--- a/packages/tools/tests/data/relational/tools/insert-tool.test.ts
+++ b/packages/tools/tests/data/relational/tools/insert-tool.test.ts
@@ -7,13 +7,13 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // Mock ConnectionManager to avoid real DB connections
 const mockConnect = vi.fn().mockResolvedValue(undefined);
-const mockDisconnect = vi.fn().mockResolvedValue(undefined);
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 const mockExecute = vi.fn().mockResolvedValue([{ affectedRows: 1, insertId: 1 }]);
 
 vi.mock('../../../../src/data/relational/connection/connection-manager.js', () => ({
   ConnectionManager: vi.fn().mockImplementation(() => ({
     connect: mockConnect,
-    disconnect: mockDisconnect,
+    dispose: mockDispose,
     execute: mockExecute,
   })),
 }));
@@ -24,7 +24,7 @@ describe('relational-insert > tool > invoke', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConnect.mockResolvedValue(undefined);
-    mockDisconnect.mockResolvedValue(undefined);
+    mockDispose.mockResolvedValue(undefined);
     mockExecute.mockResolvedValue([{ affectedRows: 1, insertId: 1 }]);
   });
 
@@ -39,7 +39,7 @@ describe('relational-insert > tool > invoke', () => {
     expect(result.success).toBe(true);
     expect(result.rowCount).toBeGreaterThanOrEqual(0);
     expect(mockConnect).toHaveBeenCalledOnce();
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 
   it('should return error response when connection fails', async () => {
@@ -85,7 +85,7 @@ describe('relational-insert > tool > invoke', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('should always disconnect even on error', async () => {
+  it('should always dispose even on error', async () => {
     mockExecute.mockRejectedValue(new Error('Query failed'));
 
     await relationalInsert.invoke({
@@ -95,6 +95,6 @@ describe('relational-insert > tool > invoke', () => {
       connectionString: 'postgresql://localhost/test',
     });
 
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 });

--- a/packages/tools/tests/data/relational/tools/update-tool.test.ts
+++ b/packages/tools/tests/data/relational/tools/update-tool.test.ts
@@ -6,13 +6,13 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const mockConnect = vi.fn().mockResolvedValue(undefined);
-const mockDisconnect = vi.fn().mockResolvedValue(undefined);
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 const mockExecute = vi.fn().mockResolvedValue([{ affectedRows: 1 }]);
 
 vi.mock('../../../../src/data/relational/connection/connection-manager.js', () => ({
   ConnectionManager: vi.fn().mockImplementation(() => ({
     connect: mockConnect,
-    disconnect: mockDisconnect,
+    dispose: mockDispose,
     execute: mockExecute,
   })),
 }));
@@ -23,7 +23,7 @@ describe('relational-update > tool > invoke', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConnect.mockResolvedValue(undefined);
-    mockDisconnect.mockResolvedValue(undefined);
+    mockDispose.mockResolvedValue(undefined);
     mockExecute.mockResolvedValue([{ affectedRows: 1 }]);
   });
 
@@ -39,7 +39,7 @@ describe('relational-update > tool > invoke', () => {
     expect(result.success).toBe(true);
     expect(result.rowCount).toBeGreaterThanOrEqual(0);
     expect(mockConnect).toHaveBeenCalledOnce();
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 
   it('should return error response when connection fails', async () => {
@@ -87,7 +87,7 @@ describe('relational-update > tool > invoke', () => {
     expect(result.error).toBeDefined();
   });
 
-  it('should always disconnect even on error', async () => {
+  it('should always dispose even on error', async () => {
     mockExecute.mockRejectedValue(new Error('Query failed'));
 
     await relationalUpdate.invoke({
@@ -98,6 +98,6 @@ describe('relational-update > tool > invoke', () => {
       connectionString: 'postgresql://localhost/test',
     });
 
-    expect(mockDisconnect).toHaveBeenCalledOnce();
+    expect(mockDispose).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Closes #224

## Summary
- delegate the credential-bearing Insert, Update, and Delete Tools to ephemeral Relational Tool Sets
- preserve legacy schemas, safe results, connection-failure text, and missing-driver behavior
- mark all three exports deprecated and update migration documentation
- add delegation, lifecycle, cleanup, no-cache, and compatibility coverage

## Validation
- pnpm --filter @agentforge/tools typecheck
- pnpm --filter @agentforge/tools lint
- pnpm exec vitest --config vitest.config.ts run (from packages/tools): 1,205 passed, 110 skipped